### PR TITLE
metadata: Do not raise an exception if a PDF file has empty metadata

### DIFF
--- a/src/calibre/ebooks/metadata/pdf.py
+++ b/src/calibre/ebooks/metadata/pdf.py
@@ -95,7 +95,7 @@ def get_metadata(stream, cover=True):
             raw = f.read().strip()
             if raw:
                 prints(raw)
-        if not info:
+        if info is None:
             raise ValueError('Could not read info dict from PDF')
         covpath = os.path.join(pdfpath, 'cover.jpg')
         cdata = None


### PR DESCRIPTION
Check explicitly for `info is None`, since an empty dict also evaluates to false. Otherwise it raises an exception when there is no metadata, and prevents from generating the cover.

This has started to happen recently with some arxiv PDF's, like this one: https://arxiv.org/pdf/1605.02391v2