### PR TITLE
bug #1516880: composite column definitions not copied when books are …

### DIFF
--- a/src/calibre/gui2/actions/copy_to_library.py
+++ b/src/calibre/gui2/actions/copy_to_library.py
@@ -432,11 +432,12 @@ class CopyToLibraryAction(InterfaceAction):
                 incompatible_columns = []
                 missing_columns = []
                 for k, m in db.field_metadata.custom_iteritems():
-                    if m['datatype'] == 'composite':
-                        continue
                     if k not in newdb_meta:
                         missing_columns.append(k)
                     elif not self._column_is_compatible(m, newdb_meta[k]):
+                        # Note that composite columns are always assumed to be
+                        # compatible. No attempt is made to copy the template
+                        # from the source to the destination.
                         incompatible_columns.append(k)
 
                 if missing_columns or incompatible_columns:


### PR DESCRIPTION
…copied between libraries. Note that because the templates can vary, there is no guarantee that composite column A in library 1 will produce the same answer as column A in library 2.