### PR TITLE
Don't register the empty string as a shortcut in template tester. …

### DIFF
--- a/src/calibre/gui2/actions/show_template_tester.py
+++ b/src/calibre/gui2/actions/show_template_tester.py
@@ -13,7 +13,7 @@ from calibre.gui2 import error_dialog
 class ShowTemplateTesterAction(InterfaceAction):
 
     name = 'Template tester'
-    action_spec = (_('Template tester'), 'debug.png', None, '')
+    action_spec = (_('Template tester'), 'debug.png', None, ())
     dont_add_to = frozenset(['context-menu-device'])
     action_type = 'current'
 


### PR DESCRIPTION
…Instead register the empty tuple. This avoids some spurious messages in the debug log.