### PR TITLE
lwn_weekly: Prevents fail if article title is not defined.

### DIFF
--- a/recipes/lwn_weekly.recipe
+++ b/recipes/lwn_weekly.recipe
@@ -104,6 +104,8 @@ class WeeklyLWN(BasicNewsRecipe):
 
             elif 'SummaryHL' in curr.attrMap['class']:
                 article_title = text
+                if not article_title:
+                    article_title = _('Undefined article title')
 
                 if subsection:
                     section_title = "%s: %s" % (section, subsection)


### PR DESCRIPTION
More resilient behavior if article title contains non-html-encoded
characters. E.g. "<Programming>" string in the title start is recognized
by beatiful soup as html tag, but it is not, making the title a
NoneType, and raising an exception on Article creation.

This is actually a bug in the news page itself, but it anyways breaks
the recipe; hence, adding here a fixed string if for any reason the
article title end up with a NoneType.