### PR TITLE
Add a store_epub_bookmarks_in_the_file option for ebook-viewer

### DIFF
--- a/src/calibre/ebooks/oeb/iterator/bookmarks.py
+++ b/src/calibre/ebooks/oeb/iterator/bookmarks.py
@@ -66,7 +66,8 @@ class BookmarksMixin(object):
         self.bookmarks = []
         bmfile = os.path.join(self.base, 'META-INF', 'calibre_bookmarks.txt')
         raw = ''
-        if os.path.exists(bmfile):
+        if self.get_sore_epub_bookmarks_in_the_file_opt() and \
+            os.path.exists(bmfile):
             with open(bmfile, 'rb') as f:
                 raw = f.read()
         else:
@@ -81,7 +82,8 @@ class BookmarksMixin(object):
         if bookmarks is None:
             bookmarks = self.bookmarks
         dat = self.serialize_bookmarks(bookmarks)
-        if os.path.splitext(self.pathtoebook)[1].lower() == '.epub' and \
+        if self.get_sore_epub_bookmarks_in_the_file_opt() and \
+            os.path.splitext(self.pathtoebook)[1].lower() == '.epub' and \
             os.access(self.pathtoebook, os.R_OK):
             try:
                 zf = open(self.pathtoebook, 'r+b')
@@ -92,6 +94,11 @@ class BookmarksMixin(object):
                     add_missing=True)
         else:
             self.config['bookmarks_'+self.pathtoebook] = dat
+
+    def get_sore_epub_bookmarks_in_the_file_opt(self):
+        from calibre.gui2.viewer.documentview import config
+        c = config().parse()
+        return c.store_epub_bookmarks_in_the_file
 
     def add_bookmark(self, bm):
         self.bookmarks = [x for x in self.bookmarks if x['title'] !=

--- a/src/calibre/gui2/viewer/config.py
+++ b/src/calibre/gui2/viewer/config.py
@@ -49,6 +49,8 @@ def config(defaults=None):
             help=_('Default language for hyphenation rules'))
     c.add_opt('remember_current_page', default=True,
             help=_('Save the current position in the document, when quitting'))
+    c.add_opt('store_epub_bookmarks_in_the_file', default=True,
+            help=_('When viewing EPUB files, store bookmarks in the file'))
     c.add_opt('wheel_flips_pages', default=False,
             help=_('Have the mouse wheel turn pages'))
     c.add_opt('tap_flips_pages', default=True,
@@ -281,6 +283,7 @@ class ConfigDialog(QDialog, Ui_Dialog):
     def load_options(self, opts):
         self.opt_remember_window_size.setChecked(opts.remember_window_size)
         self.opt_remember_current_page.setChecked(opts.remember_current_page)
+        self.opt_store_epub_bookmarks_in_the_file.setChecked(opts.store_epub_bookmarks_in_the_file)
         self.opt_wheel_flips_pages.setChecked(opts.wheel_flips_pages)
         self.opt_tap_flips_pages.setChecked(opts.tap_flips_pages)
         self.opt_page_flip_duration.setValue(opts.page_flip_duration)
@@ -383,6 +386,7 @@ class ConfigDialog(QDialog, Ui_Dialog):
         c.set('max_fs_height', max_fs_height)
         c.set('hyphenate', self.hyphenate.isChecked())
         c.set('remember_current_page', self.opt_remember_current_page.isChecked())
+        c.set('store_epub_bookmarks_in_the_file', self.opt_store_epub_bookmarks_in_the_file.isChecked())
         c.set('wheel_flips_pages', self.opt_wheel_flips_pages.isChecked())
         c.set('tap_flips_pages', self.opt_tap_flips_pages.isChecked())
         c.set('page_flip_duration', self.opt_page_flip_duration.value())

--- a/src/calibre/gui2/viewer/config.ui
+++ b/src/calibre/gui2/viewer/config.ui
@@ -689,6 +689,13 @@ QToolBox::tab:hover {
              </property>
             </widget>
            </item>
+           <item row="5" column="0">
+            <widget class="QCheckBox" name="opt_store_epub_bookmarks_in_the_file">
+             <property name="text">
+              <string>When viewing EPUB files, store bookmarks in the file</string>
+             </property>
+            </widget>
+           </item>
           </layout>
          </widget>
         </widget>


### PR DESCRIPTION
Follows #378

I'm not a python expert, and I want to test it by myself first, but I can't find out where to begin. I tried `$ python2 setup.py install --prefix=dist`, it does not work. And I use ArchLinux.