### PR TITLE
add bin/pdfimages from poppler to calibre packages

### DIFF
--- a/setup/installer/linux/freeze2.py
+++ b/setup/installer/linux/freeze2.py
@@ -67,7 +67,7 @@ arch = 'x86_64' if is64bit else 'i686'
 
 def binary_includes():
     return [
-    j(SW, 'bin', x) for x in ('pdftohtml', 'pdfinfo', 'pdftoppm')] + [
+    j(SW, 'bin', x) for x in ('pdftohtml', 'pdfinfo', 'pdftoppm', 'pdfimages')] + [
 
     j(SW, 'lib', 'lib' + x) for x in (
         'usb-1.0.so.0', 'mtp.so.9', 'expat.so.1', 'sqlite3.so.0',

--- a/setup/installer/osx/app/main.py
+++ b/setup/installer/osx/app/main.py
@@ -415,7 +415,7 @@ class Py2App(object):
         info('\nAdding poppler')
         for x in ('libpoppler.46.dylib',):
             self.install_dylib(os.path.join(SW, 'lib', x))
-        for x in ('pdftohtml', 'pdftoppm', 'pdfinfo'):
+        for x in ('pdftohtml', 'pdftoppm', 'pdfinfo', 'pdfimages'):
             self.install_dylib(os.path.join(SW, 'bin', x), False)
 
     @flush

--- a/setup/installer/windows/freeze.py
+++ b/setup/installer/windows/freeze.py
@@ -315,7 +315,7 @@ class Win32Freeze(Command, WixMixIn):
 
         self.info('\tAdding misc binary deps')
         bindir = os.path.join(SW, 'bin')
-        for x in ('pdftohtml', 'pdfinfo', 'pdftoppm'):
+        for x in ('pdftohtml', 'pdfinfo', 'pdftoppm', 'pdfimages'):
             shutil.copy2(os.path.join(bindir, x+'.exe'), self.base)
         for pat in ('*.dll',):
             for f in glob.glob(os.path.join(bindir, pat)):


### PR DESCRIPTION
Hello again Kovid!

Please consider adding the 48K binary [`pdfimages`](http://cgit.freedesktop.org/poppler/poppler/tree/utils/pdfimages.cc) from poppler to the calibre packages.
It has the same library requirements as the other poppler binaries being shipped.

I ask because my [plugin](http://github.com/kfix/calibre_plugin_djvumaker) uses it to list PDFs' image contents to decide whether they are scanned library books that should be further compressed to DJVU. The python functions in calibre to extract PDF images are way slower than `pdfimages`.

Currently, installing my plugin requires the user to install an external popper just to get `pdfimages`. Poppler has a few layers of dependencies (cairo, glib) which may be completely useless to the user (e.g. ones on Windows)

If `pdfimages` (which is already being built by the calibre CI bots) was included in the calibre package, the user would only have to install djvulibre and ghostscript, which have a smaller and shallow set of dependencies and more general value to any user.

Regards, joey