### PR TITLE
Fix #1598017 - KoboTouch configuration migration not working for older settings

### DIFF
--- a/src/calibre/devices/kobo/kobotouch_config.py
+++ b/src/calibre/devices/kobo/kobotouch_config.py
@@ -113,6 +113,7 @@ class KOBOTOUCHConfig(TabbedDeviceConfig):
 
         p['support_newer_firmware'] = self.support_newer_firmware
         p['debugging_title'] = self.debugging_title
+        p['driver_version'] = '.'.join([unicode(i) for i in self.device.version])
 
         return p
 


### PR DESCRIPTION
If the KoboTouch configuration was last saved using a very old version of calibre, the migration to the new style will fail. This will increases the likelyhood that the migration will work.

Plus realised I wasn't using the cached settings, so the migration kept happening.