### PR TITLE
Fix #1516890: in bulk metadata update, the "apply changes" checkbox …

### DIFF
--- a/src/calibre/gui2/custom_column_widgets.py
+++ b/src/calibre/gui2/custom_column_widgets.py
@@ -1046,9 +1046,11 @@ class BulkText(BulkBase):
         if not self.col_metadata['is_multiple']:
             val = self.get_initial_value(book_ids)
             self.initial_val = val = self.normalize_db_val(val)
+            self.ignore_change_signals = True
             self.main_widget.blockSignals(True)
             self.main_widget.show_initial_value(val)
             self.main_widget.blockSignals(False)
+            self.ignore_change_signals = False
 
     def commit(self, book_ids, notify=False):
         if not self.a_c_checkbox.isChecked():


### PR DESCRIPTION
…for text-like custom columns was erroneously checked if only one value exists for the column, causing the value to be reset when the edit applied.