### PR TITLE
Allow the empty string when writing to bool custom columns. Bulk edit ...

### DIFF
--- a/src/calibre/db/write.py
+++ b/src/calibre/db/write.py
@@ -94,7 +94,7 @@ def adapt_bool(x):
             x = True
         elif x == 'false':
             x = False
-        elif x == 'none':
+        elif x == 'none' or x == '':
             x = None
         else:
             x = bool(int(x))


### PR DESCRIPTION
...uses the empty string for None, at least in my test case.
