### PR TITLE
Bug 1392052: saved search with names containing backslashes don't work.

### DIFF
--- a/src/calibre/gui2/dialogs/saved_search_editor.py
+++ b/src/calibre/gui2/dialogs/saved_search_editor.py
@@ -39,8 +39,13 @@ class SavedSearchEditor(QDialog, Ui_SavedSearchEditor):
         for name in sorted(self.searches.keys(), key=sort_key):
             self.search_name_box.addItem(name)
 
+    def sanitize_name(self):
+        n = unicode(self.input_box.text()).strip().replace('\\', '')
+        self.input_box.setText(n)
+        return n
+
     def add_search(self):
-        search_name = unicode(self.input_box.text()).strip()
+        search_name = self.sanitize_name()
         if search_name == '':
             return False
         if icu_lower(search_name) in self.search_names:
@@ -67,7 +72,7 @@ class SavedSearchEditor(QDialog, Ui_SavedSearchEditor):
             self.search_name_box.removeItem(self.search_name_box.currentIndex())
 
     def rename_search(self):
-        new_search_name = unicode(self.input_box.text()).strip()
+        new_search_name = self.sanitize_name()
         if new_search_name == '':
             return False
         if icu_lower(new_search_name) in self.search_names:

--- a/src/calibre/gui2/search_box.py
+++ b/src/calibre/gui2/search_box.py
@@ -348,7 +348,13 @@ class SavedSearchBox(QComboBox):  # {{{
         name = unicode(self.currentText())
         if not name.strip():
             name = unicode(self.search_box.text()).replace('"', '')
-        if not (name and self.search_box.text()):
+        name = name.replace('\\', '')
+        if not name:
+            error_dialog(self, _('Create saved search'),
+                         _('Invalid saved search name. '
+                           'It must contain at least one letter or number'), show=True)
+            return
+        if not self.search_box.text():
             error_dialog(self, _('Create saved search'),
                          _('There is no search to save'), show=True)
             return


### PR DESCRIPTION
@Kovid: I didn't bother with looping through existing searches and removing the backslashes. The OP can do it easily, and I didn't want the extra code that would need to be maintained.
