### PR TITLE
Fixes Network rename/move issues with windows and servers

### DIFF
--- a/src/calibre/utils/filenames.py
+++ b/src/calibre/utils/filenames.py
@@ -404,8 +404,10 @@ class WindowsAtomicFolderMove(object):
                         ' operation was started'%path)
             else:
                 raise ValueError(u'The file %r does not exist'%path)
+
+        hardlink = get_hardlink_function(path, dest)
         try:
-            windows_hardlink(path, dest)
+            hardlink(path, dest)
             return
         except:
             pass


### PR DESCRIPTION
I realize you don't officially "support" network locations; and that the current edition of Calibre is single user.   But for those of us who are willing to run this as a single user hitting a network share; this fixes the most common reason for the error -13 permissions issue when changing a Author/Title on a network share from a windows machine.

