### PR TITLE
Don't apply clickable link to title in book details.

### DIFF
--- a/src/calibre/ebooks/metadata/book/render.py
+++ b/src/calibre/ebooks/metadata/book/render.py
@@ -190,6 +190,13 @@ def mi_to_html(mi, field_list=None, default_author_link=None, use_roman_numbers=
                 search_href('publisher', mi.publisher), _('Click to see books with {0}: {1}').format(metadata['name'], a(mi.publisher)),
                 a(item_data('publisher', mi.publisher, book_id)), p(mi.publisher))
             ans.append((field, row % (name, val)))
+        elif field == 'title':
+            # otherwise title gets metadata['datatype'] == 'text'
+            # treatment below with a click to search link (which isn't
+            # too bad), and a right-click 'Delete' option to delete
+            # the title (which is bad).
+            val = mi.format_field(field)[-1]
+            ans.append((field, row % (name, val)))
         else:
             val = mi.format_field(field)[-1]
             if val is None:


### PR DESCRIPTION
Commit f7e8e5e8f066b07672a9be34ae283089c16406bd added click-able link handle for all `metadata['datatype'] == 'text'` entries in book details.  This was in answer to bug [#1521004 Non-clickables in the book details](https://bugs.launchpad.net/calibre/+bug/1521004).

The bug report is specifically talking about custom columns, so I assume the fact it also changed handling for Title was incidental.

Being able to click on the title to do a search for identical titles is situationally useful.  Being able to right-click and *delete the title* is IMO a bad idea.

This change explicitly exempts title from getting a link in book detail.