### PR TITLE
missing Canada option for amazon download plugin

### DIFF
--- a/src/calibre/ebooks/metadata/sources/amazon.py
+++ b/src/calibre/ebooks/metadata/sources/amazon.py
@@ -800,6 +800,7 @@ class Amazon(Source):
             'br': _('Brazil'),
             'nl': _('Netherlands'),
             'cn': _('China'),
+            'ca': _('Canada'),
     }
 
     options = (


### PR DESCRIPTION
From what I saw of the rest of the code, amazon_ca is all good and ready to go, it's only missing this option in the UI. 
http://i.imgur.com/GKqtDLp.png