### PR TITLE
Update last_mod times when custom column metadata changes instead of ...

### DIFF
--- a/src/calibre/db/backend.py
+++ b/src/calibre/db/backend.py
@@ -427,7 +427,7 @@ class DB(object):
         defs['virtual_libraries'] = {}
         defs['virtual_lib_on_startup'] = defs['cs_virtual_lib_on_startup'] = ''
         defs['virt_libs_hidden'] = defs['virt_libs_order'] = ()
-        defs['backup_all_metadata_on_start'] = 'no'
+        defs['update_all_last_mod_dates_on_start'] = 'no'
 
         # Migrate the bool tristate tweak
         defs['bools_are_tristate'] = \
@@ -542,7 +542,7 @@ class DB(object):
                         DROP TABLE   IF EXISTS {lt};
                         '''.format(table=table, lt=lt)
                 )
-                self.prefs.set('backup_all_metadata_on_start', 'yes')
+                self.prefs.set('update_all_last_mod_dates_on_start', 'yes')
             self.conn.execute('DELETE FROM custom_columns WHERE mark_for_delete=1')
 
         # Load metadata for custom columns
@@ -968,7 +968,7 @@ class DB(object):
             ]
         script = ' \n'.join(lines)
         self.conn.execute(script)
-        self.prefs.set('backup_all_metadata_on_start', 'yes')
+        self.prefs.set('update_all_last_mod_dates_on_start', 'yes')
         return num
     # }}}
 

--- a/src/calibre/db/cache.py
+++ b/src/calibre/db/cache.py
@@ -308,9 +308,9 @@ class Cache(object):
                     field.author_sort_field = self.fields['author_sort']
                 elif name == 'title':
                     field.title_sort_field = self.fields['sort']
-        if self.backend.prefs['backup_all_metadata_on_start'] == 'yes':
-            self.mark_as_dirty(self.all_book_ids())
-            self.backend.prefs.set('backup_all_metadata_on_start', 'no')
+        if self.backend.prefs['update_all_last_mod_dates_on_start'] == 'yes':
+            self.update_last_modified(self.all_book_ids())
+            self.backend.prefs.set('update_all_last_mod_dates_on_start', 'no')
 
     @read_api
     def field_for(self, name, book_id, default_value=None):
@@ -1609,9 +1609,9 @@ class Cache(object):
         changed = self.backend.set_custom_column_metadata(num, name=name, label=label, is_editable=is_editable, display=display)
         if changed:
             if immediate_backup:
-                self.mark_as_dirty(self._all_book_ids())
+                self.update_last_modified(self._all_book_ids())
             else:
-                self.backend.prefs.set('backup_all_metadata_on_start', 'yes')
+                self.backend.prefs.set('update_all_last_mod_dates_on_start', 'yes')
         return changed
 
     @read_api


### PR DESCRIPTION
...triggering a backup.

Note that this changes the behavior when a custom column is deleted. Previously deleting a column triggered a full backup, but no other column metadata change did. Now all column metadata changes trigger an update of the last_mod dates.

The new column data will be written to the metadata prefs json file at some point, and will be written to metadata.opf for books modified after the change. These two are sufficient for a correct restore.
