### PR TITLE
Three changes for editing tags

### DIFF
--- a/src/calibre/gui2/custom_column_widgets.py
+++ b/src/calibre/gui2/custom_column_widgets.py
@@ -317,8 +317,10 @@ class Text(Base):
             if self.sep['ui_to_list'] == '&':
                 w.set_space_before_sep(True)
                 w.set_add_separator(tweaks['authors_completer_append_separator'])
+                w.get_editor_button().setVisible(False)
+            else:
+                w.get_editor_button().clicked.connect(self.edit)
             w.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Preferred)
-            w.get_editor_button().clicked.connect(self.edit)
         else:
             w = EditWithComplete(parent)
             w.set_separator(None)


### PR DESCRIPTION
The first commit improves the category editor available from the tag browser. The second commit makes Shift F2 (or whatever the edit key is) on a tags-like column in the book list open the tags editor instead of the line editor. The third removes the edit tag button in single edit metadata because it alters the order of the tags.