### PR TITLE
Add a tweak telling the content server to give the client a path ...

### DIFF
--- a/resources/default_tweaks.py
+++ b/resources/default_tweaks.py
@@ -572,14 +572,3 @@ restrict_output_formats = None
 # numbers.
 # The value can be between 50 and 99
 content_server_thumbnail_compression_quality = 75
-
-#: Set the template for the file name supplied by the content server
-# Setting this tweak will make the content server supply the template's value
-# when a book's metadata is requested in "device compatible" mode. The client
-# can use this value as part of the path for the book when downloaded. Note
-# that the save_template_title_series_sorting tweak is used to control title
-# and series values.
-# Examples:
-#  content_server_path_for_client = "{title}-{author}"
-#  content_server_path_for_client = "{title_sort}-{:'series_sort()'||-}{author_sort}"
-content_server_path_for_client = ''


### PR DESCRIPTION
...computed from a template (the value of the tweak). This can happen only if the client sets the device_compatible flag. Clients such as calibre companion can use the value when storing the book.

As far as I can tell, these changes do not bring any of Qt or other GUI components into the content server. There are no extra imports if the tweak is not used.
