### PR TITLE
Kobo decided the new firmware should be 4.0.

### DIFF
--- a/src/calibre/devices/kobo/driver.py
+++ b/src/calibre/devices/kobo/driver.py
@@ -67,7 +67,7 @@ class KOBO(USBMS):
 
     dbversion = 0
     fwversion = (0,0,0)
-    supported_dbversion = 128
+    supported_dbversion = 129
     has_kepubs = False
 
     supported_platforms = ['windows', 'osx', 'linux']
@@ -1309,7 +1309,7 @@ class KOBOTOUCH(KOBO):
         KOBO.author)
 #    icon        = I('devices/kobotouch.jpg')
 
-    supported_dbversion             = 128
+    supported_dbversion             = 129
     min_supported_dbversion         = 53
     min_dbversion_series            = 65
     min_dbversion_externalid        = 65
@@ -1321,7 +1321,7 @@ class KOBOTOUCH(KOBO):
     # Starting with firmware version 3.19.x, the last number appears to be is a
     # build number. A number will be recorded here but It can be safely ignored
     # when testing the firmware version.
-    max_supported_fwversion         = (3, 20, 7413)
+    max_supported_fwversion         = (4, 0, 7523)
     # The following document firwmare versions where new function or devices were added.
     # Not all are used, but this feels a good place to record it.
     min_fwversion_shelves           = (2, 0, 0)


### PR DESCRIPTION
I think the title says it all.