### PR TITLE
fetch-ebook-metadata: add option to use only a single metadata plugin

### DIFF
--- a/src/calibre/ebooks/metadata/sources/cli.py
+++ b/src/calibre/ebooks/metadata/sources/cli.py
@@ -40,6 +40,8 @@ of title, authors or ISBN.
             help=_('Specify a filename. The cover, if available, will be saved to it. Without this option, no cover will be downloaded.'))
     parser.add_option('-d', '--timeout', default='30',
             help=_('Timeout in seconds. Default is 30'))
+    parser.add_option('-p', '--plugin',
+            help=_('Specify a metadata plugin. By default, all enabled metadata plugins will be used.'))
 
     return parser
 
@@ -62,7 +64,8 @@ def main(args=sys.argv):
         identifiers['isbn'] = opts.isbn
 
     results = identify(log, abort, title=opts.title, authors=authors,
-            identifiers=identifiers, timeout=int(opts.timeout))
+            identifiers=identifiers, timeout=int(opts.timeout),
+            plugin=opts.plugin)
 
     if not results:
         print (log, file=sys.stderr)

--- a/src/calibre/ebooks/metadata/sources/identify.py
+++ b/src/calibre/ebooks/metadata/sources/identify.py
@@ -369,13 +369,15 @@ def merge_identify_results(result_map, log):
 
 
 def identify(log, abort,  # {{{
-        title=None, authors=None, identifiers={}, timeout=30):
+        title=None, authors=None, identifiers={}, timeout=30, plugin=None):
     if title == _('Unknown'):
         title = None
     if authors == [_('Unknown')]:
         authors = None
     start_time = time.time()
-    plugins = [p for p in metadata_plugins(['identify']) if p.is_configured()]
+
+    plugins = [p for p in metadata_plugins(['identify'])
+        if p.is_configured() and (plugin == None or p.name == plugin)]
 
     kwargs = {
         'title': title,


### PR DESCRIPTION
This is very useful for shell scripts that need to compare metadata from different sources or when we have hardcoded preferences (ex. prefer Goodreads to Amazon to Google, etc.)