### PR TITLE
Change the demo link in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For more information, see the [calibre About page](http://calibre-ebook.com/abou
 
 Screenshots
 -------------
-[Screenshots page](https://calibre-ebook.com/demo)
+[Screenshots page](http://calibre-ebook.com/demo)
 
 Usage
 -------


### PR DESCRIPTION
The demo link (https://calibre-ebook.com/demo) present in the README.md threw a certificate error. This modification makes the URL use the HTTP protocol to avoid this issue.
