### PR TITLE
Proposed solution for 1/2 of enhancement #1415714. Instead of making ...

### DIFF
--- a/src/calibre/gui2/actions/show_quickview.py
+++ b/src/calibre/gui2/actions/show_quickview.py
@@ -37,6 +37,7 @@ class ShowQuickviewAction(InterfaceAction):
             self.current_instance = \
                 Quickview(self.gui, self.gui.library_view, index)
             self.current_instance.show()
+            self.last_window_state = self.current_instance.windowState();
 
     def change_quickview_column(self, idx):
         self.show_quickview()
@@ -48,3 +49,7 @@ class ShowQuickviewAction(InterfaceAction):
     def library_changed(self, db):
         if self.current_instance and not self.current_instance.is_closed:
             self.current_instance.reject()
+
+    def change_window_state(self, state):
+        if self.current_instance and not self.current_instance.is_closed:
+            self.current_instance.change_window_state(state)

--- a/src/calibre/gui2/dialogs/quickview.py
+++ b/src/calibre/gui2/dialogs/quickview.py
@@ -63,8 +63,9 @@ class Quickview(QDialog, Ui_Quickview):
 
         # Remove the help button from the window title bar
         icon = self.windowIcon()
-        self.setWindowFlags(self.windowFlags()&(~Qt.WindowContextHelpButtonHint))
-        self.setWindowFlags(self.windowFlags()|Qt.WindowStaysOnTopHint)
+        self.setWindowFlags(self.windowFlags()&(~Qt.WindowContextHelpButtonHint &
+                            ~Qt.WindowMinMaxButtonsHint))
+        self.setWindowFlags(self.windowFlags()|Qt.Window)
         self.setWindowIcon(icon)
 
         self.db = view.model().db
@@ -256,6 +257,12 @@ class Quickview(QDialog, Ui_Quickview):
         if select_item is not None:
             self.books_table.setCurrentItem(select_item)
             self.books_table.scrollToItem(select_item, QAbstractItemView.PositionAtCenter)
+
+    def change_window_state(self, state):
+        if state & Qt.WindowMinimized:
+            self.setWindowState(Qt.WindowMinimized)
+        else:
+            self.setWindowState(Qt.WindowNoState)
 
     # Deal with sizing the table columns. Done here because the numbers are not
     # correct until the first paint.

--- a/src/calibre/gui2/ui.py
+++ b/src/calibre/gui2/ui.py
@@ -928,9 +928,9 @@ class Main(MainWindow, MainWindowMixin, DeviceMixin, EmailMixin,  # {{{
             QApplication.instance().quit()
 
     def changeEvent(self, e):
-        e.ignore()
         if isinstance(e, QWindowStateChangeEvent):
             self.iactions['Show quickview'].change_window_state(self.windowState())
+        MainWindow.changeEvent(self, e)
 
     def closeEvent(self, e):
         self.write_settings()

--- a/src/calibre/gui2/ui.py
+++ b/src/calibre/gui2/ui.py
@@ -18,7 +18,7 @@ from io import BytesIO
 import apsw
 from PyQt5.Qt import (
     Qt, QTimer, QAction, QMenu, QIcon, pyqtSignal, QUrl, QFont, QDialog,
-    QApplication, QSystemTrayIcon)
+    QApplication, QSystemTrayIcon, QWindowStateChangeEvent)
 
 from calibre import prints, force_unicode, detect_ncpus
 from calibre.constants import __appname__, isosx, filesystem_encoding, DEBUG
@@ -926,6 +926,11 @@ class Main(MainWindow, MainWindowMixin, DeviceMixin, EmailMixin,  # {{{
             except:
                 pass
             QApplication.instance().quit()
+
+    def changeEvent(self, e):
+        e.ignore()
+        if isinstance(e, QWindowStateChangeEvent):
+            self.iactions['Show quickview'].change_window_state(self.windowState())
 
     def closeEvent(self, e):
         self.write_settings()


### PR DESCRIPTION
...quickview a pane, which I think would be very invasive, these changes make the quickview window always on top of calibre but not other application windows. In addition, minimizing calibre will minimize quickview and vice versa. I have tested this change on windows.

This is clearly a behavior change, but I think it is for the better.

Also note that I removed the minimize and maximize buttons. Minimize didn't really minimize anymore, and the window state was getting confused. This behavior change might trigger some unhappiness.