### PR TITLE
Something related to Google Chromecast is broadcasting invalid MDNS ...

### DIFF
--- a/src/calibre/utils/Zeroconf.py
+++ b/src/calibre/utils/Zeroconf.py
@@ -199,6 +199,9 @@ def address_type(address):
 
 # Exceptions
 
+class MalformedPacketException(Exception):
+    pass
+
 class NonLocalNameException(Exception):
     pass
 
@@ -595,23 +598,26 @@ class DNSIncoming(object):
         first = off
 
         while 1:
-            len = ord(self.data[off])
-            off += 1
-            if len == 0:
-                break
-            t = len & 0xC0
-            if t == 0x00:
-                result = ''.join((result, self.readUTF(off, len) + '.'))
-                off += len
-            elif t == 0xC0:
-                if next < 0:
-                    next = off + 1
-                off = ((len & 0x3F) << 8) | ord(self.data[off])
-                if off >= first:
-                    raise BadDomainNameCircular(off)
-                first = off
-            else:
-                raise BadDomainName(off)
+            try:
+                len = ord(self.data[off])
+                off += 1
+                if len == 0:
+                    break
+                t = len & 0xC0
+                if t == 0x00:
+                    result = ''.join((result, self.readUTF(off, len) + '.'))
+                    off += len
+                elif t == 0xC0:
+                    if next < 0:
+                        next = off + 1
+                    off = ((len & 0x3F) << 8) | ord(self.data[off])
+                    if off >= first:
+                        raise BadDomainNameCircular(off)
+                    first = off
+                else:
+                    raise BadDomainName(off)
+            except IndexError:
+                raise MalformedPacketException
 
         if next >= 0:
             self.offset = next
@@ -876,6 +882,8 @@ class Engine(threading.Thread):
                     for sock in rr:
                         try:
                             self.readers[sock].handle_read()
+                        except MalformedPacketException:
+                            pass
                         except:
                             if DEBUG:
                                 traceback.print_exc()


### PR DESCRIPTION
...packets (sigh). Make calibre's MDNS stuff tolerate them without flooding the log with exceptions.
