### PR TITLE
Stop cover metadata merge from dying on invalid img URLs

### DIFF
--- a/src/calibre/ebooks/oeb/transforms/metadata.py
+++ b/src/calibre/ebooks/oeb/transforms/metadata.py
@@ -175,8 +175,15 @@ class MergeMetadata(object):
                 images = []
             removed = False
             for img in images:
-                href = item.abshref(img.get('src'))
-                if href == cover_item.href:
+                try:
+                    href = item.abshref(img.get('src'))
+                except:
+                    # Invalid URLs can make abshref throw an exception, most-
+                    # commonly if they look sort of like an IPv6 URL.
+                    href = False
+                    self.oeb.log.exception(
+                        'Skipping invalid href: %r'%img.get('src'))
+                if not href or href == cover_item.href:
                     img.getparent().remove(img)
                     removed = True
             if removed:


### PR DESCRIPTION
If an ebook contains a bad img tag, whose src looks enough like an IPv6 URL to
trip that codepath, but which isn't actually an IPv6 URL, it'll throw a
ValueError.

Fixes launchpad 1628969.