### PR TITLE
Store: Change punucation into spaces when using author or title searching

### DIFF
--- a/src/calibre/gui2/store/search/models.py
+++ b/src/calibre/gui2/store/search/models.py
@@ -451,11 +451,15 @@ class SearchFilter(SearchQueryParser):
                         vals = accessor(sr).split(',')
                     elif locvalue in ('author2', 'title2'):
                         m = self.IN_MATCH
-                        vals = re.sub(r'(^|\s)(and|not|or|a|the|is|of)(\s|$)', ' ', accessor(sr))
-                        vals = re.sub('[.,!@#$%^&*\(\)\'"\[\]]', ' ', vals)
+                        def field_trimmer(field):
+                            field = re.sub(r'(^|\s)(and|not|or|a|the|is|of)(\s|$)', ' ', field)
+                            field = re.sub('[.,!@#$%^&*\(\)\'"\[\]]', ' ', field)
+                            return field
+                        vals = field_trimmer(accessor(sr))
                         vals = vals.split(' ')
                         vals = [x for x in vals if x]
-                        final_query = query.lower()
+                        final_query = field_trimmer(query.lower())
+                        final_query = re.sub('[ ]{2,}', ' ', final_query)
                     else:
                         vals = [accessor(sr)]
                     if self._match(final_query, vals, m):


### PR DESCRIPTION
Tomasz brought up an issue where titles were not matching due to having periods. The titles returned from the store are doing something like: "this.is.the.title." searching for "the title" was yielding no results. I've enhanced the search to replace punctuation with spaces to work around this issue.

It should also enhancing searching for authors where initials make up part of the name. Such as searching for j.k. Rowlling.

Finally, this should fix the issue where and/of/the... are being counted as matches for searching by title.
