### PR TITLE
Remove "related" widget content from Economist recipe

### DIFF
--- a/recipes/economist.recipe
+++ b/recipes/economist.recipe
@@ -46,7 +46,7 @@ class Economist(BasicNewsRecipe):
             dict(name=['script', 'noscript', 'title', 'iframe', 'cf_floatingcontent']),
             dict(attrs={'class':['dblClkTrk', 'ec-article-info',
                 'share_inline_header', 'related-items',
-                                 'main-content-container']}),
+                                 'main-content-container', 'ec-topic-widget']}),
             {'class': lambda x: x and 'share-links-header' in x},
     ]
     keep_only_tags = [dict(name='article')]

--- a/recipes/economist_free.recipe
+++ b/recipes/economist_free.recipe
@@ -46,7 +46,7 @@ class Economist(BasicNewsRecipe):
             dict(name=['script', 'noscript', 'title', 'iframe', 'cf_floatingcontent']),
             dict(attrs={'class':['dblClkTrk', 'ec-article-info',
                 'share_inline_header', 'related-items',
-                                 'main-content-container']}),
+                                 'main-content-container', 'ec-topic-widget']}),
             {'class': lambda x: x and 'share-links-header' in x},
     ]
     keep_only_tags = [dict(name='article')]


### PR DESCRIPTION
This removes noisy "related articles" widget content from The Economist recipe:

![image](https://cloud.githubusercontent.com/assets/25395/15286981/a39b4ef2-1b68-11e6-86c6-ae860cf0f3c1.png)

(example of the widget takes from [this article](http://www.economist.com/news/united-states/21698712-republicans-are-tatters-over-donald-trump-learning-love-don))