### PR TITLE
FreeBSD hal requires an extra step to get the correct path...

### DIFF
--- a/src/calibre/devices/usbms/device.py
+++ b/src/calibre/devices/usbms/device.py
@@ -699,7 +699,8 @@ class Device(DeviceConfig, DevicePlugin):
                         d.manufacturer == objif.GetProperty('usb.vendor') and \
                         d.product == objif.GetProperty('usb.product') and \
                         d.serial == objif.GetProperty('usb.serial'):
-                    dpaths = manager.FindDeviceStringMatch('storage.originating_device', path)
+                    midpath = manager.FindDeviceStringMatch('info.parent', path)
+                    dpaths = manager.FindDeviceStringMatch('storage.originating_device', midpath[0])
                     for dpath in dpaths:
                         # devif = dbus.Interface(bus.get_object('org.freedesktop.Hal', dpath), 'org.freedesktop.Hal.Device')
                         try:

--- a/src/calibre/devices/usbms/device.py
+++ b/src/calibre/devices/usbms/device.py
@@ -700,7 +700,7 @@ class Device(DeviceConfig, DevicePlugin):
                         d.product == objif.GetProperty('usb.product') and \
                         d.serial == objif.GetProperty('usb.serial'):
                     midpath = manager.FindDeviceStringMatch('info.parent', path)
-                    dpaths = manager.FindDeviceStringMatch('storage.originating_device', midpath[0])
+                    dpaths = manager.FindDeviceStringMatch('storage.originating_device', path) + manager.FindDeviceStringMatch('storage.originating_device', midpath[0])
                     for dpath in dpaths:
                         # devif = dbus.Interface(bus.get_object('org.freedesktop.Hal', dpath), 'org.freedesktop.Hal.Device')
                         try:


### PR DESCRIPTION
… to the device to be mounted.

As stated in the subject, after testing I discovered that when mounting USB devices The FreeBSD hal has a different structure from what is expected.

This patch fixes it.