### PR TITLE
sanitize_html shouldn't error when handed an empty string.

### DIFF
--- a/src/calibre/library/comments.py
+++ b/src/calibre/library/comments.py
@@ -134,6 +134,8 @@ def merge_comments(one, two):
     return comments_to_html(one) + '\n\n' + comments_to_html(two)
 
 def sanitize_html(html):
+    if not html:
+        return u''
     if isinstance(html, bytes):
         html = html.decode('utf-8', 'replace')
     import html5lib


### PR DESCRIPTION
FanFicFare calls calibre.library.comments.sanitize_comments_html() before setting comments.

sanitize_comments_html() now does some processing before calling sanitize_html().

But if given HTML such as "<div></div>", sanitize_comments_html() reduces it down to an empty string before calling sanitize_html(), which then throws an exception when it calls serializer.render().