### PR TITLE
Apnxfiles

### DIFF
--- a/src/calibre/devices/kindle/driver.py
+++ b/src/calibre/devices/kindle/driver.py
@@ -484,7 +484,6 @@ class KINDLE2(KINDLE):
         apnx_path = '%s.apnx' % os.path.join(path, filename)
         apnx_builder = APNXBuilder()
         ### Check to see if there is an existing apnx file on Kindle we should keep.
-        apnx_file = '%s.apnx' % os.path.splitext(filepath.lower())[0]
         if not opts.extra_customization[self.OPT_APNX_OVERWRITE] and os.path.isfile(apnx_path):
             pass #do nothing, existing apnx file on the kindle is kept
         else:


### PR DESCRIPTION
Two options which modify the behavior of calibre with regard to apnx files.

The first makes explicit the fact that calibre currently overwrites an apnx file on the device when sending a book already present and allows the user to turn this behavior off.

The second allows the user to override the apnx calculation method on a book by book basis.
