### PR TITLE
Fix title of downloaded ebooks.

### DIFF
--- a/src/calibre/gui2/ebook_download.py
+++ b/src/calibre/gui2/ebook_download.py
@@ -15,7 +15,7 @@ from calibre import browser, get_download_filename
 from calibre.ebooks import BOOK_EXTENSIONS
 from calibre.gui2 import Dispatcher
 from calibre.gui2.threaded_jobs import ThreadedJob
-from calibre.ptempfile import PersistentTemporaryFile
+from calibre.ptempfile import PersistentTemporaryDirectory
 from calibre.utils.filenames import ascii_filename
 
 class EbookDownload(object):
@@ -56,7 +56,8 @@ class EbookDownload(object):
             cj.load(cookie_file)
             br.set_cookiejar(cj)
         with closing(br.open(url)) as r:
-            tf = PersistentTemporaryFile(suffix=filename)
+            temp_path = os.path.join(PersistentTemporaryDirectory(), filename)
+            tf = open(temp_path, 'w+b')
             tf.write(r.read())
             dfilename = tf.name
 


### PR DESCRIPTION
The issue was the book is downloaded to a temporary file using PersistentTemporaryFile and the filename was set as the suffix. This ended up creating a filename with random text and the real filename appended after. When implemented it was assumed the suffix would become the filename instead of being appended after the filename. 

The fix is to download to a temporary directory and create the file with the filename unaltered.
