### PR TITLE
Don't clear the user-defined function list until after the DB is …

### DIFF
--- a/src/calibre/db/backend.py
+++ b/src/calibre/db/backend.py
@@ -31,7 +31,8 @@ from calibre.utils.filenames import (
     WindowsAtomicFolderMove, atomic_rename, remove_dir_if_empty,
     copytree_using_links, copyfile_using_links)
 from calibre.utils.img import save_cover_data_to
-from calibre.utils.formatter_functions import load_user_template_functions
+from calibre.utils.formatter_functions import (load_user_template_functions,
+                                               unload_user_template_functions)
 from calibre.db.tables import (OneToOneTable, ManyToOneTable, ManyToManyTable,
         SizeTable, FormatsTable, AuthorsTable, IdentifiersTable, PathTable,
         CompositeTable, UUIDTable, RatingTable)
@@ -1032,6 +1033,10 @@ class DB(object):
         self.execute('UPDATE custom_columns SET mark_for_delete=1 WHERE id=?', (data['num'],))
 
     def close(self, force=False):
+        try:
+            unload_user_template_functions(self.library_id)
+        except:
+            pass
         if getattr(self, '_conn', None) is not None:
             self._conn.close(force)
             del self._conn

--- a/src/calibre/gui2/ui.py
+++ b/src/calibre/gui2/ui.py
@@ -634,9 +634,6 @@ class Main(MainWindow, MainWindowMixin, DeviceMixin, EmailMixin,  # {{{
             olddb = self.library_view.model().db
             if copy_structure:
                 default_prefs = olddb.prefs
-
-            from calibre.utils.formatter_functions import unload_user_template_functions
-            unload_user_template_functions(olddb.library_id)
         except:
             olddb = None
         try:
@@ -688,6 +685,8 @@ class Main(MainWindow, MainWindowMixin, DeviceMixin, EmailMixin,  # {{{
             try:
                 if call_close:
                     olddb.close()
+                from calibre.utils.formatter_functions import unload_user_template_functions
+                unload_user_template_functions(olddb.library_id)
             except:
                 import traceback
                 traceback.print_exc()

--- a/src/calibre/gui2/ui.py
+++ b/src/calibre/gui2/ui.py
@@ -685,8 +685,6 @@ class Main(MainWindow, MainWindowMixin, DeviceMixin, EmailMixin,  # {{{
             try:
                 if call_close:
                     olddb.close()
-                from calibre.utils.formatter_functions import unload_user_template_functions
-                unload_user_template_functions(olddb.library_id)
             except:
                 import traceback
                 traceback.print_exc()


### PR DESCRIPTION
…actually closed. This order prevents problems in plugins that run just before closing the db, e.g., library closed plugins.

It is possible that a better fix is to move the two lines of code into db.cache.close(). I looked for unwanted side effects and didn't see any, but I didnt want to make the more invasive change.