### PR TITLE
Added callback method: sanitize_callback

### DIFF
--- a/src/calibre/devices/usbms/device.py
+++ b/src/calibre/devices/usbms/device.py
@@ -1015,6 +1015,15 @@ class Device(DeviceConfig, DevicePlugin):
 
         return path
 
+    def sanitize_callback(self, path):
+        '''
+        Callback to allow override the path sanitization
+        used by :meth:`create_upload_path`.
+
+        *CAUTION* Official plugin developer must not override this method to pass the sanitization
+        '''
+        return sanitize(path)
+
     def filename_callback(self, default, mi):
         '''
         Callback to allow drivers to change the default file name
@@ -1044,7 +1053,7 @@ class Device(DeviceConfig, DevicePlugin):
     def create_upload_path(self, path, mdata, fname, create_dirs=True):
         from calibre.devices.utils import create_upload_path
         settings = self.settings()
-        filepath = create_upload_path(mdata, fname, self.save_template(), sanitize,
+        filepath = create_upload_path(mdata, fname, self.save_template(), sanitize=self.sanitize_callback,
                 prefix_path=os.path.abspath(path),
                 maxlen=self.MAX_PATH_LEN,
                 use_subdirs = self.SUPPORTS_SUB_DIRS and settings.use_subdirs,

--- a/src/calibre/devices/utils.py
+++ b/src/calibre/devices/utils.py
@@ -99,7 +99,8 @@ def create_upload_path(mdata, fname, template, sanitize,
     app_id = str(getattr(mdata, 'application_id', ''))
     id_ = mdata.get('id', fname)
     extra_components = get_components(template, mdata, id_,
-            timefmt=opts.send_timefmt, length=maxlen-len(app_id)-1)
+            timefmt=opts.send_timefmt, length=maxlen-len(app_id)-1,
+            sanitize_func=sanitize)
     if not extra_components:
         extra_components.append(sanitize(filename_callback(fname,
             mdata)))


### PR DESCRIPTION
This callback enables change sanitize behavior.
Filename sanitization when sending to the device is not necessary for some devices.
Official plugin should never override this callback this callback to pass the
sanitization, but this is useful to override by the private driver plugin.

This is the another approach of #155 to respect Calibre's development policy.
I'm glad if this approach will be accpeptable for convenience of multibyte-region users.
