### PR TITLE
convert the text for Semitic Languages

### DIFF
--- a/src/calibre/gui2/book_details.py
+++ b/src/calibre/gui2/book_details.py
@@ -75,6 +75,12 @@ def render_html(mi, css, vertical, widget, all_fields=False, render_data_func=No
         ans = templ%(u'<table><tr><td valign="top" '
             'style="padding-right:2em; width:40%%">%s</td><td valign="top">%s</td></tr></table>'
                 % (table, right_pane))
+    
+    # Layout of text to Semitic languages display
+    from calibre.adjustments_lang import html_text
+    text = html_text(ans,"div")
+    ans = text.convert2()
+    
     return ans
 
 def get_field_list(fm, use_defaults=False):


### PR DESCRIPTION
convert the text for Semitic Languages - for example:
text like this:
"author:   someone"
Looks like this, in Semitic Languages :
"someone  :author"
its necessary for good display to these languages