### PR TITLE
Fix UnicodeDecodeError in linux installer script

### DIFF
--- a/setup/linux-installer.py
+++ b/setup/linux-installer.py
@@ -594,7 +594,7 @@ def get_https_resource_securely(url, timeout=60, max_redirects=5, ssl_version=No
 def extract_tarball(raw, destdir):
     prints('Extracting application files...')
     with open('/dev/null', 'w') as null:
-        p = subprocess.Popen(['tar', 'xJof', '-', '-C', destdir], stdout=null, stdin=subprocess.PIPE, close_fds=True,
+        p = subprocess.Popen([b'tar', 'xJof', '-', '-C', destdir], stdout=null, stdin=subprocess.PIPE, close_fds=True,
             preexec_fn=lambda:
                         signal.signal(signal.SIGPIPE, signal.SIG_DFL))
         p.stdin.write(raw)


### PR DESCRIPTION
Had an exception whenever I used linux-installer.py with Python 2.7.6 :

~~~
Traceback (most recent call last):
  File "linux-installer.py", line 667, in <module>
    main('~/calibre-bin', True)
  File "linux-installer.py", line 646, in main
    download_and_extract(destdir)
  File "linux-installer.py", line 626, in download_and_extract
    extract_tarball(raw, destdir)
  File "linux-installer.py", line 598, in extract_tarball
    preexec_fn=lambda:
  File "/usr/lib/python2.7/subprocess.py", line 710, in __init__
    errread, errwrite)
  File "/usr/lib/python2.7/subprocess.py", line 1327, in _execute_child
    raise child_exception
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 12: ordinal not in range(128)
~~~

Turns out it was related to *unicode_literals* creating trouble with *subprocess.Popen*.

Expliciting the 'tar' command as a bytestring did the trick.