### PR TITLE
Handle custom is_names columns in the tag editor.

### DIFF
--- a/src/calibre/gui2/custom_column_widgets.py
+++ b/src/calibre/gui2/custom_column_widgets.py
@@ -317,9 +317,7 @@ class Text(Base):
             if self.sep['ui_to_list'] == '&':
                 w.set_space_before_sep(True)
                 w.set_add_separator(tweaks['authors_completer_append_separator'])
-                w.get_editor_button().setVisible(False)
-            else:
-                w.get_editor_button().clicked.connect(self.edit)
+            w.get_editor_button().clicked.connect(self.edit)
             w.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Preferred)
         else:
             w = EditWithComplete(parent)

--- a/src/calibre/gui2/library/delegates.py
+++ b/src/calibre/gui2/library/delegates.py
@@ -311,8 +311,7 @@ class CompleteDelegate(QStyledItemDelegate, UpdateEditorGeometry):  # {{{
             m = index.model()
             col = m.column_map[index.column()]
             # If shifted, bring up the tag editor instead of the line editor.
-            # Don't do this for people-name columns because order will be lost
-            if QApplication.keyboardModifiers() == Qt.ShiftModifier and self.sep == ',':
+            if QApplication.keyboardModifiers() == Qt.ShiftModifier and col != 'authors':
                 key = col if m.is_custom_column(col) else None
                 d = TagEditor(parent, self.db, m.id(index.row()), key=key)
                 if d.exec_() == TagEditor.Accepted:


### PR DESCRIPTION
You were right -- drag/drop was trivial. However, I didn't find a straightforward way to know that the order had been changed, so I changed the code to regenerate the applied tags list whenever necessary.

I thought about changing it to work on "authors" but that turned out to be more work than I wanted to do. :)