### PR TITLE
Fix content server internal redirects not unquoting the category.

### DIFF
--- a/src/calibre/library/server/browse.py
+++ b/src/calibre/library/server/browse.py
@@ -632,6 +632,8 @@ class BrowseServer(object):
 
     @Endpoint(sort_type='list')
     def browse_matches(self, category=None, cid=None, list_sort=None):
+        # We might get here from an internal redirect that doesn't unquote the category
+        category = unquote(category)
         if list_sort:
             list_sort = unquote(list_sort)
         if not cid:


### PR DESCRIPTION
See http://www.mobileread.com/forums/showthread.php?t=236441 for some context. The bug happens when a category contains only one item, so it is redirected to show the books instead of the category.

Although the fix works, I am not sure that this is the right way to fix it. I am not familiar enough with the routing system to know if there is a single place somewhere that is missing the unquote.
