### PR TITLE
Write the value of composite columns to the database when the OPF …

### DIFF
--- a/src/calibre/db/backup.py
+++ b/src/calibre/db/backup.py
@@ -83,6 +83,17 @@ class MetadataBackup(Thread):
             self.db.clear_dirtied(book_id, sequence)
             return
 
+        cc_metadata = mi.get_all_user_metadata(False)
+        for key,custom_col in cc_metadata.iteritems():
+            try:
+                if custom_col.get('datatype') == 'composite':
+                    self.db.set_field(key, {book_id: custom_col.get('#value#')},
+                                      allow_case_change=False,
+                                      do_path_update=False,
+                                      mark_dirty=False)
+            except:
+                pass
+
         # Give the GUI thread a chance to do something. Python threads don't
         # have priorities, so this thread would naturally keep the processor
         # until some scheduling event happens. The wait makes such an event

--- a/src/calibre/db/cache.py
+++ b/src/calibre/db/cache.py
@@ -1020,7 +1020,8 @@ class Cache(object):
             self.backend.executemany('INSERT OR IGNORE INTO metadata_dirtied (book) VALUES (?)', book_ids)
 
     @write_api
-    def set_field(self, name, book_id_to_val_map, allow_case_change=True, do_path_update=True):
+    def set_field(self, name, book_id_to_val_map, allow_case_change=True, do_path_update=True,
+                  mark_dirty=True):
         '''
         Set the values of the field specified by ``name``. Returns the set of all book ids that were affected by the change.
 
@@ -1064,7 +1065,8 @@ class Cache(object):
         if dirtied and update_path and do_path_update:
             self._update_path(dirtied, mark_as_dirtied=False)
 
-        self._mark_as_dirty(dirtied)
+        if mark_dirty:
+            self._mark_as_dirty(dirtied)
 
         return dirtied
 

--- a/src/calibre/db/write.py
+++ b/src/calibre/db/write.py
@@ -486,8 +486,7 @@ class Writer(object):
         self.field = field
         dt = field.metadata['datatype']
         self.accept_vals = lambda x: True
-        if dt == 'composite' or field.name in {
-            'id', 'size', 'path', 'formats', 'news'}:
+        if field.name in {'id', 'size', 'path', 'formats', 'news'}:
             self.set_books_func = dummy
         elif self.name[0] == '#' and self.name.endswith('_index'):
             self.set_books_func = custom_series_index


### PR DESCRIPTION
…backup is written.

The rationale: several programs/applications read the calibre database to get information about a book. One problem: the values of composite columns isn't there because those values are computed as needed. This patch writes the values to the db that are correct at the moment the metadata.opf is written. That means that an app can use the dirtied table to check if the values might be out of date.

Without the mark_dirty change the book is backed up over and over.