### PR TITLE
Fix for bug #1404526 using the template I found in gui2.library.models.p...

### DIFF
--- a/src/calibre/gui2/dialogs/match_books.py
+++ b/src/calibre/gui2/dialogs/match_books.py
@@ -84,7 +84,7 @@ class MatchBooks(QDialog, Ui_MatchBooks):
         self.books_table.setHorizontalHeaderItem(0, t)
         t = QTableWidgetItem(_('Authors'))
         self.books_table.setHorizontalHeaderItem(1, t)
-        t = QTableWidgetItem(_('Series'))
+        t = QTableWidgetItem(ngettext("Series", 'Series', 1))
         self.books_table.setHorizontalHeaderItem(2, t)
         self.books_table_header_height = self.books_table.height()
         self.books_table.cellDoubleClicked.connect(self.book_doubleclicked)

--- a/src/calibre/gui2/dialogs/quickview.py
+++ b/src/calibre/gui2/dialogs/quickview.py
@@ -96,7 +96,7 @@ class Quickview(QDialog, Ui_Quickview):
         self.books_table.setHorizontalHeaderItem(self.title_column, t)
         t = QTableWidgetItem(_('Authors'))
         self.books_table.setHorizontalHeaderItem(self.author_column, t)
-        t = QTableWidgetItem(_('Series'))
+        t = QTableWidgetItem(ngettext("Series", 'Series', 1))
         self.books_table.setHorizontalHeaderItem(self.series_column, t)
         self.books_table_header_height = self.books_table.height()
         self.books_table.cellDoubleClicked.connect(self.book_doubleclicked)


### PR DESCRIPTION
...y: ngettext("Series", 'Series', 1). Note that the same problem existed in the match_books dialog.
