### PR TITLE
Minor toolbar string fix: 1 book, 0 or > 1 - books

### DIFF
--- a/src/calibre/gui2/actions/choose_library.py
+++ b/src/calibre/gui2/actions/choose_library.py
@@ -290,7 +290,7 @@ class ChooseLibraryAction(InterfaceAction):
         return self.stats.pretty(path)
 
     def update_tooltip(self, count):
-        tooltip = self.action_spec[2] + '\n\n' + _('{0} [{1} books]').format(
+        tooltip = self.action_spec[2] + '\n\n' + _('{0} [{1} book]' if count == 1 else '{0} [{1} books]').format(
             getattr(self, 'last_lname', ''), count)
         a = self.qaction
         a.setToolTip(tooltip)


### PR DESCRIPTION
Just a little tooltip string fix for just one book it will be saying "1 book" instead "1 books".