### PR TITLE
Change Name=calibre to Name=Calibre for .desktop file entry

### DIFF
--- a/src/calibre/linux.py
+++ b/src/calibre/linux.py
@@ -1019,7 +1019,7 @@ GUI = '''\
 [Desktop Entry]
 Version=1.0
 Type=Application
-Name=calibre
+Name=Calibre
 GenericName=E-book library management
 Comment=E-book library management: Convert, view, share, catalogue all your e-books
 TryExec=calibre


### PR DESCRIPTION
English conventions standardize the capitalization of names.