### PR TITLE
Add application category (Utilities)

### DIFF
--- a/setup/installer/osx/app/main.py
+++ b/setup/installer/osx/app/main.py
@@ -357,6 +357,7 @@ class Py2App(object):
                 CFBundleIconFile='library.icns',
                 LSMultipleInstancesProhibited=True,
                 NSHighResolutionCapable=True,
+                LSApplicationCategoryType='public.app-category.utilities',
                 LSEnvironment=env
         )
         plistlib.writePlist(pl, join(self.contents_dir, 'Info.plist'))


### PR DESCRIPTION
OS X's View by Category requires LSApplicationCategoryType otherwise it sorts an app out to "Other" at the bottom.

Utilities was chosen, Apple's other categories are here: https://developer.apple.com/library/ios/documentation/general/Reference/InfoPlistKeyReference/Articles/LaunchServicesKeys.html#//apple_ref/doc/plist/info/LSApplicationCategoryType

'public.app-category.productivity' would be my second choice but I don't have a strong preference.
