### PR TITLE
Kepubs should follow epub rules for covers and ToC

### DIFF
--- a/src/calibre/ebooks/conversion/plumber.py
+++ b/src/calibre/ebooks/conversion/plumber.py
@@ -1111,7 +1111,7 @@ OptionRecommendation(name='search_replace',
         pr(0.35)
         self.flush()
 
-        if self.output_plugin.file_type != 'epub':
+        if self.output_plugin.file_type not in ('epub', 'kepub'):
             # Remove the toc reference to the html cover, if any, except for
             # epub, as the epub output plugin will do the right thing with it.
             item = getattr(self.oeb.toc, 'item_that_refers_to_cover', None)


### PR DESCRIPTION
From
http://www.mobileread.com/forums/showthread.php?p=3421577#post3421577, when an epub is converted to kepub, if the ToC had an entry pointing to the cover, it is removed. This does not happen when doing an epub-to-epub conversion. Found that the Plumber was treating epubs specially for this, so added kepub as another exception.