### PR TITLE
Enhancement request #1440146: make the return key do a search instead of...

### DIFF
--- a/src/calibre/gui2/dialogs/edit_authors_dialog.py
+++ b/src/calibre/gui2/dialogs/edit_authors_dialog.py
@@ -38,6 +38,8 @@ class EditAuthorsDialog(QDialog, Ui_EditAuthorsDialog):
         except:
             pass
 
+        self.buttonBox.button(QDialogButtonBox.Ok).setText(_('&OK'))
+        self.buttonBox.button(QDialogButtonBox.Cancel).setText(_('&Cancel'))
         self.buttonBox.accepted.connect(self.accepted)
 
         # Set up the column headings
@@ -114,6 +116,7 @@ class EditAuthorsDialog(QDialog, Ui_EditAuthorsDialog):
         self.find_box.lineEdit().returnPressed.connect(self.do_find)
         self.find_box.editTextChanged.connect(self.find_text_changed)
         self.find_button.clicked.connect(self.do_find)
+        self.find_button.setDefault(True)
 
         l = QLabel(self.table)
         self.not_found_label = l

--- a/src/calibre/gui2/dialogs/tag_list_editor.ui
+++ b/src/calibre/gui2/dialogs/tag_list_editor.ui
@@ -18,19 +18,35 @@
     <normaloff>:/images/chapters.png</normaloff>:/images/chapters.png</iconset>
   </property>
   <layout class="QGridLayout">
-   <item row="0" column="1">
+   <item row="0" column="0" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout_11">
+     <item>
+      <widget class="QLabel">
+       <property name="text">
+        <string>&amp;Search for:</string>
+       </property>
+       <property name="buddy">
+        <cstring>search_box</cstring>
+       </property>
+      </widget>
+     </item>
      <item>
       <widget class="HistoryLineEdit" name="search_box">
        <property name="toolTip">
         <string>Search for an item in the Tag column</string>
        </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>100</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
       </widget>
      </item>
      <item>
-      <widget class="QToolButton" name="search_button">
+      <widget class="QPushButton" name="search_button">
        <property name="text">
-        <string>Find</string>
+        <string>&amp;Find</string>
        </property>
        <property name="toolTip">
         <string>Copy the selected color name to the clipboard</string>


### PR DESCRIPTION
... closing the dialog.

While doing the above, I also made Manage Authors and Manage (something) behave similarly wrt searching again. I also added keyboard shortcuts to OK and Cancel.