### PR TITLE
When in debug mode, print the lookup name of the column with a …

### DIFF
--- a/src/calibre/utils/formatter.py
+++ b/src/calibre/utils/formatter.py
@@ -525,6 +525,8 @@ class TemplateFormatter(string.Formatter):
         except Exception as e:
             if DEBUG:  # and getattr(e, 'is_locking_error', False):
                 traceback.print_exc()
+                if column_name:
+                    print('Error evaluating column named: %s' % column_name)
             ans = error_value + ' ' + e.message
         return ans
 


### PR DESCRIPTION
…template that is throwing an exception.