### PR TITLE
Added a device option: opt_do_not_sanitize_filename

### DIFF
--- a/src/calibre/devices/kindle/driver.py
+++ b/src/calibre/devices/kindle/driver.py
@@ -297,6 +297,8 @@ class KINDLE2(KINDLE):
     # SUPPORTS_SUB_DIRS = False # Apparently the Paperwhite doesn't like files placed in subdirectories
     # SUPPORTS_SUB_DIRS_FOR_SCAN = True
 
+    SUPPORTS_NOT_SANITIZED_FILENAME = True
+
     EXTRA_CUSTOMIZATION_MESSAGE = [
         _('Send page number information when sending books') +
             ':::' +

--- a/src/calibre/devices/usbms/device.py
+++ b/src/calibre/devices/usbms/device.py
@@ -1044,7 +1044,9 @@ class Device(DeviceConfig, DevicePlugin):
     def create_upload_path(self, path, mdata, fname, create_dirs=True):
         from calibre.devices.utils import create_upload_path
         settings = self.settings()
-        filepath = create_upload_path(mdata, fname, self.save_template(), sanitize,
+        do_not_sanitize_filename = self.SUPPORTS_NOT_SANITIZED_FILENAME and settings.do_not_sanitize_filename
+        sanitize_func = None if do_not_sanitize_filename else sanitize
+        filepath = create_upload_path(mdata, fname, self.save_template(), sanitize=sanitize_func,
                 prefix_path=os.path.abspath(path),
                 maxlen=self.MAX_PATH_LEN,
                 use_subdirs = self.SUPPORTS_SUB_DIRS and settings.use_subdirs,

--- a/src/calibre/devices/usbms/deviceconfig.py
+++ b/src/calibre/devices/usbms/deviceconfig.py
@@ -41,6 +41,8 @@ class DeviceConfig(object):
     #: If True the user can add new formats to the driver
     USER_CAN_ADD_NEW_FORMATS = True
 
+    #: If True, by default do not sanitize filename of the content that will be sent to the devie
+    SUPPORTS_NOT_SANITIZED_FILENAME = False
 
     @classmethod
     def _default_save_template(cls):
@@ -70,6 +72,8 @@ class DeviceConfig(object):
         c.add_opt('extra_customization',
                 default=cls.EXTRA_CUSTOMIZATION_DEFAULT,
                 help=_('Extra customization'))
+        c.add_opt('do_not_sanitize_filename', default=False,
+                help=_('Do not sanitize filename of the content that will be sent to the device'))
         return c
 
     @classmethod
@@ -81,6 +85,7 @@ class DeviceConfig(object):
         from calibre.gui2.device_drivers.configwidget import ConfigWidget
         cw = ConfigWidget(cls.settings(), cls.FORMATS, cls.SUPPORTS_SUB_DIRS,
             cls.MUST_READ_METADATA, cls.SUPPORTS_USE_AUTHOR_SORT,
+            cls.SUPPORTS_NOT_SANITIZED_FILENAME,
             cls.EXTRA_CUSTOMIZATION_MESSAGE, cls)
         return cw
 
@@ -110,6 +115,8 @@ class DeviceConfig(object):
                 if not ec:
                     ec = None
             proxy['extra_customization'] = ec
+        if cls.SUPPORTS_NOT_SANITIZED_FILENAME:
+            proxy['do_not_sanitize_filename'] = config_widget.do_not_sanitize_filename()
         st = unicode(config_widget.opt_save_template.text())
         proxy['save_template'] = st
 

--- a/src/calibre/devices/utils.py
+++ b/src/calibre/devices/utils.py
@@ -62,7 +62,7 @@ def build_template_regexp(template):
         template = u'{title} - {authors}'
         return re.compile(re.sub('{([^}]*)}', f, template) + '([_\d]*$)')
 
-def create_upload_path(mdata, fname, template, sanitize,
+def create_upload_path(mdata, fname, template, sanitize=None,
         prefix_path='',
         path_type=os.path,
         maxlen=250,
@@ -73,6 +73,8 @@ def create_upload_path(mdata, fname, template, sanitize,
         ):
     from calibre.library.save_to_disk import get_components, config
     from calibre.utils.filenames import shorten_components_to
+
+    sanitize_func = sanitize if sanitize else lambda x: x
 
     special_tag = None
     if mdata.tags:
@@ -90,7 +92,7 @@ def create_upload_path(mdata, fname, template, sanitize,
             date = (today[0], today[1], today[2])
         template = u"{title}_%d-%d-%d" % date
 
-    fname = sanitize(fname)
+    fname = sanitize_func(fname)
     ext = path_type.splitext(fname)[1]
 
     opts = config().parse()
@@ -99,12 +101,13 @@ def create_upload_path(mdata, fname, template, sanitize,
     app_id = str(getattr(mdata, 'application_id', ''))
     id_ = mdata.get('id', fname)
     extra_components = get_components(template, mdata, id_,
-            timefmt=opts.send_timefmt, length=maxlen-len(app_id)-1)
+            timefmt=opts.send_timefmt, length=maxlen-len(app_id)-1,
+            sanitize_func=sanitize_func)
     if not extra_components:
-        extra_components.append(sanitize(filename_callback(fname,
+        extra_components.append(sanitize_func(filename_callback(fname,
             mdata)))
     else:
-        extra_components[-1] = sanitize(filename_callback(extra_components[-1]+ext, mdata))
+        extra_components[-1] = sanitize_func(filename_callback(extra_components[-1]+ext, mdata))
 
     if extra_components[-1] and extra_components[-1][0] in ('.', '_'):
         extra_components[-1] = 'x' + extra_components[-1][1:]

--- a/src/calibre/gui2/device_drivers/configwidget.py
+++ b/src/calibre/gui2/device_drivers/configwidget.py
@@ -18,6 +18,7 @@ class ConfigWidget(QWidget, Ui_ConfigWidget):
 
     def __init__(self, settings, all_formats, supports_subdirs,
         must_read_metadata, supports_use_author_sort,
+        supports_not_sanitized_filename,
         extra_customization_message, device):
 
         QWidget.__init__(self)
@@ -61,6 +62,12 @@ class ConfigWidget(QWidget, Ui_ConfigWidget):
             self.opt_use_author_sort.setChecked(self.settings.use_author_sort)
         else:
             self.opt_use_author_sort.hide()
+
+        if supports_not_sanitized_filename:
+            self.opt_do_not_sanitize_filename.setChecked(self.settings.do_not_sanitize_filename)
+        else:
+            self.opt_do_not_sanitize_filename.hide()
+
         if extra_customization_message:
             def parse_msg(m):
                 msg, _, tt = m.partition(':::') if m else ('', '', '')
@@ -136,6 +143,9 @@ class ConfigWidget(QWidget, Ui_ConfigWidget):
 
     def use_author_sort(self):
         return self.opt_use_author_sort.isChecked()
+
+    def do_not_sanitize_filename(self):
+        return self.opt_do_not_sanitize_filename.isChecked()
 
     def validate(self):
         formats = set(self.format_map())

--- a/src/calibre/gui2/device_drivers/configwidget.ui
+++ b/src/calibre/gui2/device_drivers/configwidget.ui
@@ -100,10 +100,20 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="0">
-    <layout class="QGridLayout" name="extra_layout"/>
+   <item row="4" column="0">
+    <widget class="QCheckBox" name="opt_do_not_sanitize_filename">
+     <property name="toolTip">
+      <string>If checked, do not sanitize filename of the content that will be sent to the device.</string>
+     </property>
+     <property name="text">
+      <string>Do not sanitize filename</string>
+     </property>
+    </widget>
    </item>
    <item row="7" column="0">
+    <layout class="QGridLayout" name="extra_layout"/>
+   </item>
+   <item row="8" column="0">
     <spacer name="verticalSpacer_2">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -116,7 +126,7 @@
      </property>
     </spacer>
    </item>
-   <item row="4" column="0">
+   <item row="5" column="0">
     <widget class="QLabel" name="label">
      <property name="text">
       <string>Save &amp;template:</string>
@@ -126,7 +136,7 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
+   <item row="6" column="0">
     <widget class="QLineEdit" name="opt_save_template"/>
    </item>
   </layout>

--- a/src/calibre/library/save_to_disk.py
+++ b/src/calibre/library/save_to_disk.py
@@ -243,6 +243,7 @@ def get_components(template, mi, id, timefmt='%b %Y', length=250,
         components = Formatter().unsafe_format(template, format_args, mi)
     components = [x.strip() for x in components.split('/')]
     components = [sanitize_func(x) for x in components if x]
+
     if not components:
         components = [str(id)]
     if to_lowercase:


### PR DESCRIPTION
This option just enables to not sanitize a filename of the content at all.
Some devices, such as Amazon Kindle, for PDF books, use a filename as a title to display.
In non-ascii encoding region, filenames may contain not only ascii
characters but also multibyte characters, which are currently sanitized
to only-ascii characters.

This must be inconvenience to the users of multibyte characters.

So I added opt_do_not_sanitize_filename to DeviceConfig,
and at the first, enabled the option for Kinde2(and the later)
because I can confirm that device.
