### PR TITLE
Performance improvements:

### DIFF
--- a/src/calibre/devices/smart_device_app/driver.py
+++ b/src/calibre/devices/smart_device_app/driver.py
@@ -1260,7 +1260,7 @@ class SMART_DEVICE_APP(DeviceConfig, DevicePlugin):
                     if book:
                         if self.client_cache_uses_lpaths:
                             lpaths_on_device.add(r.get('lpath'))
-                        bl.add_book(book, replace_metadata=True,
+                        bl.add_book_extended(book, replace_metadata=True,
                                 check_for_duplicates=not self.client_cache_uses_lpaths)
                         book.set('_is_read_', r.get('_is_read_', None))
                         book.set('_sync_type_', r.get('_sync_type_', None))
@@ -1307,7 +1307,7 @@ class SMART_DEVICE_APP(DeviceConfig, DevicePlugin):
                     book.set('_is_read_', result.get('_is_read_', None))
                     book.set('_sync_type_', result.get('_sync_type_', None))
                     book.set('_last_read_date_', result.get('_last_read_date_', None))
-                    bl.add_book(book, replace_metadata=True,
+                    bl.add_book_extended(book, replace_metadata=True,
                                 check_for_duplicates=not self.client_cache_uses_lpaths)
                     if '_new_book_' in result:
                         book.set('_new_book_', True)

--- a/src/calibre/devices/usbms/books.py
+++ b/src/calibre/devices/usbms/books.py
@@ -72,7 +72,10 @@ class BookList(_BookList):
     def supports_collections(self):
         return False
 
-    def add_book(self, book, replace_metadata, check_for_duplicates=True):
+    def add_book(self, book, replace_metadata):
+        self.add_book_extended(book, replace_metadata, check_for_duplicates=True)
+
+    def add_book_extended(self, book, replace_metadata, check_for_duplicates):
         '''
         Add the book to the booklist, if needed. Return None if the book is
         already there and not updated, otherwise return the book.


### PR DESCRIPTION
- Add an option to booklists to not check for duplicates if the device knows there aren't any. Eliminates N squared lookup times.
- Make the wireless device driver use the above option.
- Change a comprehension to use a generator instead of a returned list of keys.

FWIW: found these because a CC user has 18,000 books on his device!
