### PR TITLE
bugfix: pass book_id to FileType plugins on postimport instead of __builtins__.id()

### DIFF
--- a/src/calibre/library/database2.py
+++ b/src/calibre/library/database2.py
@@ -1502,7 +1502,7 @@ class LibraryDatabase2(LibraryDatabase, SchemaUpgrade, CustomColumns):
         format = check_ebook_format(stream, format)
         retval = self.add_format(index, format, stream, replace=replace,
                                index_is_id=index_is_id, path=path, notify=notify)
-        run_plugins_on_postimport(self, id, format)
+        run_plugins_on_postimport(self, index, format)
         return retval
 
     def add_format(self, index, format, stream, index_is_id=False, path=None,


### PR DESCRIPTION
I have written a FileType plugin which automatically converts scanned PDF ebooks to DJVU on import to the library. the plugin needs to be given a book_id from the library's database in order to add the DJVU formatted-file to it, but the postimport dispatcher is calling the plugin with python object id's instead. I have been using a workaround to grab index (the book_id) but I'd like the upstream fixed so I can release my plugin.

thanks for the greatness that is Calibre
-joey

PS. I know there is an excellent conversion plugin framework but it is useless for scanned PDF's that have little or no markup that can be saved in intermediate HTML.
