### PR TITLE
Change default date format for news

### DIFF
--- a/src/calibre/web/feeds/news.py
+++ b/src/calibre/web/feeds/news.py
@@ -91,7 +91,7 @@ class BasicNewsRecipe(Recipe):
 
     #: The format string for the date shown on the first page.
     #: By default: Day_Name, Day_Number Month_Name Year
-    timefmt                = ' [%a, %d %b %Y]'
+    timefmt                = ' [%Y-%m-%d]'
 
     #: List of feeds to download.
     #: Can be either ``[url1, url2, ...]`` or ``[('title1', url1), ('title2', url2),...]``


### PR DESCRIPTION
It's easier to organize news library using this [yyyy-mm-dd] format, especially when the library gets big