### PR TITLE
Tweak to allow minimum size for proceed popup

### DIFF
--- a/resources/default_tweaks.py
+++ b/resources/default_tweaks.py
@@ -564,3 +564,10 @@ restrict_output_formats = None
 # numbers.
 # The value can be between 50 and 99
 content_server_thumbnail_compression_quality = 75
+
+#: Minimum size of the notification popup at the completion of background jobs
+# When a background job completes a notification pops up in the calibre window.
+# The minimum size for this notification can be set using this tweak. The pair
+# of values indicate the number of pixels of width and height. The default is
+# (0, 0) to use the automatically determined smallest size.
+proceed_question_min_size = (0, 0)

--- a/src/calibre/gui2/proceed.py
+++ b/src/calibre/gui2/proceed.py
@@ -16,6 +16,7 @@ from PyQt5.Qt import (
 
 from calibre.constants import __version__
 from calibre.gui2.dialogs.message_box import ViewLog
+from calibre.utils.config_base import tweaks
 
 Question = namedtuple('Question', 'payload callback cancel_callback '
         'title msg html_log log_viewer_title log_is_file det_msg '
@@ -213,10 +214,11 @@ class ProceedQuestion(QWidget):
         self.do_resize()
 
     def do_resize(self):
+        minsz = tweaks.get('proceed_question_min_size', (0, 0))
         sz = self.sizeHint()
-        sz.setWidth(min(self.parent().width(), sz.width()))
+        sz.setWidth(min(self.parent().width(), max(minsz[0], sz.width())))
         sb = self.parent().statusBar().height() + 10
-        sz.setHeight(min(self.parent().height() - sb, sz.height()))
+        sz.setHeight(min(self.parent().height() - sb, max(minsz[1], sz.height())))
         self.resize(sz)
         self.position_widget()
 


### PR DESCRIPTION
In versions of calibre prior to 2.7 it was possible for the user to increase the size of the job completion notification (proceed_question) dialog. This was useful for users of my Overdrive Link plugin, which can return a large detailed message. Now the notification popup is a small fixed size, which is best for most users, but those (like myself) with large screens would benefit from it being larger.

I am submitting for your consideration the implementation of a tweak to allow the minimum dimensions of the popup to be set.

This is just a suggestion. Perhaps you may have a better way to accomplish this.
