### PR TITLE
add la vanguardia corresponsales spanish recipe

### DIFF
--- a/recipes/lavanguardia_corresponsales_es.recipe
+++ b/recipes/lavanguardia_corresponsales_es.recipe
@@ -1,0 +1,36 @@
+from calibre.web.feeds.news import BasicNewsRecipe
+import urllib
+
+class LaVanguardiaCorresponsalesRecipe (BasicNewsRecipe):
+   __author__ = 'Marc Busqué <marc@lamarciana.com>'
+   __url__ = 'http://www.lamarciana.com'
+   __version__ = '1.0.2'
+   __license__   = 'GPL v3'
+   __copyright__ = '2012, Marc Busqué <marc@lamarciana.com>'
+   title = u'La Vanguardia - Blogs de los corresponsales'
+   description = u'Blogs de los corresponsales de La Vanguardia en este mismo periódico'
+   url = 'http://www.lavanguardia.com/blogs/index.html'
+   language = 'es'
+   tags = 'información, internacional '
+   oldest_article = 30
+   remove_empty_feeds = True
+   no_stylesheets = True
+   extra_css = urllib.urlopen('https://raw.githubusercontent.com/laMarciana/gutenweb/master/dist/gutenweb.css').read().replace('@charset "UTF-8";', '')
+
+   feeds = [
+         (u'Marc Bassets - Diario de Washington', u'http://blogs.lavanguardia.com/washington/feed'),
+         (u'Rafael Poch - Diario de Berlín', u'http://blogs.lavanguardia.com/berlin/feed'),
+         (u'Eusebio Val - Diario de Roma', u'http://blogs.lavanguardia.com/roma/feed'),
+         (u'Robert Mur - Diario de Buenos Aires', u'http://blogs.lavanguardia.com/buenos-aires/feed'),
+         (u'Isidre Ambrós - Diario de Pekín', u'http://blogs.lavanguardia.com/pekin/feed'),
+         (u'Beatriz Navarro - Diario de Bruselas', u'http://blogs.lavanguardia.com/bruselas-navarro/feed'),
+         (u'Lluis Uría - Diario de París', u'http://blogs.lavanguardia.com/paris-uria/feed'),
+         (u'Tomás Alcoverro - Diario de Beirut', u'http://blogs.lavanguardia.com/beirut/feed'),
+         (u'Enrique Cymerman - Diario de Jerusalén', u'http://blogs.lavanguardia.com/jerusalen-cymerman/feed'),
+         (u'Jordi Joan Baños - Diario de India', u'http://blogs.lavanguardia.com/india/feed'),
+         (u'Gonzalo Aragonés - Diario de Moscú', u'http://blogs.lavanguardia.com/moscu/feed'),
+         (u'Andy Robinson - Diario itinerante', u'http://blogs.lavanguardia.com/diario-itinerante/feed'),
+         (u'Rafael Ramos - Diario de Londres', u'http://blogs.lavanguardia.com/londres/feed'),
+         (u'Rafael Ramos - El cocinero de Downing Street', u'http://blogs.lavanguardia.com/el-cocinero-de-downing-street/feed'),
+         (u'Ricardo Ginés Echevarría - Diario de Estambul', u'http://blogs.lavanguardia.com/estambul/feed'),
+         ]


### PR DESCRIPTION
Recipe with [La Vanguardia](http://lavanguardia.com) correspondent blogs.
