### PR TITLE
Fix typo(?) in set_metadata()

### DIFF
--- a/src/calibre/utils/podofo/__init__.py
+++ b/src/calibre/utils/podofo/__init__.py
@@ -36,7 +36,7 @@ def set_metadata(stream, mi):
         except WorkerError as e:
             raise Exception('Failed to set PDF metadata: %s'%e.orig_tb)
         if touched:
-            with open(os.path.join(tdir, u'output.pdf'), 'rb') as f:
+            with open(os.path.join(tdir, u'input.pdf'), 'rb') as f:
                 f.seek(0, 2)
                 if f.tell() > 100:
                     f.seek(0)


### PR DESCRIPTION
This was causing errors every time it was called. I'm fairly confident that the change I put in place is the intended code, please advise.
