### PR TITLE
Kindle specific view for the Content Server

### DIFF
--- a/resources/content_server/kindle.css
+++ b/resources/content_server/kindle.css
@@ -63,6 +63,11 @@ div.navigation {
 #listing td.thumbnail {
     height: 60px;
     width: 60px;
+    vertical-align: top;
+}
+
+#listing td.download {
+    vertical-align: top;
 }
 
 #listing tr.lastTr {

--- a/resources/content_server/kindle.css
+++ b/resources/content_server/kindle.css
@@ -1,0 +1,106 @@
+/* CSS for the mobile version of the content server webpage */
+
+.body {
+    font-family: sans-serif;
+}
+
+.navigation table.buttons {
+    width: 100%;
+}
+
+.navigation .button {
+    width: 50%;
+}
+
+.button a, .button:visited a {
+    padding: 0.5em;
+    font-size: larger;
+    border: 1px solid black;
+    text-color: black;
+    text-decoration: none;
+    margin-right: 0.5em;
+    background-color: #ddd;
+    border-top: 1px solid ThreeDLightShadow;
+    border-right: 1px solid ButtonShadow;
+    border-bottom: 1px solid ButtonShadow;
+    border-left: 1 px solid ThreeDLightShadow;
+    -moz-border-radius: 0.25em;
+    -webkit-border-radius: 0.25em;
+}
+
+.button:hover a {
+    border-top: 1px solid #666;
+    border-right: 1px solid #CCC;
+    border-bottom: 1 px solid #CCC;
+    border-left: 1 px solid #666;
+
+
+}
+
+div.navigation {
+    padding-bottom: 1em;
+    clear: both;
+}
+
+#search_box {
+    border: 1px solid #393;
+    -moz-border-radius: 0.5em;
+    -webkit-border-radius: 0.5em;
+    padding: 1em;
+    margin-bottom: 0.5em;
+    float: right;
+}
+
+#listing {
+    width: 100%;
+    border-collapse: collapse;
+}
+#listing td {
+    padding: 0.25em;
+    vertical-align: middle;
+}
+
+#listing td.thumbnail {
+    height: 60px;
+    width: 60px;
+}
+
+#listing tr.lastTr {
+    height: 1px;
+    width: 100%;
+    background-color: blue;
+}
+
+#listing .button a{
+    display: inline-block;
+    width: 2.5em;
+    padding-left: 0em;
+    padding-right: 0em;
+    overflow: hidden;
+    text-align: center;
+    text-decoration: none;
+    vertical-align: middle;
+}
+
+#logo {
+    float: left;
+}
+
+#spacer {
+    clear: both;
+}
+
+.data-container {
+    display: inline-block;
+    vertical-align: middle;
+}
+
+.first-line {
+    font-size: larger;
+    font-weight: bold;
+}
+
+.second-line {
+    margin-top: 0.75ex;
+    display: block;
+}

--- a/resources/content_server/kindle.css
+++ b/resources/content_server/kindle.css
@@ -13,28 +13,15 @@
 }
 
 .button a, .button:visited a {
+    color: black;
     padding: 0.5em;
     font-size: larger;
     border: 1px solid black;
     text-color: black;
     text-decoration: none;
+    margin-top: 0.5em;
     margin-right: 0.5em;
     background-color: #ddd;
-    border-top: 1px solid ThreeDLightShadow;
-    border-right: 1px solid ButtonShadow;
-    border-bottom: 1px solid ButtonShadow;
-    border-left: 1 px solid ThreeDLightShadow;
-    -moz-border-radius: 0.25em;
-    -webkit-border-radius: 0.25em;
-}
-
-.button:hover a {
-    border-top: 1px solid #666;
-    border-right: 1px solid #CCC;
-    border-bottom: 1 px solid #CCC;
-    border-left: 1 px solid #666;
-
-
 }
 
 div.navigation {
@@ -78,13 +65,14 @@ div.navigation {
 
 #listing .button a{
     display: inline-block;
-    width: 2.5em;
-    padding-left: 0em;
-    padding-right: 0em;
     overflow: hidden;
     text-align: center;
     text-decoration: none;
     vertical-align: middle;
+}
+
+#searchShow {
+    float: right;
 }
 
 #logo {

--- a/src/calibre/library/server/base.py
+++ b/src/calibre/library/server/base.py
@@ -20,6 +20,7 @@ from calibre.utils.mdns import publish as publish_zeroconf, \
             unpublish as unpublish_zeroconf, get_external_ip, verify_ipV4_address
 from calibre.library.server.content import ContentServer
 from calibre.library.server.mobile import MobileServer
+from calibre.library.server.kindle import KindleServer
 from calibre.library.server.xml import XMLServer
 from calibre.library.server.opds import OPDSServer
 from calibre.library.server.cache import Cache
@@ -115,7 +116,7 @@ cherrypy.engine.bonjour = BonJour(cherrypy.engine)
 
 # }}}
 
-class LibraryServer(ContentServer, MobileServer, XMLServer, OPDSServer, Cache,
+class LibraryServer(ContentServer, MobileServer, KindleServer, XMLServer, OPDSServer, Cache,
         BrowseServer, AjaxServer):
 
     server_name = __appname__ + '/' + __version__

--- a/src/calibre/library/server/kindle.py
+++ b/src/calibre/library/server/kindle.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python
+# vim:fileencoding=UTF-8:ts=4:sw=4:sta:et:sts=4:ai
+
+__license__   = 'GPL v3'
+__copyright__ = '2014, Yorick Terweijden <terwey@gmail.com>'
+__docformat__ = 'restructuredtext en'
+
+import re, os
+import __builtin__
+from urllib import quote
+
+import cherrypy
+from lxml import html
+from lxml.html.builder import HTML, HEAD, TITLE, LINK, DIV, IMG, BODY, \
+        OPTION, SELECT, INPUT, FORM, SPAN, TABLE, TR, TD, A, HR
+
+from calibre.library.server import custom_fields_to_display
+from calibre.library.server.utils import strftime, format_tag_string
+from calibre.ebooks.metadata import fmt_sidx
+from calibre.constants import __appname__
+from calibre import human_readable, isbytestring
+from calibre.utils.date import utcfromtimestamp, as_local_time
+from calibre.utils.filenames import ascii_filename
+from calibre.utils.icu import sort_key
+
+def CLASS(*args, **kwargs):  # class is a reserved word in Python
+    kwargs['class'] = ' '.join(args)
+    return kwargs
+
+
+def build_search_box(num, search, sort, order, prefix):  # {{{
+    div = DIV(id='search_box')
+    form = FORM('Show ', method='get', action=prefix+'/kindle')
+    form.set('accept-charset', 'UTF-8')
+
+    div.append(form)
+
+    num_select = SELECT(name='num')
+    for option in (5, 10, 25, 100):
+        kwargs = {'value':str(option)}
+        if option == num:
+            kwargs['SELECTED'] = 'SELECTED'
+        num_select.append(OPTION(str(option), **kwargs))
+    num_select.tail = ' books matching '
+    form.append(num_select)
+
+    searchf = INPUT(name='search', id='s', value=search if search else '')
+    searchf.tail = ' sorted by '
+    form.append(searchf)
+
+    sort_select = SELECT(name='sort')
+    for option in ('date','author','title','rating','size','tags','series'):
+        kwargs = {'value':option}
+        if option == sort:
+            kwargs['SELECTED'] = 'SELECTED'
+        sort_select.append(OPTION(option, **kwargs))
+    form.append(sort_select)
+
+    order_select = SELECT(name='order')
+    for option in ('ascending','descending'):
+        kwargs = {'value':option}
+        if option == order:
+            kwargs['SELECTED'] = 'SELECTED'
+        order_select.append(OPTION(option, **kwargs))
+    form.append(order_select)
+
+    form.append(INPUT(id='go', type='submit', value='Search'))
+
+    return div
+    # }}}
+
+def build_navigation(start, num, total, url_base):  # {{{
+    end = min((start+num-1), total)
+    tagline = SPAN('Books %d to %d of %d'%(start, end, total),
+            style='display: block; text-align: center;')
+    left_buttons = TD(CLASS('button', style='text-align:left'))
+    right_buttons = TD(CLASS('button', style='text-align:right'))
+
+    if start > 1:
+        for t,s in [('First', 1), ('Previous', max(start-num,1))]:
+            left_buttons.append(A(t, href='%s;start=%d'%(url_base, s)))
+
+    if total > start + num:
+        for t,s in [('Next', start+num), ('Last', total-num+1)]:
+            right_buttons.append(A(t, href='%s;start=%d'%(url_base, s)))
+
+    buttons = TABLE(
+            TR(left_buttons, right_buttons),
+            CLASS('buttons'))
+    return DIV(tagline, buttons, CLASS('navigation'))
+
+    # }}}
+
+def build_index(books, num, search, sort, order, start, total, url_base, CKEYS,
+        prefix):
+    logo = DIV(IMG(src=prefix+'/static/calibre.png', alt=__appname__), id='logo')
+
+    search_box = build_search_box(num, search, sort, order, prefix)
+    navigation = build_navigation(start, num, total, prefix+url_base)
+    navigation2 = build_navigation(start, num, total, prefix+url_base)
+    bookt = TABLE(id='listing')
+
+    body = BODY(
+        logo,
+        search_box,
+        navigation,
+        HR(CLASS('spacer')),
+        bookt,
+        HR(CLASS('spacer')),
+        navigation2
+    )
+
+    # Book list {{{
+    for book in books:
+        thumbnail = TD(
+                IMG(type='image/jpeg', border='0',
+                    src=prefix+'/get/thumb/%s' %
+                            book['id']),
+                CLASS('thumbnail'),
+                rowspan="3")
+
+        # data = TD()
+
+        downloadButton = TD(rowspan="3")
+
+        for fmt in book['formats'].split(','):
+            if not fmt or fmt.lower().startswith('original_'):
+                continue
+
+            # Only display Kindle compatible formats
+            if 'azw3' == fmt.lower() or 'mobi' == fmt.lower():
+                a = quote(ascii_filename(book['authors']))
+                t = quote(ascii_filename(book['title']))
+                s = SPAN(
+                    A(
+                        fmt.lower(),
+                        href=prefix+'/get/%s/%s-%s_%d.%s' % (fmt, a, t,
+                            book['id'], fmt.lower())
+                    ),
+                    CLASS('button'))
+                s.tail = u''
+                downloadButton.append(s)
+
+        # div = DIV(CLASS('data-container'))
+        # data.append(div)
+
+        series = u'Series: [%s - %s]'%(book['series'], book['series_index']) \
+                if book['series'] else ''
+        tags = u'Tags: [%s]'%book['tags'] if book['tags'] else ''
+
+        # ctext = ''
+        # for key in CKEYS:
+        #     val = book.get(key, None)
+        #     if val:
+        #         ctext += '%s=[%s] '%tuple(val.split(':#:'))
+
+        # first = SPAN(u'\u202f%s %s by %s' % (book['title'], series,
+        #     book['authors']), CLASS('first-line'))
+        # div.append(first)
+        # second = SPAN(u'%s - %s %s %s' % (book['size'],
+        #     book['timestamp'],
+        #     tags, ctext), CLASS('second-line'))
+        # div.append(second)
+
+        BookTitle = TD(CLASS('BookTitle'))
+        BookTitle.append(SPAN(book['title'], style="font-weight:bold"))
+
+        BookAuthor = TD(CLASS('BookAuthor'))
+        BookAuthor.append(SPAN(u'by %s' % (book['authors'])))
+
+        BookInfo = TD(CLASS('BookInfo'))
+        BookInfo.append(SPAN(series))
+        BookInfo.append(SPAN(tags))
+
+        BookRow1 = TR(thumbnail, BookTitle, downloadButton)
+        BookRow2 = TR(BookAuthor)
+        BookRow3 = TR(BookInfo)
+        BookRow4 = TR(TD(HR(), CLASS('lastTr'), colspan="3"))
+
+        bookt.append(BookRow1)
+        bookt.append(BookRow2)
+        bookt.append(BookRow3)
+        bookt.append(BookRow4)
+    # }}}
+
+    body.append(DIV(
+        A(_('Switch to the full interface (non-Kindle interface)'),
+            href=prefix+"/browse",
+            style="text-decoration: none; color: blue",
+            title=_('The full interface gives you many more features, '
+                'but it may not work well on a small screen')),
+        style="text-align:center"))
+    return HTML(
+        HEAD(
+            TITLE(__appname__ + ' Library'),
+            LINK(rel='icon', href='http://calibre-ebook.com/favicon.ico',
+                type='image/x-icon'),
+            LINK(rel='stylesheet', type='text/css',
+                href=prefix+'/kindle/style.css'),
+            LINK(rel='apple-touch-icon', href="/static/calibre.png")
+        ),  # End head
+        body
+    )  # End html
+
+
+class KindleServer(object):
+    'A view optimized for browsers on Kindle devices'
+
+    KINDLE_UA = re.compile('(?i)(?:Kindle)')
+
+    def is_kindle_browser(self, ua):
+        match = self.KINDLE_UA.search(ua)
+        return match is not None and 'iPad' not in ua
+
+    def add_routes(self, connect):
+        connect('kindle', '/kindle', self.kindle)
+        connect('kindle_css', '/kindle/style.css', self.kindle_css)
+
+    def kindle_css(self, *args, **kwargs):
+        path = P('content_server/kindle.css')
+        cherrypy.response.headers['Content-Type'] = 'text/css; charset=utf-8'
+        updated = utcfromtimestamp(os.stat(path).st_mtime)
+        cherrypy.response.headers['Last-Modified'] = self.last_modified(updated)
+        with open(path, 'rb') as f:
+            ans = f.read()
+        return ans.replace('{prefix}', self.opts.url_prefix)
+
+    def kindle(self, start='1', num='25', sort='author', search='',
+                _=None, order='ascending'):
+        '''
+        Serves metadata from the calibre database as XML.
+
+        :param sort: Sort results by ``sort``. Can be one of `title,author,rating`.
+        :param search: Filter results by ``search`` query. See :class:`SearchQueryParser` for query syntax
+        :param start,num: Return the slice `[start:start+num]` of the sorted and filtered results
+        :param _: Firefox seems to sometimes send this when using XMLHttpRequest with no caching
+        '''
+        try:
+            start = int(start)
+        except ValueError:
+            raise cherrypy.HTTPError(400, 'start: %s is not an integer'%start)
+        try:
+            num = int(num)
+        except ValueError:
+            raise cherrypy.HTTPError(400, 'num: %s is not an integer'%num)
+        if not search:
+            search = ''
+        if isbytestring(search):
+            search = search.decode('UTF-8')
+        # We're only interested in showing books that can be read on the Kindle
+        # so we have to search for them here
+        ids = self.search_for_books(u'%s %s' % (search, 'format:azw3 OR format:mobi'))
+        FM = self.db.FIELD_MAP
+        items = [r for r in iter(self.db) if r[FM['id']] in ids]
+        if sort is not None:
+            self.sort(items, sort, (order.lower().strip() == 'ascending'))
+
+        CFM = self.db.field_metadata
+        CKEYS = [key for key in sorted(custom_fields_to_display(self.db),
+                                       key=lambda x:sort_key(CFM[x]['name']))]
+        # This method uses its own book dict, not the Metadata dict. The loop
+        # below could be changed to use db.get_metadata instead of reading
+        # info directly from the record made by the view, but it doesn't seem
+        # worth it at the moment.
+        books = []
+        for record in items[(start-1):(start-1)+num]:
+            book = {'formats':record[FM['formats']], 'size':record[FM['size']]}
+            if not book['formats']:
+                book['formats'] = ''
+            if not book['size']:
+                book['size'] = 0
+            book['size'] = human_readable(book['size'])
+
+            aus = record[FM['authors']] if record[FM['authors']] else __builtin__._('Unknown')
+            aut_is = CFM['authors']['is_multiple']
+            authors = aut_is['list_to_ui'].join([i.replace('|', ',') for i in aus.split(',')])
+            book['authors'] = authors
+            book['series_index'] = fmt_sidx(float(record[FM['series_index']]))
+            book['series'] = record[FM['series']]
+            book['tags'] = format_tag_string(record[FM['tags']], ',',
+                                             no_tag_count=True)
+            book['title'] = record[FM['title']]
+            for x in ('timestamp', 'pubdate'):
+                book[x] = strftime('%d %b, %Y', as_local_time(record[FM[x]]))
+            book['id'] = record[FM['id']]
+
+            # We're only interested in showing books that can be read on the Kindle
+            # so we have to filter them here (primitively)
+
+            # kindleCompatibleFormats = ['azw3', 'mobi']
+            # bookFormats = [x.strip().lower() for x in book['formats'].split(',')]
+
+            # if any(x in bookFormats for x in kindleCompatibleFormats):
+            books.append(book)
+
+            for key in CKEYS:
+                def concat(name, val):
+                    return '%s:#:%s'%(name, unicode(val))
+                mi = self.db.get_metadata(record[CFM['id']['rec_index']], index_is_id=True)
+                name, val = mi.format_field(key)
+                if not val:
+                    continue
+                datatype = CFM[key]['datatype']
+                if datatype in ['comments']:
+                    continue
+                if datatype == 'text' and CFM[key]['is_multiple']:
+                    book[key] = concat(name,
+                                       format_tag_string(val,
+                                           CFM[key]['is_multiple']['ui_to_list'],
+                                           no_tag_count=True,
+                                           joinval=CFM[key]['is_multiple']['list_to_ui']))
+                else:
+                    book[key] = concat(name, val)
+
+        updated = self.db.last_modified()
+
+        cherrypy.response.headers['Content-Type'] = 'text/html; charset=utf-8'
+        cherrypy.response.headers['Last-Modified'] = self.last_modified(updated)
+
+        url_base = "/kindle?search=" + search+";order="+order+";sort="+sort+";num="+str(num)
+
+        raw = html.tostring(build_index(books, num, search, sort, order,
+                             start, len(ids), url_base, CKEYS,
+                             self.opts.url_prefix),
+                             encoding='utf-8',
+                             pretty_print=True)
+        # tostring's include_meta_content_type is broken
+        raw = raw.replace('<head>', '<head>\n'
+                '<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">')
+        return raw
+

--- a/src/calibre/library/server/kindle.py
+++ b/src/calibre/library/server/kindle.py
@@ -249,7 +249,7 @@ class KindleServer(object):
             search = search.decode('UTF-8')
         # We're only interested in showing books that can be read on the Kindle
         # so we have to search for them here
-        ids = self.search_for_books(u'%s %s' % (search, 'format:azw3 OR format:mobi'))
+        ids = self.search_for_books(u'%s %s' % (search, 'AND (format:azw3 OR format:mobi)'))
         FM = self.db.FIELD_MAP
         items = [r for r in iter(self.db) if r[FM['id']] in ids]
         if sort is not None:
@@ -284,13 +284,6 @@ class KindleServer(object):
                 book[x] = strftime('%d %b, %Y', as_local_time(record[FM[x]]))
             book['id'] = record[FM['id']]
 
-            # We're only interested in showing books that can be read on the Kindle
-            # so we have to filter them here (primitively)
-
-            # kindleCompatibleFormats = ['azw3', 'mobi']
-            # bookFormats = [x.strip().lower() for x in book['formats'].split(',')]
-
-            # if any(x in bookFormats for x in kindleCompatibleFormats):
             books.append(book)
 
             for key in CKEYS:


### PR DESCRIPTION
Hi,

this is still a Work in Progress but I wanted to get some feedback on this before.
This is a Kindle specific view for the Calibre Content Server because the mobile view was sadly a bit of a mess on my Kindle.

I started by taking the normal mobile.py and duplicate it to kindle.py and work my way from there.

On top of that I've decided to filter away formats that the Kindle cannot show and just display the one's it can.
It starts by doing a `format:mobi OR format:azw3` search query and then afterwards on URL generation for the Download again only showing the relevant formats.

I've also made it possible to directly search for an Author, Tag or Series through the use of normal hyperlinks.
And because sometimes you want to see a Summary (but not always) this is Toggled through a simple Javascript command (which the Kindle supports! hooray!)

I'd love to hear some feedback, I haven't done Python in a while so don't go completely bonkers on me ;)
