### PR TITLE
Minor index fix for some entries with spaces

### DIFF
--- a/src/calibre/ebooks/docx/fields.py
+++ b/src/calibre/ebooks/docx/fields.py
@@ -105,7 +105,6 @@ class Fields(object):
 
     def __call__(self, doc, log):
         all_ids = frozenset(XPath('//*/@w:id')(doc))
-        # import pydevd;pydevd.settrace()
         c = 0
         while self.index_bookmark_prefix in all_ids:
             c += 1


### PR DESCRIPTION
Very minor index fix.
In the military justice document, t.docx, fixes the "Summary Hearing:Higher Authority" index entry by preserving the space in "Summary Hearing".
