### PR TITLE
Add 'are your sure' check to quit when proceed_question is waiting.

### DIFF
--- a/src/calibre/gui2/ui.py
+++ b/src/calibre/gui2/ui.py
@@ -861,6 +861,12 @@ class Main(MainWindow, MainWindowMixin, DeviceMixin, EmailMixin,  # {{{
 
             if not question_dialog(self, _('Active jobs'), msg):
                 return False
+
+        if self.proceed_question.questions:
+            msg = _('There are library updates waiting. Are you sure you want to quit?')
+            if not question_dialog(self, _('Library Updates Waiting'), msg):
+                return False
+
         from calibre.db.delete_service import has_jobs
         if has_jobs():
             msg = _('Some deleted books are still being moved to the Recycle '


### PR DESCRIPTION
Calibre already has an 'are you sure' check before quitting for running background jobs, and checks before switching libraries for both running background jobs and outstanding proceed_questions.  This change brings parity.  And I've accidentally quit before accepting updates a couple times.