### PR TITLE
Fix regression where multiple coloring rules were used for the same ...

### DIFF
--- a/src/calibre/gui2/library/models.py
+++ b/src/calibre/gui2/library/models.py
@@ -55,6 +55,7 @@ class ColumnColor(object):  # {{{
         self.formatter = formatter
 
     def __call__(self, id_, key, fmt, db, color_cache, template_cache):
+        key += str(hash(fmt))
         if id_ in color_cache and key in color_cache[id_]:
             self.mi = None
             color = color_cache[id_][key]


### PR DESCRIPTION
...column.

@Kovid: the problem is that multiple rules are sequenced by the model, not the color evaluator. Because of this the same key is used for every rule. The change to cache the output of the formatter meant that only the first evaluation was ever used.
