### PR TITLE
Patch to https://bugs.launchpad.net/calibre/+bug/1207131

### DIFF
--- a/src/calibre/gui2/tag_browser/model.py
+++ b/src/calibre/gui2/tag_browser/model.py
@@ -971,6 +971,10 @@ class TagsModel(QAbstractItemModel): # {{{
             else:
                 nkey = ckey[:dotpos+1] + val
             nkey_lower = icu_lower(nkey)
+
+            if ckey == nkey:
+                return True
+
             for c in sorted(user_cats.keys(), key=sort_key):
                 if icu_lower(c).startswith(ckey_lower):
                     if len(c) == len(ckey):


### PR DESCRIPTION
Fix the issue of renaming user categories to the same name it already has resulting in deletion of the category (see https://bugs.launchpad.net/calibre/+bug/1207131)
