### PR TITLE
Comments custom columns:

### DIFF
--- a/src/calibre/ebooks/metadata/book/render.py
+++ b/src/calibre/ebooks/metadata/book/render.py
@@ -89,24 +89,20 @@ def mi_to_html(mi, field_list=None, default_author_link=None, use_roman_numbers=
             if val:
                 ctype = disp.get('interpret_as') or 'html'
                 val = force_unicode(val)
-                if ctype == 'short-text':
-                    ans.append((field, row % (name, p(val))))
+                if ctype == 'long-text':
+                    val = '<pre style="white-space:pre-wrap">%s</pre>' % p(val)
+                elif ctype == 'short-text':
+                    val = '<span>%s</span>' % p(val)
+                elif ctype == 'markdown':
+                    val = markdown(val)
                 else:
-                    if ctype == 'long-text':
-                        val = '<pre>%s</pre>' % p(val)
-                    elif ctype == 'markdown':
-                        val = markdown(val)
-                    else:
-                        val = comments_to_html(val)
-                    add_comment = True
-                    if disp.get('show_heading'):
-                        if disp.get('heading_on_side'):
-                            ans.append((field, row % (name, val)))
-                            add_comment = False
-                        else:
-                            val = '<h3 class="comments-heading">%s</h3>%s' % (p(name), val)
-                    if add_comment:
-                        comment_fields.append('<div id="%s" class="comments">%s</div>' % (field.replace('#', '_'), val))
+                    val = comments_to_html(val)
+                if disp.get('heading_position', 'hide') == 'side':
+                    ans.append((field, row % (name, val)))
+                else:
+                    if disp.get('heading_position', 'hide') == 'above':
+                        val = '<h3 class="comments-heading">%s</h3>%s' % (p(name), val)
+                    comment_fields.append('<div id="%s" class="comments">%s</div>' % (field.replace('#', '_'), val))
         elif metadata['datatype'] == 'rating':
             val = getattr(mi, field)
             if val:

--- a/src/calibre/srv/metadata.py
+++ b/src/calibre/srv/metadata.py
@@ -53,10 +53,10 @@ def add_field(field, db, book_id, ans, field_metadata):
                 ctype = field_metadata.get('display', {}).get('interpret_as', 'html')
                 if ctype == 'markdown':
                     val = markdown(val)
-                elif ctype == 'short-text':
-                    pass
                 elif ctype == 'long-text':
-                    val = '<pre>%s</pre>' % prepare_string_for_xml(val)
+                    val = '<pre style="white-space:pre-wrap">%s</pre>' % prepare_string_for_xml(val)
+                elif ctype == 'short-text':
+                    val = '<span">%s</span>' % prepare_string_for_xml(val)
                 else:
                     val = comments_to_html(val)
             elif datatype == 'composite' and field_metadata['display'].get('contains_html'):

--- a/src/pyj/book_list/book_details.pyj
+++ b/src/pyj/book_list/book_details.pyj
@@ -201,8 +201,8 @@ def render_metadata(mi, interface_data, table, field_list=None):
         datatype = fm.datatype
         val = mi[field]
         if field is 'comments' or datatype is 'comments':
-            if fm.display?.heading_on_side:
-                add_row(name, val, is_html=fm.display?.interpret_as is not 'short-text')
+            if fm.display?.heading_position is 'side':
+                add_row(name, val, is_html=True)
             else:
                 comments[field] = val
             return
@@ -256,7 +256,7 @@ def render_metadata(mi, interface_data, table, field_list=None):
         comment = comments[field]
         div = E.div()
         div.innerHTML = comment
-        if fm.display?.show_heading:
+        if fm.display?.heading_position is 'above':
             name = fm.name or field
             div.insertBefore(E.h3(name), div.firstChild or None)
         table.parentNode.appendChild(div)


### PR DESCRIPTION
- collapse the two booleans controlling the heading into one string
- allow short-text to appear on the right in book details
- make the new server and book details do (more-or-less) the same thing with headings
- use different CSS for short-text and long-text.

I changed the name of the show_heading property to heading_position to ensure the properties had no odd values, making it easier to test.

I did not change the old content server. It displays all comments as html.