### PR TITLE
Fix build on FreeBSD 9.3 i386.

### DIFF
--- a/src/calibre/utils/imageops/imageops.cpp
+++ b/src/calibre/utils/imageops/imageops.cpp
@@ -582,9 +582,9 @@ QImage despeckle(const QImage &image) {
 
 // overlay() {{{ 
 static inline unsigned int BYTE_MUL(unsigned int x, unsigned int a) {
-    quint64 t = (((quint64(x)) | ((quint64(x)) << 24)) & 0x00ff00ff00ff00ff) * a;
-    t = (t + ((t >> 8) & 0xff00ff00ff00ff) + 0x80008000800080) >> 8;
-    t &= 0x00ff00ff00ff00ff;
+    quint64 t = (((quint64(x)) | ((quint64(x)) << 24)) & 0x00ff00ff00ff00ffULL) * a;
+    t = (t + ((t >> 8) & 0xff00ff00ff00ffULL) + 0x80008000800080ULL) >> 8;
+    t &= 0x00ff00ff00ff00ffULL;
     return ((unsigned int)(t)) | ((unsigned int)(t >> 24));
 }
 


### PR DESCRIPTION
While updating the FreeBSD port I noticed a failure on i386 (32bit) only on FreeBSD 9.3.

I'd like this modifications which fix the problem to be included in calibre.

This is caused by the fact that FreeBSD 9.3 is still using gcc 4.2.1 as it's system compiler, and generated these error messages:

g++ -c -pipe -O2 -Wall -W -pthread -D_THREAD_SAFE -fPIC -DQT_NO_DEBUG -DQT_PLUGIN -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -I. -I/usr/local/include/python2.7 -I/usr/local/include/python2.7 -I../../../src/calibre/utils/imageops -I/usr/local/include/qt5 -I/usr/local/include/qt5/QtWidgets -I/usr/local/include/qt5/QtGui -I/usr/local/include/qt5/QtCore -I. -I/usr/local/include -I/usr/local/include -I/usr/local/lib/qt5/mkspecs/freebsd-g++ -o imageops.o ../../../src/calibre/utils/imageops/imageops.cpp
../../../src/calibre/utils/imageops/imageops.cpp:585: error: integer constant is too large for 'long' type
../../../src/calibre/utils/imageops/imageops.cpp:586: error: integer constant is too large for 'long' type
../../../src/calibre/utils/imageops/imageops.cpp:586: error: integer constant is too large for 'long' type
../../../src/calibre/utils/imageops/imageops.cpp:587: error: integer constant is too large for 'long' type
*** [imageops.o] Error code 1
1 error

I generated a patch which silences these errors, it should be a NOP on newer compilers.

Newer FreeBSD versions use clang 3.4 or newer as system compiler and are not affected.

Thanks!