### PR TITLE
Build scripts: Fix thread leak

### DIFF
--- a/setup/parallel_build.py
+++ b/setup/parallel_build.py
@@ -36,7 +36,9 @@ def parallel_build(jobs, log, verbose=True):
             if stderr:
                 log(stderr)
         if not ok:
+            p.close()
             return False
+    p.close()
     return True
 
 def parallel_check_output(jobs, log):


### PR DESCRIPTION
This leak would cause the build to fail due to
"thread.error: can't start new thread" here:

http://hydra.nixos.org/build/21690585/nixlog/1

Presumably it's the root cause of this report as well:
http://mail-index.netbsd.org/tech-pkg/2015/02/26/msg014313.html