### PR TITLE
Have metadata.book.set_all_user_metadata actually set the metadata, not ...

### DIFF
--- a/src/calibre/ebooks/metadata/book/base.py
+++ b/src/calibre/ebooks/metadata/book/base.py
@@ -391,7 +391,7 @@ class Metadata(object):
                     m['#value#'] = None
             um[key] = m
         _data = object.__getattribute__(self, '_data')
-        _data['user_metadata'].update(um)
+        _data['user_metadata'] = um
 
     def set_user_metadata(self, field, metadata):
         '''


### PR DESCRIPTION
...merge it. Merging left deleted columns in the resulting metadata.
