### PR TITLE
Change working of BG job options in Pref/Misc--also affects plugin jobs.

### DIFF
--- a/src/calibre/gui2/preferences/misc.ui
+++ b/src/calibre/gui2/preferences/misc.ui
@@ -17,7 +17,7 @@
    <item row="0" column="0">
     <widget class="QLabel" name="label_5">
      <property name="text">
-      <string>Max. simultaneous conversion/news download jobs:</string>
+      <string>Max. simultaneous conversion/news download/plugin jobs:</string>
      </property>
      <property name="buddy">
       <cstring>opt_worker_limit</cstring>
@@ -134,7 +134,7 @@
    <item row="3" column="0">
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>&amp;Abort conversion jobs that take more than:</string>
+      <string>&amp;Abort jobs that take more than:</string>
      </property>
      <property name="buddy">
       <cstring>opt_worker_max_time</cstring>


### PR DESCRIPTION
Until a user pointed it out today, I never realized the worker_max_time option affected PI jobs because it said 'conversion' on it.