### PR TITLE
remove 'masthead-social' tag

### DIFF
--- a/recipes/nytimes.recipe
+++ b/recipes/nytimes.recipe
@@ -277,6 +277,7 @@ class NYTimes(BasicNewsRecipe):
             'login',
             'masthead',
             'masthead-nav',
+            'masthead-social',
             'memberTools',
             'navigation', 'navigation-ghost', 'navigation-modal', 'navigation-edge',
             'page-footer',


### PR DESCRIPTION
this shows up on blogs like "The Upshot". See the source of https://www.nytimes.com/2017/02/01/upshot/strife-over-immigrants-can-california-foretell-nations-future.html?ref=todayspaper. Without the fix "The Upshot" always has "Follow Us" and then three blank bullet points at the top then "Get the Upshot in your Inbox".