### PR TITLE
Use QSystemTrayIcon as a fallback

### DIFF
--- a/src/calibre/gui2/dbus_export/widgets.py
+++ b/src/calibre/gui2/dbus_export/widgets.py
@@ -238,8 +238,7 @@ class Factory(QObject):
             self.prune_dead_refs()
             self.status_notifiers.append(weakref.ref(ans))
             return ans
-        if iswindows or isosx:
-            return QSystemTrayIcon(parent)
+        return QSystemTrayIcon(parent)
 
     def bus_disconnected(self):
         self._bus = None


### PR DESCRIPTION
If one is using Linux and StatusNotifier spec is not available, use
QSystemTrayIcon as a fallback.