### PR TITLE
Create plugins dir if it doesn't exist

### DIFF
--- a/setup/extensions.py
+++ b/setup/extensions.py
@@ -535,6 +535,8 @@ class Build(Command):
             src = (glob.glob('*.so') + glob.glob('release/*.dll') +
                     glob.glob('*.dylib'))
             ext = 'pyd' if iswindows else 'so'
+            if not os.path.exists(dest):
+                os.makedirs(dest)
             shutil.copy2(src[0], self.j(dest, 'calibre_style.'+ext))
         finally:
             os.chdir(ocwd)


### PR DESCRIPTION
When building, the calibre plugins directory (src/calibre/plugins) may not exist. If not, create the directory before trying to copy the calibre_style library there.
