### PR TITLE
Fix problem of invalid datetime metadata coming from a device.

### DIFF
--- a/src/calibre/devices/smart_device_app/driver.py
+++ b/src/calibre/devices/smart_device_app/driver.py
@@ -1308,18 +1308,22 @@ class SMART_DEVICE_APP(DeviceConfig, DevicePlugin):
                     self._debug('getting book metadata. Done', i, 'of', count)
                 opcode, result = self._receive_from_client(print_debug_info=False)
                 if opcode == 'OK':
-                    if '_series_sort_' in result:
-                        del result['_series_sort_']
-                    book = self.json_codec.raw_to_book(result, SDBook, self.PREFIX)
-                    book.set('_is_read_', result.get('_is_read_', None))
-                    book.set('_sync_type_', result.get('_sync_type_', None))
-                    book.set('_last_read_date_', result.get('_last_read_date_', None))
-                    bl.add_book_extended(book, replace_metadata=True,
-                                check_for_duplicates=not self.client_cache_uses_lpaths)
-                    if '_new_book_' in result:
-                        book.set('_new_book_', True)
-                    else:
-                        self._set_known_metadata(book)
+                    try:
+                        if '_series_sort_' in result:
+                            del result['_series_sort_']
+                        book = self.json_codec.raw_to_book(result, SDBook, self.PREFIX)
+                        book.set('_is_read_', result.get('_is_read_', None))
+                        book.set('_sync_type_', result.get('_sync_type_', None))
+                        book.set('_last_read_date_', result.get('_last_read_date_', None))
+                        bl.add_book_extended(book, replace_metadata=True,
+                                    check_for_duplicates=not self.client_cache_uses_lpaths)
+                        if '_new_book_' in result:
+                            book.set('_new_book_', True)
+                        else:
+                            self._set_known_metadata(book)
+                    except:
+                        self._debug('exception retrieving metadata for book', result.get('title', 'Unknown'))
+                        traceback.print_exc()
                 else:
                     raise ControlError(desc='book metadata not returned')
 

--- a/src/calibre/ebooks/metadata/book/json_codec.py
+++ b/src/calibre/ebooks/metadata/book/json_codec.py
@@ -17,9 +17,12 @@ from calibre import isbytestring
 # UTC. The returned date is also UTC
 def string_to_datetime(src):
     from calibre.utils.date import parse_date
-    if src == "None":
-        return None
-    return parse_date(src)
+    if src != "None":
+        try:
+            return parse_date(src)
+        except:
+            pass
+    return None
 
 def datetime_to_string(dateval):
     from calibre.utils.date import isoformat, UNDEFINED_DATE, local_tz


### PR DESCRIPTION
1) Catch errors in the wireless device driver
2) Return None in the json_codec if a date cannot be parsed.
