### PR TITLE
Use zero-based month as 2nd dynamic field in URL

### DIFF
--- a/recipes/nrc_next.recipe
+++ b/recipes/nrc_next.recipe
@@ -42,7 +42,7 @@ class NRCNext(BasicNewsRecipe):
             raise ValueError('Failed to login, check username and password')
         epubraw = None
         for today in (date.today(), date.today() - timedelta(days=1),):
-            url = 'http://digitaleeditie.nrc.nl/digitaleeditie/NN/%s/3/%s___/downloads.html' % (today.strftime('%Y'), today.strftime('%Y%m%d'))
+            url = 'http://digitaleeditie.nrc.nl/digitaleeditie/NN/%s/%d/%s___/downloads.html' % (today.strftime('%Y'), today.month - 1, today.strftime('%Y%m%d'))
             self.log('Trying to download epub from:', url)
             br.start_load(url, timeout=60)
             try:


### PR DESCRIPTION
This probably needs to be done too for nrc-nl-epub.recipe (need to ask https://bugs.launchpad.net/calibre/+bug/1303331).
