### PR TITLE
Encoding in OGlobo recipe was wrong and unnecessar

### DIFF
--- a/recipes/o_globo.recipe
+++ b/recipes/o_globo.recipe
@@ -18,7 +18,6 @@ class OGlobo(BasicNewsRecipe):
     max_articles_per_feed = 100
     no_stylesheets        = True
     use_embedded_content  = False
-    encoding              = 'cp1252'
     cover_url             = 'http://oglobo.globo.com/_img/o-globo.png'
     remove_javascript     = True
 


### PR DESCRIPTION
Encoding in O'Globo recipe was wrong and unnecessary.

With the original recipe the article titles was ok, but on the articles the text body encoding is wrong.

The fetched articules already include its encoding information (to be utf-8 when/with the one I tried), and changing the recipe to remove the `encoding` specification seems to work ok!
