### PR TITLE
Add an option to disable writing calibre_boookmarks.txt into epub file

### DIFF
--- a/src/calibre/ebooks/oeb/iterator/bookmarks.py
+++ b/src/calibre/ebooks/oeb/iterator/bookmarks.py
@@ -81,7 +81,7 @@ class BookmarksMixin(object):
         if bookmarks is None:
             bookmarks = self.bookmarks
         dat = self.serialize_bookmarks(bookmarks)
-        if os.path.splitext(self.pathtoebook)[1].lower() == '.epub' and \
+        if (not os.environ["CALIBRE_NO_WRITE_BOOKMARKS"]) and os.path.splitext(self.pathtoebook)[1].lower() == '.epub' and \
             os.access(self.pathtoebook, os.R_OK):
             try:
                 zf = open(self.pathtoebook, 'r+b')


### PR DESCRIPTION
There's a lot of posts saying about it, a quick Google search got below links, including your reponse:
                                                                                
http://www.mobileread.com/forums/showthread.php?t=85802
http://ebooks.stackexchange.com/questions/2603/how-to-delete-calibre-epub-bookmarks
https://code.google.com/p/epub-squeaker/wiki/RemoveCalibreBookmarks             
                                                                                
**USAGE**                                                                       
                                                                                
``` bash                                                                        
$ CALIBRE_NO_WRITE_BOOKMARKS=1 calibre                                          
```                                                                             
                                                                                
The enviornment variable name is a bit longer, maybe you can think of a better version.
