### PR TITLE
Fix proceed dialog pops up multiple times

### DIFF
--- a/src/calibre/gui2/proceed.py
+++ b/src/calibre/gui2/proceed.py
@@ -255,8 +255,8 @@ class ProceedQuestion(QWidget):
             button = self.action_button if question.focus_action and question.action_callback is not None else \
                 (self.bb.button(self.bb.Ok) if question.show_ok else self.bb.button(self.bb.Yes))
             button.setDefault(True)
-        self.raise_()
-        self.start_show_animation()
+            self.raise_()
+            self.start_show_animation()
 
     def start_show_animation(self):
         if self.rendered_pixmap is not None:


### PR DESCRIPTION
Bug Fix. The proceed question dialog animation is performed whenever a job completes, even if the dialog is already being displayed due to a previous job completion. 
