### PR TITLE
Add Message-Id header to outgoing emails.

### DIFF
--- a/src/calibre/utils/smtp.py
+++ b/src/calibre/utils/smtp.py
@@ -18,16 +18,23 @@ def create_mail(from_, to, subject, text=None, attachment_data=None,
     assert text or attachment_data
 
     from email.mime.multipart import MIMEMultipart
-    from email.utils import formatdate, make_msgid
+    from email.utils import formatdate
     from email import encoders
+    import uuid
 
     outer = MIMEMultipart()
     outer['Subject'] = subject
     outer['To'] = to
     outer['From'] = from_
     outer['Date'] = formatdate(localtime=True)
-    outer['Message-Id'] = make_msgid()
     outer.preamble = 'You will not see this in a MIME-aware mail reader.\n'
+
+    # generate a Message-Id for this email
+    msgid_domain = from_.partition("@")[2]
+    if not msgid_domain:
+        # from address didn't provide a domain, let's make a best guess
+        msgid_domain = safe_localhost()
+    outer['Message-Id'] = "<{0}@{1}>".format(uuid.uuid4(), msgid_domain)
 
     if text is not None:
         from email.mime.text import MIMEText

--- a/src/calibre/utils/smtp.py
+++ b/src/calibre/utils/smtp.py
@@ -18,7 +18,7 @@ def create_mail(from_, to, subject, text=None, attachment_data=None,
     assert text or attachment_data
 
     from email.mime.multipart import MIMEMultipart
-    from email.utils import formatdate
+    from email.utils import formatdate, make_msgid
     from email import encoders
 
     outer = MIMEMultipart()
@@ -26,6 +26,7 @@ def create_mail(from_, to, subject, text=None, attachment_data=None,
     outer['To'] = to
     outer['From'] = from_
     outer['Date'] = formatdate(localtime=True)
+    outer['Message-Id'] = make_msgid()
     outer.preamble = 'You will not see this in a MIME-aware mail reader.\n'
 
     if text is not None:

--- a/src/calibre/utils/smtp.py
+++ b/src/calibre/utils/smtp.py
@@ -18,7 +18,7 @@ def create_mail(from_, to, subject, text=None, attachment_data=None,
     assert text or attachment_data
 
     from email.mime.multipart import MIMEMultipart
-    from email.utils import formatdate
+    from email.utils import formatdate, parseaddr
     from email import encoders
     import uuid
 
@@ -30,7 +30,12 @@ def create_mail(from_, to, subject, text=None, attachment_data=None,
     outer.preamble = 'You will not see this in a MIME-aware mail reader.\n'
 
     # generate a Message-Id for this email
-    msgid_domain = from_.partition("@")[2]
+    # Parse out the address from the From line, and then the domain from that
+    from_email = parseaddr(from_)[1]
+    msgid_domain = from_email.partition("@")[2].strip()
+    if msgid_domain.endswith(">"):
+        # This can sometimes sneak through parseaddr if the input is malformed
+        msgid_domain = msgid_domain[:-1]
     if not msgid_domain:
         # from address didn't provide a domain, let's make a best guess
         msgid_domain = safe_localhost()


### PR DESCRIPTION
Some MTAs/spam filters/etc seem more likely to treat an email as spam if it has no Message ID. 

This patch should hopefully make it less likely for an email to be dropped .