### PR TITLE
Fix bounds error in lzxd_static_init

### DIFF
--- a/src/calibre/utils/lzx/lzxd.c
+++ b/src/calibre/utils/lzx/lzxd.c
@@ -357,11 +357,12 @@ static unsigned char extra_bits[51];
 static void lzxd_static_init(void) {
   int i, j;
 
-  for (i = 0, j = 0; i < 51; i += 2) {
+  for (i = 0, j = 0; i < 50; i += 2) {
     extra_bits[i]   = j; /* 0,0,0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7... */
     extra_bits[i+1] = j;
     if ((i != 0) && (j < 17)) j++; /* 0,0,1,2,3,4...15,16,17,17,17,17... */
   }
+  extra_bits[50] = 17;
 
   for (i = 0, j = 0; i < 51; i++) {
     position_base[i] = j; /* 0,1,2,3,4,6,8,12,16,24,32,... */


### PR DESCRIPTION
This includes the changes from the following upstream commits:

https://github.com/kyz/libmspack/commit/6a42ddd1d472afeaf0f7da91e16b60ab2063fb92
https://github.com/kyz/libmspack/commit/ce3cc03aa500dd9c0b6b820f9519f6b6b9dede05