### PR TITLE
Save/restore dialog size changes for the device driver configuration.

### DIFF
--- a/src/calibre/gui2/device.py
+++ b/src/calibre/gui2/device.py
@@ -955,23 +955,39 @@ class DeviceMixin(object):  # {{{
                     _('Cannot configure the device while there are running'
                         ' device jobs.'), show=True)
         dev = self.device_manager.connected_device
+        prefname = 'plugin config dialog:' + dev.type + ':' + dev.name
+        geom = gprefs.get(prefname, None)
+
         cw = dev.config_widget()
-        d = QDialog(self)
-        d.setWindowTitle(_('Configure %s')%dev.get_gui_name())
-        d.setWindowIcon(QIcon(I('config.png')))
-        l = QVBoxLayout(d)
-        d.setLayout(l)
+        config_dialog = QDialog(self)
+
+        config_dialog.setWindowTitle(_('Configure %s')%dev.get_gui_name())
+        config_dialog.setWindowIcon(QIcon(I('config.png')))
+        l = QVBoxLayout(config_dialog)
+        config_dialog.setLayout(l)
         bb = QDialogButtonBox(QDialogButtonBox.Ok|QDialogButtonBox.Cancel)
-        bb.accepted.connect(d.accept)
-        bb.rejected.connect(d.reject)
+        bb.accepted.connect(config_dialog.accept)
+        bb.rejected.connect(config_dialog.reject)
         l.addWidget(cw)
         l.addWidget(bb)
+
+        def size_dialog():
+            if geom is None:
+                config_dialog.resize(config_dialog.sizeHint())
+            else:
+                config_dialog.restoreGeometry(geom)
+
+        size_dialog()
+
         def validate():
             if cw.validate():
-                QDialog.accept(d)
-        d.accept = validate
-        if d.exec_() == d.Accepted:
+                QDialog.accept(config_dialog)
+        config_dialog.accept = validate
+        if config_dialog.exec_() == config_dialog.Accepted:
             dev.save_settings(cw)
+            geom = bytearray(config_dialog.saveGeometry())
+            gprefs[prefname] = geom
+
             do_restart = show_restart_warning(_('Restart calibre for the changes to %s'
                 ' to be applied.')%dev.get_gui_name(), parent=self)
             if do_restart:


### PR DESCRIPTION
As suggested, this saves and restores the dialog size for the device configuration dialogs. This was already being done when the configuration was opened from the plugin list, so the same preference name is used.