### PR TITLE
Fix incorrect return value that causes book matching to run very slowly

### DIFF
--- a/src/calibre/devices/smart_device_app/driver.py
+++ b/src/calibre/devices/smart_device_app/driver.py
@@ -1553,12 +1553,12 @@ class SMART_DEVICE_APP(DeviceConfig, DevicePlugin):
 
     def _check_if_format_send_needed(self, db, id_, book):
         if not self.will_ask_for_update_books:
-            return None
+            return (None, False)
 
         from calibre.utils.date import parse_date, isoformat
         try:
             if not hasattr(book, '_format_mtime_'):
-                return None
+                return (None, False)
 
             ext = posixpath.splitext(book.lpath)[1][1:]
             fmt_metadata = db.new_api.format_metadata(id_, ext)


### PR DESCRIPTION
This isn't important enough to require a slipstream release, but if you make one for some other reason could you include this patch? Thanks.
