### PR TITLE
Block lib change when proceed_question has questions.

### DIFF
--- a/src/calibre/gui2/actions/choose_library.py
+++ b/src/calibre/gui2/actions/choose_library.py
@@ -604,5 +604,11 @@ class ChooseLibraryAction(InterfaceAction):
                         ' are running.'), show=True)
             return False
 
+        if self.gui.proceed_question.questions:
+            warning_dialog(self.gui, _('Not allowed'),
+                    _('You cannot change libraries until all'
+                        ' updates are accepted or rejected.'), show=True)
+            return False
+
         return True
 


### PR DESCRIPTION
Just like you can't change libraries while there are BG jobs running, I don't think you should be able to change libraries while there are outstanding updates waiting on the gui.proceed_question dialog.

This wasn't an issue when proceed_question was modal, but now it can happen.