### PR TITLE
Amazon.CA amended with tests

### DIFF
--- a/src/calibre/ebooks/metadata/sources/amazon.py
+++ b/src/calibre/ebooks/metadata/sources/amazon.py
@@ -800,6 +800,7 @@ class Amazon(Source):
             'br': _('Brazil'),
             'nl': _('Netherlands'),
             'cn': _('China'),
+            'ca': _('Canada'),
     }
 
     options = (
@@ -1408,6 +1409,23 @@ if __name__ == '__main__':  # tests {{{
             ),
     ]  # }}}
 
+    ca_tests = [  # {{{
+             (   # Paperback with series
+                {'identifiers':{'isbn':'9781623808747'}},
+                [title_test('Parting Shot', exact=True), authors_test(['Mary Calmes'])]
+            ),
+            (  # # in title
+                {'title':'Expert C# 2008 Business Objects',
+                    'authors':['Lhotka']},
+                [title_test('Expert C# 2008 Business Objects'), authors_test(['Rockford Lhotka'])]
+            ),
+            (  # noscript description
+                {'identifiers':{'amazon_ca':'162380874X'}},
+                [title_test('Parting Shot', exact=True), authors_test(['Mary Calmes'])
+                ]
+            ),
+    ]  # }}}
+
     def do_test(domain, start=0, stop=None):
         tests = globals().get(domain+'_tests')
         if stop is None:
@@ -1416,8 +1434,8 @@ if __name__ == '__main__':  # tests {{{
         test_identify_plugin(Amazon.name, tests, modify_plugin=lambda
                 p:(setattr(p, 'testing_domain', domain), setattr(p, 'touched_fields', p.touched_fields - {'tags'})))
 
-    do_test('com')
-
+    #do_test('com')
+    do_test('ca')
     # do_test('de')
 
 # }}}


### PR DESCRIPTION
- tests were sucessful
- series_test will fail beccause that information is not available on amazon.ca
- i did not see any region specific code in parse_series and that leads me to beleive that lack of series information is handled elsewhere
- sidenote: my first attempt at squashing my commit history, I hope this doesn't turn out to be a mess on your side