### PR TITLE
Improve quality of images manipulated by calibre. In particular improve ...

### DIFF
--- a/src/calibre/gui2/__init__.py
+++ b/src/calibre/gui2/__init__.py
@@ -738,14 +738,14 @@ def choose_images(window, name, title, select_only_single_file=True,
         return fd.get_files()
     return None
 
-def pixmap_to_data(pixmap, format='JPEG'):
+def pixmap_to_data(pixmap, format='JPEG', quality=90):
     '''
     Return the QPixmap pixmap as a string saved in the specified format.
     '''
     ba = QByteArray()
     buf = QBuffer(ba)
     buf.open(QBuffer.WriteOnly)
-    pixmap.save(buf, format)
+    pixmap.save(buf, format, quality=quality)
     return bytes(ba.data())
 
 class ResizableDialog(QDialog):

--- a/src/calibre/gui2/widgets.py
+++ b/src/calibre/gui2/widgets.py
@@ -236,7 +236,7 @@ class ImageDropMixin(object):  # {{{
 
     def handle_image_drop(self, pmap):
         self.set_pixmap(pmap)
-        self.cover_changed.emit(pixmap_to_data(pmap))
+        self.cover_changed.emit(pixmap_to_data(pmap, quality=100))
 
     def dragMoveEvent(self, event):
         event.acceptProposedAction()
@@ -268,7 +268,7 @@ class ImageDropMixin(object):  # {{{
         if not pmap.isNull():
             self.set_pixmap(pmap)
             self.cover_changed.emit(
-                    pixmap_to_data(pmap))
+                    pixmap_to_data(pmap, quality=100))
 # }}}
 
 class ImageView(QWidget, ImageDropMixin):  # {{{


### PR DESCRIPTION
...images dropped or pasted into edit metadata. Note: Qt's default compression quality is 75, which is very low. Perhaps calibre's default doesn't need to be as high as 90, but it should be higher than 75. Perhaps this is a good place for a tweak.

BTW: when an image is dropped on edit metadata single, even with the quality set to 100 the resulting cover.jpg is smaller than the original. Why this should be is a mystery. I suspect that Qt's pixmap processing is doing some extra compression. At any rate, the images are much better now than they used to be.
