### PR TITLE
Quickview changes:

### DIFF
--- a/src/calibre/gui2/actions/show_quickview.py
+++ b/src/calibre/gui2/actions/show_quickview.py
@@ -47,4 +47,4 @@ class ShowQuickviewAction(InterfaceAction):
 
     def library_changed(self, db):
         if self.current_instance and not self.current_instance.is_closed:
-            self.current_instance.set_database(db)
+            self.current_instance.reject()

--- a/src/calibre/gui2/dialogs/quickview.ui
+++ b/src/calibre/gui2/dialogs/quickview.ui
@@ -22,8 +22,8 @@
   <layout class="QGridLayout">
    <item row="0" column="0">
     <widget class="QLabel" name="items_label">
-     <property name="text">
-      <string>Items</string>
+     <property name="buddy">
+      <cstring>items</cstring>
      </property>
     </widget>
    </item>
@@ -39,6 +39,9 @@
    </item>
    <item row="0" column="1">
     <widget class="QLabel" name="books_label">
+     <property name="buddy">
+      <cstring>books_table</cstring>
+     </property>
     </widget>
    </item>
    <item row="1" column="1">
@@ -60,12 +63,39 @@
    <item row="3" column="0" colspan="2">
     <layout class="QHBoxLayout">
      <item>
+      <widget class="QCheckBox" name="lock_qv">
+       <property name="text">
+        <string>&amp;Lock Quickview contents</string>
+       </property>
+       <property name="toolTip">
+        <string>Select to prevent Quickview from changing content when the
+        selection on the library view is changed</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
       <widget class="QPushButton" name="search_button">
        <property name="text">
-        <string>Search</string>
+        <string>&amp;Search</string>
        </property>
        <property name="toolTip">
         <string>Search in the library view for the selected item</string>
+       </property>
+       <property name="autoDefault">
+        <bool>false</bool>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
1) Close the quickview window on library change. Keeping track of what should be shown in the new library wasn't working.
2) Add keyboard shortcuts to move between quickview's controls.
3) Add a checkbox to "lock" quickview's contents, preventing their change when moving around on the main spreadsheet.
