### PR TITLE
Accept null last_modified dates from a smart device. Can happen when ...

### DIFF
--- a/src/calibre/devices/smart_device_app/driver.py
+++ b/src/calibre/devices/smart_device_app/driver.py
@@ -682,6 +682,8 @@ class SMART_DEVICE_APP(DeviceConfig, DevicePlugin):
             return None
 
     def _metadata_in_cache(self, uuid, ext, lastmod):
+        if lastmod == 'None':
+            return None
         from calibre.utils.date import parse_date, now
         key = uuid+ext
         if isinstance(lastmod, unicode):


### PR DESCRIPTION
...books are added from a scan and not matched.
