### PR TITLE
Reset the alignment map when switching libraries. This prevents non-left...

### DIFF
--- a/src/calibre/gui2/library/models.py
+++ b/src/calibre/gui2/library/models.py
@@ -256,6 +256,7 @@ class BooksModel(QAbstractTableModel):  # {{{
 
     def set_database(self, db):
         self.ids_to_highlight = []
+        self.alignment_map = {}
         self.ids_to_highlight_set = set()
         self.current_highlighted_idx = None
         self.db = db


### PR DESCRIPTION
... alignments from taking effect in the newly-opened library.

See http://www.mobileread.com/forums/showthread.php?t=256221