### PR TITLE
Make the Economist recipe respect bold text

### DIFF
--- a/recipes/economist.recipe
+++ b/recipes/economist.recipe
@@ -24,6 +24,9 @@ class Economist(BasicNewsRecipe):
         .headline {font-size: x-large;}
         h2 { font-size: small;  }
         h1 { font-size: medium;  }
+        em.Bold {font-weight:bold;font-style:normal;}
+        em.Italic {font-style:italic;}
+        p.xhead {font-weight:bold;}
         .pullquote {
             float: right;
             font-size: larger;

--- a/recipes/economist_free.recipe
+++ b/recipes/economist_free.recipe
@@ -24,6 +24,9 @@ class Economist(BasicNewsRecipe):
         .headline {font-size: x-large;}
         h2 { font-size: small;  }
         h1 { font-size: medium;  }
+        em.Bold {font-weight:bold;font-style:normal;}
+        em.Italic {font-style:italic;}
+        p.xhead {font-weight:bold;}
         .pullquote {
             float: right;
             font-size: larger;


### PR DESCRIPTION
Economist wraps intertitles in articles into

```
<p class="xhead"></p>
```

and they appear bold on the website.

Text that is bold is wrapped into

```
<em class="Bold"></em>
```

and text that is in Italic is wrapped into 

```
<em class="Italic"></em>
```

(all can be see n the first paragraph of this article: http://www.economist.com/news/world-week/21590604-politics-week ). This change makes the recipe respect these settings so they are displayed accordingly in the resulting ebook. Currently, both Italic and Bold em classes are displayed in Italic and xhead is not highlighted in any way. I think this increases readability.
