### PR TITLE
Instapaper recipe:  remove hidden "speedRead" div to fix SplitError

### DIFF
--- a/recipes/instapaper.recipe
+++ b/recipes/instapaper.recipe
@@ -30,6 +30,7 @@ class AdvancedUserRecipe1299694372(BasicNewsRecipe):
         dict(name='div', attrs={'class': 'evernote_confirm'}),
         dict(name='div', attrs={'id': 'controlbar_container'}),
         dict(name='div', attrs={'id': 'footer'}),
+        dict(name='div', attrs={'id': 'speedRead'}),
         dict(name='label')
     ]
     use_embedded_content = False


### PR DESCRIPTION
(Also discussed in [this forum thread](http://www.mobileread.com/forums/showthread.php?t=279130)...)

I recently experienced errors using the Instapaper recipe with some longer articles, and traced it down to this error:

```
SplitError: Could not find reasonable point at which to split: feed_0/article_9/index_u33.html Sub-tree size: 606 KB
http://www.w3.org/1999/xhtml}h3 /*/*[2]/*[4]/*/*[2]/*[6]/*[19]
```
I looked at the processed HTML of one of the articles, and found a huge section of hidden HTML in a `<div id='speedRead'>` element which replicated the text of the article with each word wrapped in individual `<span>` elements. I tried adding the "speedRead" div to the `remove_tags` attribute of the recipe, and that solved the problem.

Thanks!