### PR TITLE
Two tag browser shortcut code changes ...

### DIFF
--- a/src/calibre/gui2/tag_browser/ui.py
+++ b/src/calibre/gui2/tag_browser/ui.py
@@ -337,7 +337,7 @@ class TagBrowserWidget(QWidget):  # {{{
         ac = QAction(parent)
         parent.addAction(ac)
         parent.keyboard.register_shortcut('tag browser find box',
-                _('Find item'), default_keys=("Alt+f",),
+                _('Find item'), default_keys=(),
                 action=ac, group=_('Tag Browser'))
         ac.triggered.connect(self.set_focus_to_find_box)
 
@@ -348,7 +348,7 @@ class TagBrowserWidget(QWidget):  # {{{
         ac = QAction(parent)
         parent.addAction(ac)
         parent.keyboard.register_shortcut('tag browser find button',
-                _('Find button'), default_keys=("Alt+i",),
+                _('Find button'), default_keys=(),
                 action=ac, group=_('Tag Browser'))
         ac.triggered.connect(self.search_button.click)
 

--- a/src/calibre/gui2/tag_browser/ui.py
+++ b/src/calibre/gui2/tag_browser/ui.py
@@ -452,7 +452,6 @@ class TagBrowserWidget(QWidget):  # {{{
         parent.addAction(ac)
         parent.keyboard.register_shortcut('tag browser toggle item',
                 _("'Click' found item"), default_keys=(),
-                description="foobar",
                 action=ac, group=_('Tag Browser'))
         ac.triggered.connect(self.toggle_item)
 


### PR DESCRIPTION
The changes are in the commit messages.

Although I think that removing the default shortcuts will make support easier, I have no objection at all if you choose to leave them there.