### PR TITLE
Disable preferences toolbar context menu

### DIFF
--- a/src/calibre/gui2/preferences/main.py
+++ b/src/calibre/gui2/preferences/main.py
@@ -221,6 +221,7 @@ class Preferences(QMainWindow):
         self.stack.addWidget(self.scroll_area)
         self.scroll_area.setWidgetResizable(True)
 
+        self.setContextMenuPolicy(Qt.NoContextMenu)
         self.bar = QToolBar(self)
         self.addToolBar(self.bar)
         self.bar.setVisible(False)


### PR DESCRIPTION
The unwanted preferences context menu allowed the user to hide the
apply, cancel and restore defaults buttons.  This should stop the
menu from appearing.
