### PR TITLE
Adapt to html5lib 0.99999999/1.0b9

### DIFF
--- a/src/calibre/ebooks/oeb/polish/parsing.py
+++ b/src/calibre/ebooks/oeb/polish/parsing.py
@@ -13,8 +13,14 @@ from bisect import bisect
 from lxml.etree import ElementBase, XMLParser, ElementDefaultClassLookup, CommentBase, fromstring, Element as LxmlElement
 
 from html5lib.constants import namespaces, tableInsertModeElements, EOF
-from html5lib.treebuilders._base import TreeBuilder as BaseTreeBuilder
-from html5lib.ihatexml import InfosetFilter, DataLossWarning
+try:
+    from html5lib.treebuilders.base import TreeBuilder as BaseTreeBuilder
+except:
+    from html5lib.treebuilders._base import TreeBuilder as BaseTreeBuilder
+try:
+    from html5lib._ihatexml import InfosetFilter, DataLossWarning
+except:
+    from html5lib.ihatexml import InfosetFilter, DataLossWarning
 from html5lib.html5parser import HTMLParser
 
 from calibre import xml_replace_entities


### PR DESCRIPTION
When updating html5lib in [pkgsrc](http://cdn.netbsd.org/pub/pkgsrc/current/pkgsrc/misc/calibre/) recently, we observed the calibre build being broken due to changes in the former's module naming:

* moved treebuilders._base to .base to clarify its status as public, and
* moved and ihatexml to _ihatexml to clarify its status as private.

Since there's no (version) dependency recorded in setup.py, I added a local patch to deal with these gracefully using the try: new/except: old pattern.