### PR TITLE
Write the "real" series sort value to the existing column in the …

### DIFF
--- a/src/calibre/db/schema_upgrades.py
+++ b/src/calibre/db/schema_upgrades.py
@@ -615,3 +615,28 @@ class SchemaUpgrade(object):
         self.db.execute(script)
 
 
+    def upgrade_version_21(self):
+        '''
+        Write the series sort into the existing sort column in the series table
+        '''
+
+        script = '''
+        DROP TRIGGER series_insert_trg;
+        DROP TRIGGER series_update_trg;
+
+        UPDATE series SET sort=title_sort(name);
+
+        CREATE TRIGGER series_insert_trg
+            AFTER INSERT ON series
+            BEGIN
+              UPDATE series SET sort=title_sort(NEW.name) WHERE id=NEW.id;
+            END;
+
+        CREATE TRIGGER series_update_trg
+            AFTER UPDATE ON series
+            BEGIN
+              UPDATE series SET sort=title_sort(NEW.name) WHERE id=NEW.id;
+            END;
+        '''
+        self.db.execute(script)
+

--- a/src/calibre/db/schema_upgrades.py
+++ b/src/calibre/db/schema_upgrades.py
@@ -621,8 +621,8 @@ class SchemaUpgrade(object):
         '''
 
         script = '''
-        DROP TRIGGER series_insert_trg;
-        DROP TRIGGER series_update_trg;
+        DROP TRIGGER IF EXISTS series_insert_trg;
+        DROP TRIGGER IF EXISTS series_update_trg;
 
         UPDATE series SET sort=title_sort(name);
 


### PR DESCRIPTION
…series table. Reason: other than composite columns, series_sort is the only value that cannot be extracted from a metadata.db.

This scheme change will not prevent reinstalling an older version (within reason) because the title_sort db function has existed for years.

Currently no one uses the series table sort column because it doesn't contain useful information. This commit changes that. That said, there is no reason to change any existing code because it should be computing the same value being put into the column, and if for some reason it computes a different value then we want to keep the current behavior.