### PR TITLE
Add the ability to fetch the user categories for a book to proxy ...

### DIFF
--- a/src/calibre/db/lazy.py
+++ b/src/calibre/db/lazy.py
@@ -107,7 +107,7 @@ ga = object.__getattribute__
 sa = object.__setattr__
 
 def simple_getter(field, default_value=None):
-    def func(dbref, book_id, cache):
+    def func(dbref, book_id, cache, proxy_metadata):
         try:
             return cache[field]
         except KeyError:
@@ -117,7 +117,7 @@ def simple_getter(field, default_value=None):
     return func
 
 def pp_getter(field, postprocess, default_value=None):
-    def func(dbref, book_id, cache):
+    def func(dbref, book_id, cache, proxy_metadata):
         try:
             return cache[field]
         except KeyError:
@@ -127,7 +127,7 @@ def pp_getter(field, postprocess, default_value=None):
     return func
 
 def adata_getter(field):
-    def func(dbref, book_id, cache):
+    def func(dbref, book_id, cache, proxy_metadata):
         try:
             author_ids, adata = cache['adata']
         except KeyError:
@@ -141,7 +141,7 @@ def adata_getter(field):
     return func
 
 def dt_getter(field):
-    def func(dbref, book_id, cache):
+    def func(dbref, book_id, cache, proxy_metadata):
         try:
             return cache[field]
         except KeyError:
@@ -151,7 +151,7 @@ def dt_getter(field):
     return func
 
 def item_getter(field, default_value=None, key=0):
-    def func(dbref, book_id, cache):
+    def func(dbref, book_id, cache, proxy_metadata):
         try:
             return cache[field]
         except KeyError:
@@ -164,7 +164,7 @@ def item_getter(field, default_value=None, key=0):
     return func
 
 def fmt_getter(field):
-    def func(dbref, book_id, cache):
+    def func(dbref, book_id, cache, proxy_metadata):
         try:
             format_metadata = cache['format_metadata']
         except KeyError:
@@ -179,7 +179,7 @@ def fmt_getter(field):
         return format_metadata
     return func
 
-def approx_fmts_getter(dbref, book_id, cache):
+def approx_fmts_getter(dbref, book_id, cache, proxy_metadata):
     try:
         return cache['formats']
     except KeyError:
@@ -188,9 +188,9 @@ def approx_fmts_getter(dbref, book_id, cache):
         return ret
 
 def series_index_getter(field='series'):
-    def func(dbref, book_id, cache):
+    def func(dbref, book_id, cache, proxy_metadata):
         try:
-            series = getters[field](dbref, book_id, cache)
+            series = getters[field](dbref, book_id, cache, proxy_metadata)
         except KeyError:
             series = custom_getter(field, dbref, book_id, cache)
         if series:
@@ -202,7 +202,7 @@ def series_index_getter(field='series'):
                 return ret
     return func
 
-def has_cover_getter(dbref, book_id, cache):
+def has_cover_getter(dbref, book_id, cache, proxy_metadata):
     try:
         return cache['has_cover']
     except KeyError:
@@ -232,13 +232,23 @@ def composite_getter(mi, field, metadata, book_id, cache, formatter, template_ca
             template_cache=template_cache).strip()
         return ret
 
-def virtual_libraries_getter(dbref, book_id, cache):
+def virtual_libraries_getter(dbref, book_id, cache, proxy_metadata):
     try:
         return cache['virtual_libraries']
     except KeyError:
         db = dbref()
         vls = db.virtual_libraries_for_books((book_id,))[book_id]
         ret = cache['virtual_libraries'] = ', '.join(vls)
+        return ret
+
+def user_categories_getter(dbref, book_id, cache, proxy_metadata):
+    try:
+        return cache['user_categories']
+    except KeyError:
+        db = dbref()
+        cache['user_categories'] = {}
+        val = db.user_categories_for_book(book_id, proxy_metadata)
+        ret = cache['user_categories'] = val
         return ret
 
 getters = {
@@ -258,6 +268,7 @@ getters = {
     'application_id':lambda x, book_id, y: book_id,
     'id':lambda x, book_id, y: book_id,
     'virtual_libraries':virtual_libraries_getter,
+    'user_categories':user_categories_getter,
 }
 
 for field in ('comments', 'publisher', 'identifiers', 'series', 'rating'):
@@ -283,13 +294,13 @@ class ProxyMetadata(Metadata):
         sa(self, 'formatter', SafeFormat() if formatter is None else formatter)
         sa(self, '_db', weakref.ref(db))
         sa(self, '_book_id', book_id)
-        sa(self, '_cache', {'user_categories':{}, 'cover_data':(None,None), 'device_collections':[]})
+        sa(self, '_cache', {'cover_data':(None,None), 'device_collections':[]})
         sa(self, '_user_metadata', db.field_metadata)
 
     def __getattribute__(self, field):
         getter = getters.get(field, None)
         if getter is not None:
-            return getter(ga(self, '_db'), ga(self, '_book_id'), ga(self, '_cache'))
+            return getter(ga(self, '_db'), ga(self, '_book_id'), ga(self, '_cache'), self)
         if field in SIMPLE_GET:
             return ga(self, '_cache').get(field, None)
         try:

--- a/src/calibre/utils/formatter_functions.py
+++ b/src/calibre/utils/formatter_functions.py
@@ -1397,6 +1397,23 @@ class BuiltinVirtualLibraries(BuiltinFormatterFunction):
             return mi._proxy_metadata.virtual_libraries
         return _('This function can be used only in the GUI')
 
+class BuiltinUserCategories(BuiltinFormatterFunction):
+    name = 'user_categories'
+    arg_count = 0
+    category = 'Get values from metadata'
+    __doc__ = doc = _('user_categories() -- return a comma-separated list of '
+                      'the user categories that contain this book. This function '
+                      'works only in the GUI. If you want to use these values '
+                      'in save-to-disk or send-to-device templates then you '
+                      'must make a custom "Column built from other columns", use '
+                      'the function in that column\'s template, and use that '
+                      'column\'s value in your save/send templates')
+
+    def evaluate(self, formatter, kwargs, mi, locals_):
+        if hasattr(mi, '_proxy_metadata'):
+            return ', '.join(k for (k, v) in mi._proxy_metadata.user_categories.items() if v)
+        return _('This function can be used only in the GUI')
+
 class BuiltinTransliterate(BuiltinFormatterFunction):
     name = 'transliterate'
     arg_count = 1
@@ -1480,7 +1497,7 @@ _formatter_builtins = [
     BuiltinSublist(),BuiltinSubstr(), BuiltinSubtract(), BuiltinSwapAroundComma(),
     BuiltinSwitch(), BuiltinTemplate(), BuiltinTest(), BuiltinTitlecase(),
     BuiltinToday(), BuiltinTransliterate(), BuiltinUppercase(),
-    BuiltinVirtualLibraries()
+    BuiltinUserCategories(), BuiltinVirtualLibraries()
 ]
 
 class FormatterUserFunction(FormatterFunction):


### PR DESCRIPTION
...metadata. Add a formatter function to use it.

@Kovid: I am not completely happy with this implementation. The changes to cache.py are required to avoid infinite recursion. The method user_categories_for_book calls field_for() which calls composite_for(). The composite_for method created a new ProxyMetadata object and then attempts to evaluate the composite column in question. If that column was the one with a template calling user_categories_for_book, it recurses because the new ProxyMetadata object doesn't see the original's cache.

As you can see, I put a stop to the recursion by passing in the instance of proxy_metadata for the field_for method to use. I thing that makes me nervous with this approach is that it changes a fundamental API. I considered trying to use more basic APIs in user_categories_for_book, but that has the drawbacks of code cloning and being more difficult.

If you have an alternate idea to avoid the recursion, I am all ears.

BTW: the fact that composite_for creates a new ProxyMetadata instance raises the question of whether the caches are as effective as they should/could be. It seems that the value will be cached twice and then discarded once.
