### PR TITLE
Save/reuse ViewLog size plus Saved Search Changes

### DIFF
--- a/src/calibre/gui2/dialogs/message_box.py
+++ b/src/calibre/gui2/dialogs/message_box.py
@@ -186,10 +186,7 @@ class ViewLog(QDialog):  # {{{
         self.copy_button.clicked.connect(self.copy_to_clipboard)
         l.addWidget(self.bb)
 
-        if unique_name:
-            self.unique_name = "ViewLog_size_"+unique_name
-        else:
-            self.unique_name = None
+        self.unique_name = unique_name or 'view-log-dialog'
         self.geom = gprefs.get(self.unique_name, None)
         self.finished.connect(self.dialog_closing)
         self.resize_dialog()

--- a/src/calibre/gui2/dialogs/saved_search_editor.py
+++ b/src/calibre/gui2/dialogs/saved_search_editor.py
@@ -37,6 +37,7 @@ class SavedSearchEditor(QDialog, Ui_SavedSearchEditor):
     def populate_search_list(self):
         self.search_name_box.blockSignals(True)
         self.search_name_box.clear()
+        self.search_name_box.addItem('')
         for name in sorted(self.searches.keys(), key=sort_key):
             self.search_name_box.addItem(name)
         self.search_names = set([icu_lower(n) for n in self.searches.keys()])
@@ -88,6 +89,7 @@ class SavedSearchEditor(QDialog, Ui_SavedSearchEditor):
         if self.current_search_name in self.searches:
             self.searches[new_search_name] = self.searches[self.current_search_name]
             del self.searches[self.current_search_name]
+            self.current_search_name = None
             self.populate_search_list()
             self.select_search(new_search_name)
         return True

--- a/src/calibre/gui2/dialogs/saved_search_editor.ui
+++ b/src/calibre/gui2/dialogs/saved_search_editor.ui
@@ -123,7 +123,7 @@
      <item row="0" column="5">
       <widget class="QToolButton" name="add_search_button">
        <property name="toolTip">
-        <string>Add the new saved search</string>
+        <string>Add a new, empty saved search with the name entered</string>
        </property>
        <property name="text">
         <string>...</string>

--- a/src/calibre/gui2/proceed.py
+++ b/src/calibre/gui2/proceed.py
@@ -20,7 +20,8 @@ from calibre.gui2.dialogs.message_box import ViewLog
 Question = namedtuple('Question', 'payload callback cancel_callback '
         'title msg html_log log_viewer_title log_is_file det_msg '
         'show_copy_button checkbox_msg checkbox_checked action_callback '
-        'action_label action_icon focus_action show_det show_ok icon')
+        'action_label action_icon focus_action show_det show_ok icon '
+        'log_viewer_unique_name')
 
 class Icon(QWidget):
 
@@ -306,7 +307,7 @@ class ProceedQuestion(QWidget):
             msg, det_msg='', show_copy_button=False, cancel_callback=None,
             log_is_file=False, checkbox_msg=None, checkbox_checked=False,
             action_callback=None, action_label=None, action_icon=None, focus_action=False,
-            show_det=False, show_ok=False, icon=None, **kw):
+            show_det=False, show_ok=False, icon=None, log_viewer_unique_name=None, **kw):
         '''
         A non modal popup that notifies the user that a background task has
         been completed. This class guarantees that only a single popup is
@@ -341,12 +342,13 @@ class ProceedQuestion(QWidget):
         :param show_det: If True, the Detailed message will be shown initially
         :param show_ok: If True, OK will be shown instead of YES/NO
         :param icon: The icon to be used for this popop (defaults to question mark). Can be either a QIcon or a string to be used with I()
+        :log_viewer_unique_name: If set, ViewLog will remember/reuse its size for this name in calibre.gui2.gprefs
         '''
         question = Question(
             payload, callback, cancel_callback, title, msg, html_log,
             log_viewer_title, log_is_file, det_msg, show_copy_button,
             checkbox_msg, checkbox_checked, action_callback, action_label,
-            action_icon, focus_action, show_det, show_ok, icon)
+            action_icon, focus_action, show_det, show_ok, icon, log_viewer_unique_name)
         self.questions.append(question)
         self.show_question()
 
@@ -358,7 +360,7 @@ class ProceedQuestion(QWidget):
                 with open(log, 'rb') as f:
                     log = f.read().decode('utf-8')
             self.log_viewer = ViewLog(q.log_viewer_title, log,
-                        parent=self)
+                        parent=self, unique_name=q.log_viewer_unique_name)
 
     def paintEvent(self, ev):
         painter = QPainter(self)

--- a/src/calibre/gui2/search_box.py
+++ b/src/calibre/gui2/search_box.py
@@ -334,6 +334,7 @@ class SavedSearchBox(QComboBox):  # {{{
         QComboBox.clear(self)
         self.initialize_saved_search_names()
         self.setEditText('')
+        self.setToolTip(self.tool_tip_text)
         self.line_edit.home(False)
 
     def key_pressed(self, event):
@@ -525,9 +526,9 @@ class SavedSearchBoxMixin(object):  # {{{
         # self.saved_searches_changed()
         self.saved_search.initialize(self.search, colorize=True,
                 help_text=_('Saved Searches'))
-        self.saved_search.setToolTip(
-            _('Choose saved search or enter name for new saved search'))
-        self.saved_search.setStatusTip(self.saved_search.toolTip())
+        self.saved_search.tool_tip_text=_('Choose saved search or enter name for new saved search')
+        self.saved_search.setToolTip(self.saved_search.tool_tip_text)
+        self.saved_search.setStatusTip(self.saved_search.tool_tip_text)
         for x in ('copy', 'save'):
             b = getattr(self, x+'_search_button')
             b.setStatusTip(b.toolTip())


### PR DESCRIPTION
Save/reuse ViewLog size from proceed_question when called with log_viewer_unique_name.

Plugins use proceed_question() to safely update the database.  I'd like to have the ViewLog dialog remember its size when called from my plugin.

This change allows that, but only if proceed_question() is called with parameter log_viewer_unique_name to preserve existing behavior everywhere else.

(I considered using the existing log_viewer_title instead of a new parameter, but thought that was too likely to not be unique.)