### PR TITLE
Prevent completion dialog from being cut off if window not maximized

### DIFF
--- a/src/calibre/gui2/proceed.py
+++ b/src/calibre/gui2/proceed.py
@@ -273,10 +273,10 @@ class ProceedQuestion(QWidget):
 
     def position_widget(self):
         geom = self.parent().geometry()
-        x = geom.right() - self.width()
+        x = geom.width() - self.width()
         sb = self.parent().statusBar()
         if sb is None:
-            y = geom.bottom() - self.height()
+            y = geom.height() - self.height()
         else:
             y = sb.geometry().top() - self.height()
         self.move(x, y)


### PR DESCRIPTION
In testing the changes to completion dialog handling in proceed.py under Windows 8.1 x64 I noticed that the right side of the popup dialog was cut off unless the calibre window was maximized. It appears that the position is being calculated incorrectly.
