### PR TITLE
Allow calibre to be used by multiple users on Mac OS X.

### DIFF
--- a/setup/installer/osx/app/main.py
+++ b/setup/installer/osx/app/main.py
@@ -355,7 +355,6 @@ class Py2App(object):
                 CFBundleGetInfoString=('calibre, an E-book management '
                 'application. Visit http://calibre-ebook.com for details.'),
                 CFBundleIconFile='library.icns',
-                LSMultipleInstancesProhibited=True,
                 NSHighResolutionCapable=True,
                 LSApplicationCategoryType='public.app-category.productivity',
                 LSEnvironment=env

--- a/setup/installer/osx/freeze.py
+++ b/setup/installer/osx/freeze.py
@@ -409,7 +409,6 @@ def main():
                                         'CFBundleShortVersionString':VERSION,
                                         'CFBundleVersion':APPNAME + ' ' + VERSION,
                                         'LSMinimumSystemVersion':'10.4.3',
-                                        'LSMultipleInstancesProhibited':'true',
                                         'NSHumanReadableCopyright':'Copyright 2008, Kovid Goyal',
                                         'LSEnvironment':{
                                                          'FC_CONFIG_DIR':'@executable_path/../Resources/fonts',


### PR DESCRIPTION
Fixes bug #1320347

For reference see https://developer.apple.com/library/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/LaunchServicesKeys.html#//apple_ref/doc/uid/20001431-113300
