### PR TITLE
Add option to shown full file pathnames in Editor File Browser, fix for for file.xhtml/file.xhtml

### DIFF
--- a/src/calibre/gui2/tweak_book/__init__.py
+++ b/src/calibre/gui2/tweak_book/__init__.py
@@ -73,6 +73,7 @@ d['editor_accepts_drops'] = True
 d['toolbar_icon_size'] = 24
 d['insert_full_screen_image'] = False
 d['preserve_aspect_ratio_when_inserting_image'] = False
+d['file_list_shows_full_pathname'] = False
 del d
 
 ucase_map = {l:string.ascii_uppercase[i] for i, l in enumerate(string.ascii_lowercase)}

--- a/src/calibre/gui2/tweak_book/boss.py
+++ b/src/calibre/gui2/tweak_book/boss.py
@@ -169,6 +169,7 @@ class Boss(QObject):
         if ret == p.Accepted:
             setup_cssutils_serialization()
             self.gui.apply_settings()
+            self.refresh_file_list()
         if ret == p.Accepted or p.dictionaries_changed:
             for ed in editors.itervalues():
                 ed.apply_settings(dictionaries_changed=p.dictionaries_changed)

--- a/src/calibre/gui2/tweak_book/file_list.py
+++ b/src/calibre/gui2/tweak_book/file_list.py
@@ -304,17 +304,21 @@ class FileList(QTreeWidget):
             return category
 
         def set_display_name(name, item):
-            if name in processed:
-                # We have an exact duplicate (can happen if there are
-                # duplicates in the spine)
-                item.setText(0, processed[name].text(0))
-                item.setText(1, processed[name].text(1))
-                return
+            if tprefs['file_list_shows_full_pathname']:
+                text = name
+            else:
+                if name in processed:
+                    # We have an exact duplicate (can happen if there are
+                    # duplicates in the spine)
+                    item.setText(0, processed[name].text(0))
+                    item.setText(1, processed[name].text(1))
+                    return
 
-            parts = name.split('/')
-            text = parts.pop()
-            while text in seen and parts:
-                text = parts.pop() + '/' + text
+                parts = name.split('/')
+                text = parts.pop()
+                while text in seen and parts:
+                    text = parts.pop() + '/' + text
+
             seen[text] = item
             item.setText(0, text)
             item.setText(1, hexlify(sort_key(text)))

--- a/src/calibre/gui2/tweak_book/file_list.py
+++ b/src/calibre/gui2/tweak_book/file_list.py
@@ -312,7 +312,7 @@ class FileList(QTreeWidget):
                 return
 
             parts = name.split('/')
-            text = parts[-1]
+            text = parts.pop()
             while text in seen and parts:
                 text = parts.pop() + '/' + text
             seen[text] = item

--- a/src/calibre/gui2/tweak_book/preferences.py
+++ b/src/calibre/gui2/tweak_book/preferences.py
@@ -321,6 +321,14 @@ class MainWindowSettings(BasicSettings):
         ))
         l.addRow(nd)
 
+        nd = self('file_list_shows_full_pathname')
+        nd.setText(_('Show full file pathnames in Files Browser'))
+        nd.setToolTip('<p>' + _(
+            'Showing the full file pathnames is useful when editing books that contain'
+            ' directories or the same file name more than once.'
+        ))
+        l.addRow(nd)
+
 class PreviewSettings(BasicSettings):
 
     def __init__(self, parent=None):


### PR DESCRIPTION
Adds an option to show full file pathnames in Editor File Browser.  That makes working with books containing directories and especially duplicate file names in different directories easier.  EpubMerge creates such books.

I saved this as two separate commits so you could clearly see the fix in 1460b7a for duplicate file name (in different dirs) appearing as file.xhtml/file.xhtml instead of dir/file.xhtml.