### PR TITLE
Fix typo for `upto` => `up to` globally

### DIFF
--- a/setup/installer/windows/en-us.xml
+++ b/setup/installer/windows/en-us.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" xmlns="http://schemas.microsoft.com/wix/2006/localization">
     <String Id="AdvancedWelcomeEulaDlgDescriptionPerUser">Click Advanced to change installation settings.</String>
-    <String Id="ProgressTextFileCost">Computing space requirements, this may take upto five minutes...</String>
-    <String Id="ProgressTextCostInitialize">Computing space requirements, this may take upto five minutes...</String>
-    <String Id="ProgressTextCostFinalize">Computing space requirements, this may take upto five minutes...</String>
-    <String Id="WaitForCostingDlgText">Please wait while the installer finishes determining your disk space requirements, this may take upto five minutes...</String>
+    <String Id="ProgressTextFileCost">Computing space requirements, this may take up to five minutes...</String>
+    <String Id="ProgressTextCostInitialize">Computing space requirements, this may take up to five minutes...</String>
+    <String Id="ProgressTextCostFinalize">Computing space requirements, this may take up to five minutes...</String>
+    <String Id="WaitForCostingDlgText">Please wait while the installer finishes determining your disk space requirements, this may take up to five minutes...</String>
 </WixLocalization>
 

--- a/src/calibre/ebooks/oeb/polish/parsing.py
+++ b/src/calibre/ebooks/oeb/polish/parsing.py
@@ -369,7 +369,7 @@ class TreeBuilder(BaseTreeBuilder):
         self.promote_elem(elem, token_name)
         position = token.get('position', None)
         if position is not None:
-            # Unfortunately, libxml2 can only store line numbers upto 65535
+            # Unfortunately, libxml2 can only store line numbers up to 65535
             # (unsigned short). If you really need to workaround this, use the
             # patch here:
             # https://bug325533.bugzilla-attachments.gnome.org/attachment.cgi?id=56951

--- a/src/calibre/ebooks/oeb/polish/utils.py
+++ b/src/calibre/ebooks/oeb/polish/utils.py
@@ -137,7 +137,7 @@ def link_stylesheets(container, names, sheets, remove=False, mtype='text/css'):
 
 def lead_text(top_elem, num_words=10):
     ''' Return the leading text contained in top_elem (including descendants)
-    upto a maximum of num_words words. More efficient than using
+    up to a maximum of num_words words. More efficient than using
     etree.tostring(method='text') as it does not have to serialize the entire
     sub-tree rooted at top_elem.'''
     pat = re.compile(r'\s+', flags=re.UNICODE)

--- a/src/calibre/gui2/actions/device.py
+++ b/src/calibre/gui2/actions/device.py
@@ -221,7 +221,7 @@ class ConnectShareAction(InterfaceAction):
         else:
             self.gui.content_server.threaded_exit()
             self.stopping_msg = info_dialog(self.gui, _('Stopping'),
-                    _('Stopping server, this could take upto a minute, please wait...'),
+                    _('Stopping server, this could take up to a minute, please wait...'),
                     show_copy_button=False)
             QTimer.singleShot(1000, self.check_exited)
             self.stopping_msg.exec_()

--- a/src/calibre/gui2/preferences/server.py
+++ b/src/calibre/gui2/preferences/server.py
@@ -83,7 +83,7 @@ class ConfigWidget(ConfigWidgetBase, Ui_Form):
     def stop_server(self):
         self.gui.content_server.threaded_exit()
         self.stopping_msg = info_dialog(self, _('Stopping'),
-                _('Stopping server, this could take upto a minute, please wait...'),
+                _('Stopping server, this could take up to a minute, please wait...'),
                 show_copy_button=False)
         QTimer.singleShot(500, self.check_exited)
         self.stopping_msg.exec_()

--- a/src/calibre/gui2/tweak_book/diff/_patiencediff_c.c
+++ b/src/calibre/gui2/tweak_book/diff/_patiencediff_c.c
@@ -1000,7 +1000,7 @@ error:
 static char PatienceSequenceMatcher_get_grouped_opcodes_doc[] =
     "Isolate change clusters by eliminating ranges with no changes.\n"
     "\n"
-    "Return a list of groups with upto n lines of context.\n"
+    "Return a list of groups with up to n lines of context.\n"
     "Each group is in the same format as returned by get_opcodes().\n"
     "\n"
     ">>> from pprint import pprint\n"

--- a/src/calibre/gui2/tweak_book/editor/smarts/html.py
+++ b/src/calibre/gui2/tweak_book/editor/smarts/html.py
@@ -436,7 +436,7 @@ class Smarts(NullSmarts):
 
     def cursor_position_with_sourceline(self, cursor, for_position_sync=True, use_matched_tag=True):
         ''' Return the tag just before the current cursor as a source line
-        number and a list of tags defined on that line upto and including the
+        number and a list of tags defined on that line up to and including the
         containing tag. If ``for_position_sync`` is False then the tag
         *containing* the cursor is returned instead of the tag just before the
         cursor. Note that finding the containing tag is expensive, so

--- a/src/calibre/gui2/tweak_book/editor/syntax/html.py
+++ b/src/calibre/gui2/tweak_book/editor/syntax/html.py
@@ -195,7 +195,7 @@ def close_tag(state, name):
             break
     else:
         return  # No matching open tag found, ignore the closing tag
-    # Remove all tags upto the matching open tag
+    # Remove all tags up to the matching open tag
     state.tags = state.tags[:-len(removed_tags)]
     state.sub_parser_state = None
     # Check if we should still be bold or italic

--- a/src/calibre/srv/loop.py
+++ b/src/calibre/srv/loop.py
@@ -87,7 +87,7 @@ class ReadBuffer(object):  # {{{
         return num
 
     def readline(self):
-        # Return whatever is in the buffer upto (and including) the first \n
+        # Return whatever is in the buffer up to (and including) the first \n
         # If no \n is present, returns everything
         if self.read_pos == self.write_pos and self.full_state is WRITE:
             return b''

--- a/src/calibre/utils/filenames.py
+++ b/src/calibre/utils/filenames.py
@@ -246,7 +246,7 @@ def samefile(src, dst):
 
     Returns True iff both paths exist and point to the same file on disk.
 
-    Note: On windows will return True if the two string are identical (upto
+    Note: On windows will return True if the two string are identical (up to
     case) even if the file does not exist. This is because I have no way of
     knowing how reliable the GetFileInformationByHandle method is.
     '''


### PR DESCRIPTION
I noticed the content server pop-up modal saying it "could take upto a minute" so I fixed the typo. While I was in there, I just found/replaced it globally.