### PR TITLE
Make the smart device cache return instances of USBMS.Book instead of ...

### DIFF
--- a/src/calibre/devices/smart_device_app/driver.py
+++ b/src/calibre/devices/smart_device_app/driver.py
@@ -688,7 +688,7 @@ class SMART_DEVICE_APP(DeviceConfig, DevicePlugin):
                 lastmod = parse_date(lastmod)
             if key in self.known_uuids and self.known_uuids[key]['book'].last_modified == lastmod:
                 self.known_uuids[key]['last_used'] = now()
-                return self.known_uuids[key]['book'].deepcopy()
+                return self.known_uuids[key]['book'].deepcopy(lambda : SDBook('', ''))
         except:
             traceback.print_exc()
         return None

--- a/src/calibre/ebooks/metadata/book/base.py
+++ b/src/calibre/ebooks/metadata/book/base.py
@@ -184,11 +184,14 @@ class Metadata(object):
     def has_key(self, key):
         return key in object.__getattribute__(self, '_data')
 
-    def deepcopy(self):
+    def deepcopy(self, class_generator=lambda : Metadata(None)):
         ''' Do not use this method unless you know what you are doing, if you
         want to create a simple clone of this object, use :meth:`deepcopy_metadata`
-        instead. '''
-        m = Metadata(None)
+        instead. Class_generator must be a function that returns an instance
+        of Metadata or a subclass of it.'''
+        m = class_generator()
+        if not isinstance(m, Metadata):
+            return None
         object.__setattr__(m, '__dict__', copy.deepcopy(self.__dict__))
         return m
 


### PR DESCRIPTION
...Book.Metadata. This is probably not the most efficient way of doing this because it initializes attributes that it subsequently replaces with the **dict** copy, but I don't see another way to ensure that all the class attributes and properties of the original instance (a subclass of Metadata) are in the new instance.
