### PR TITLE
New formatter function: author_links.

### DIFF
--- a/manual/template_lang.rst
+++ b/manual/template_lang.rst
@@ -242,6 +242,7 @@ The following functions are available in addition to those described in single-f
     * ``add(x, y)`` -- returns x + y. Throws an exception if either x or y are not numbers.
     * ``assign(id, val)`` -- assigns val to id, then returns val. id must be an identifier, not an expression
     * ``approximate_formats()`` -- return a comma-separated list of formats that at one point were associated with the book. There is no guarantee that the list is correct, although it probably is. This function can be called in template program mode using the template ``{:'approximate_formats()'}``. Note that format names are always uppercase, as in EPUB.
+	* ``author_links()`` -- returns a string containing a list of authors and that author's link values in the form ``author1:author1link & author2:author2link`` etc. An author is separated from its link value by a : character. ``author:linkvalue`` pairs are separated by " & " (space ampersand space) characters. An author is included even if the author link is empty.
     * ``booksize()`` -- returns the value of the |app| 'size' field. Returns '' if there are no formats.
     * ``cmp(x, y, lt, eq, gt)`` -- compares x and y after converting both to numbers. Returns ``lt`` if x < y. Returns ``eq`` if x == y. Otherwise returns ``gt``.
     * ``current_library_name() -- `` return the last name on the path to the current calibre library. This function can be called in template program mode using the template ``{:'current_library_name()'}``.

--- a/src/calibre/utils/formatter_functions.py
+++ b/src/calibre/utils/formatter_functions.py
@@ -1398,9 +1398,30 @@ class BuiltinTransliterate(BuiltinFormatterFunction):
         return ascii_text(source)
 
 
+class BuiltinAuthorLinks(BuiltinFormatterFunction):
+    name = 'author_links'
+    arg_count = 0
+    category = 'Get values from metadata'
+    __doc__ = doc = _('author_links() -- returns a string containing a list of '
+                      'authors and that author\'s link values in the form '
+                      'author1:author1link & author2:author2link etc. '
+                      'An author is separated from its link value by a : character. '
+                      'author:linkvalue pairs are separated by " & " (space ampersand '
+                      'space) characters. An author is included even if the '
+                      'author link is empty.')
+
+    def evaluate(self, formatter, kwargs, mi, locals):
+        if hasattr(mi, '_proxy_metadata'):
+            link_data = mi._proxy_metadata.author_link_map
+            if not link_data:
+                return ''
+            names = sorted(link_data.keys(), key=sort_key)
+            return ' & '.join(n + ':' + link_data[n] for n in names)
+        return _('This function can be used only in the GUI')
+
 _formatter_builtins = [
     BuiltinAdd(), BuiltinAnd(), BuiltinApproximateFormats(),
-    BuiltinAssign(), BuiltinBooksize(),
+    BuiltinAssign(), BuiltinAuthorLinks(), BuiltinBooksize(),
     BuiltinCapitalize(), BuiltinCmp(), BuiltinContains(), BuiltinCount(),
     BuiltinCurrentLibraryName(), BuiltinCurrentLibraryPath(),
     BuiltinDaysBetween(), BuiltinDivide(), BuiltinEval(), BuiltinFirstNonEmpty(),


### PR DESCRIPTION
Returns an identifiers-like list of authors and their author link values. The list separator is & to avoid problems with commas in author names.
