### PR TITLE
Add a LibraryClosed plugin type that is called when the library is …

### DIFF
--- a/src/calibre/customize/__init__.py
+++ b/src/calibre/customize/__init__.py
@@ -789,8 +789,8 @@ class LibraryClosedPlugin(Plugin):  # {{{
     '''
     type = _('Library Closed')
 
-    # minimum version 2 because it requires the new db
-    minimum_calibre_version = (2, 0, 0)
+    # minimum version 2.54 because that is when support was added
+    minimum_calibre_version = (2, 54, 0)
 
     def run(self, db):
         '''

--- a/src/calibre/customize/__init__.py
+++ b/src/calibre/customize/__init__.py
@@ -781,3 +781,25 @@ class EditBookToolPlugin(Plugin):  # {{{
 
 # }}}
 
+class LibraryClosedPlugin(Plugin):  # {{{
+    '''
+    LibraryClosedPlugins are run when a library is closed, either at shutdown,
+    when the library is changed, or when a library is used in some other way.
+    At the moment these plugins won't be called by the CLI functions.
+    '''
+    type = _('Library Closed')
+
+    # minimum version 2 because it requires the new db
+    minimum_calibre_version = (2, 0, 0)
+
+    def run(self, db):
+        '''
+        The db will be a reference to the new_api (db.cache.py).
+
+        The plugin must run to completion. It must not use the GUI, threads, or
+        any signals.
+        '''
+        raise NotImplementedError('LibraryClosedPlugin '
+                'run method must be overridden in subclass')
+# }}}
+

--- a/src/calibre/customize/ui.py
+++ b/src/calibre/customize/ui.py
@@ -255,6 +255,13 @@ def available_library_closed_plugins():
             if not is_disabled(plugin):
                 plugin.site_customization = customization.get(plugin.name, '')
                 yield plugin
+
+def has_library_closed_plugins():
+    for plugin in _initialized_plugins:
+        if isinstance(plugin, LibraryClosedPlugin):
+            if not is_disabled(plugin):
+                return True
+    return False
 # }}}
 
 # Store Plugins # {{{

--- a/src/calibre/customize/ui.py
+++ b/src/calibre/customize/ui.py
@@ -9,7 +9,8 @@ from calibre.customize import (CatalogPlugin, FileTypePlugin, PluginNotFound,
                               MetadataReaderPlugin, MetadataWriterPlugin,
                               InterfaceActionBase as InterfaceAction,
                               PreferencesPlugin, platform, InvalidPlugin,
-                              StoreBase as Store, ViewerPlugin, EditBookToolPlugin)
+                              StoreBase as Store, ViewerPlugin, EditBookToolPlugin,
+                              LibraryClosedPlugin)
 from calibre.customize.conversion import InputFormatPlugin, OutputFormatPlugin
 from calibre.customize.zipplugin import loader
 from calibre.customize.profiles import InputProfile, OutputProfile
@@ -241,6 +242,16 @@ def preferences_plugins():
     customization = config['plugin_customization']
     for plugin in _initialized_plugins:
         if isinstance(plugin, PreferencesPlugin):
+            if not is_disabled(plugin):
+                plugin.site_customization = customization.get(plugin.name, '')
+                yield plugin
+# }}}
+
+# Library Closed Plugins # {{{
+def available_library_closed_plugins():
+    customization = config['plugin_customization']
+    for plugin in _initialized_plugins:
+        if isinstance(plugin, LibraryClosedPlugin):
             if not is_disabled(plugin):
                 plugin.site_customization = customization.get(plugin.name, '')
                 yield plugin

--- a/src/calibre/db/cache.py
+++ b/src/calibre/db/cache.py
@@ -2017,7 +2017,7 @@ class Cache(object):
         for plugin in available_library_closed_plugins():
             try:
                 plugin.run(self)
-            except:
+            except Exception:
                 import traceback
                 traceback.print_exc()
         self.backend.close()

--- a/src/calibre/db/cache.py
+++ b/src/calibre/db/cache.py
@@ -2013,6 +2013,13 @@ class Cache(object):
 
     @write_api
     def close(self):
+        from calibre.customize.ui import available_library_closed_plugins
+        for plugin in available_library_closed_plugins():
+            try:
+                plugin.run(self)
+            except:
+                import traceback
+                traceback.print_exc()
         self.backend.close()
 
     @write_api

--- a/src/calibre/gui2/layout.py
+++ b/src/calibre/gui2/layout.py
@@ -8,7 +8,7 @@ __docformat__ = 'restructuredtext en'
 from functools import partial
 
 from PyQt5.Qt import (QIcon, Qt, QWidget, QSize,
-    pyqtSignal, QToolButton, QMenu, QAction,
+    pyqtSignal, QToolButton, QMenu, QAction, QCoreApplication,
     QObject, QVBoxLayout, QSizePolicy, QLabel, QHBoxLayout, QActionGroup)
 
 
@@ -306,8 +306,34 @@ class MainWindowMixin(object):  # {{{
         l = self.centralwidget.layout()
         l.addWidget(self.search_bar)
 
+
+
+    def show_shutdown_message(self, message):
+        msgs = getattr(self, 'shutdown_messages', None)
+        if msgs is None:
+            msgs = self.shutdown_messages = []
+        msgs.append(message)
+
+        smw = QWidget()
+        sml = QVBoxLayout()
+        smw.setLayout(sml)
+
+        # Construct the widget containing all the messages to date. Add stretch
+        # to make it vertically centered.
+        sml.addStretch()
+        for msg in msgs:
+            sml.addWidget(QLabel(msg), alignment=Qt.AlignHCenter)
+        sml.addStretch()
+
+        # The next line is needed to prevent the main widget from being garbage
+        # collected just in case more processing is required (and it is). As we
+        # are shutting down, the memory leak isn't of concern
+        if getattr(self, 'saved_central_widget', None) is None:
+            self.saved_central_widget = self.centralWidget
+
+        # Show the shutdown messages
+        self.setCentralWidget(smw)
+        # Force processing the events needed to show the message
+        QCoreApplication.processEvents()
+
 # }}}
-
-
-
-

--- a/src/calibre/gui2/layout.py
+++ b/src/calibre/gui2/layout.py
@@ -304,36 +304,25 @@ class MainWindowMixin(object):  # {{{
                 pass  # PyQt5 seems to be missing this property
 
         l = self.centralwidget.layout()
+
+        # Add in the widget for the shutdown messages. It is invisible until a
+        # message is shown
+        smw = self.shutdown_message_widget = QLabel('')
+        smw.setMinimumHeight(200)
+        smw.setAlignment(Qt.AlignCenter)
+        self.shutdown_message_widget.setVisible(False)
+        l.addWidget(smw)
+
+        # And now, start adding the real widgets
         l.addWidget(self.search_bar)
 
 
-
     def show_shutdown_message(self, message):
-        msgs = getattr(self, 'shutdown_messages', None)
-        if msgs is None:
-            msgs = self.shutdown_messages = []
-        msgs.append(message)
-
-        smw = QWidget()
-        sml = QVBoxLayout()
-        smw.setLayout(sml)
-
-        # Construct the widget containing all the messages to date. Add stretch
-        # to make it vertically centered.
-        sml.addStretch()
-        for msg in msgs:
-            sml.addWidget(QLabel(msg), alignment=Qt.AlignHCenter)
-        sml.addStretch()
-
-        # The next line is needed to prevent the main widget from being garbage
-        # collected just in case more processing is required (and it is). As we
-        # are shutting down, the memory leak isn't of concern
-        if getattr(self, 'saved_central_widget', None) is None:
-            self.saved_central_widget = self.centralWidget
-
-        # Show the shutdown messages
-        self.setCentralWidget(smw)
+        smw = self.shutdown_message_widget
+        smw.setVisible(True)
+        txt = smw.text()
+        txt += '\n' + message
+        smw.setText(txt)
         # Force processing the events needed to show the message
         QCoreApplication.processEvents()
-
 # }}}

--- a/src/calibre/gui2/ui.py
+++ b/src/calibre/gui2/ui.py
@@ -880,8 +880,8 @@ class Main(MainWindow, MainWindowMixin, DeviceMixin, EmailMixin,  # {{{
     def shutdown(self, write_settings=True):
         get_gui().show_shutdown_message(_('Shutting down'))
 
-        from calibre.customize.ui import available_library_closed_plugins
-        if available_library_closed_plugins():
+        from calibre.customize.ui import has_library_closed_plugins
+        if has_library_closed_plugins():
             get_gui().show_shutdown_message(
                 _('Running database shutdown plugins. This could take a few seconds...'))
 


### PR DESCRIPTION
…closed (new_api). Add a way to provide a message during shutdown.

The shutdown message stuff turned out to be mildly complicated. Using timers broke the rest of shutdown (messages about unexpected threads), as did permitting garbage collection of the existing central widget.