### PR TITLE
Make base directories only

### DIFF
--- a/src/calibre/ebooks/oeb/polish/container.py
+++ b/src/calibre/ebooks/oeb/polish/container.py
@@ -676,7 +676,7 @@ class Container(object):  # {{{
         # of links to the file
         base = os.path.dirname(path)
         if not os.path.exists(base):
-            os.makedirs(path)
+            os.makedirs(base)
         open(path, 'wb').close()
         return item
 


### PR DESCRIPTION
This seems to make directories including the file name itself. This change makes only the directories.
