### PR TITLE
Fix for 1576742: (try to) Ensure that a date that is missing the day …

### DIFF
--- a/src/calibre/utils/date.py
+++ b/src/calibre/utils/date.py
@@ -129,7 +129,7 @@ def parse_date(date_string, assume_utc=False, as_utc=True, default=None):
         return UNDEFINED_DATE
     if default is None:
         func = datetime.utcnow if assume_utc else datetime.now
-        default = func().replace(hour=0, minute=0, second=0, microsecond=0,
+        default = func().replace(day=15, hour=0, minute=0, second=0, microsecond=0,
                 tzinfo=_utc_tz if assume_utc else _local_tz)
     dt = parse(date_string, default=default, dayfirst=parse_date_day_first)
     if dt.tzinfo is None:


### PR DESCRIPTION
…of the month uses a day in the middle of every month. It seems that the base default is the last day of the month, which breaks things for February dates for non leap years when the current year is a leap year. This is a guess ...