### PR TITLE
Replacing link to outdated Bitbucket repo with the current one

### DIFF
--- a/recipes/instapaper.recipe
+++ b/recipes/instapaper.recipe
@@ -1,7 +1,7 @@
 # Calibre recipe for Instapaper.com (Stable version)
 #
 # Homepage: http://khromov.wordpress.com/projects/instapaper-calibre-recipe/
-# Code Repository: https://bitbucket.org/khromov/calibre-instapaper
+# Source: https://github.com/kovidgoyal/calibre/blob/master/recipes/instapaper.recipe
 
 from calibre.web.feeds.news import BasicNewsRecipe
 


### PR DESCRIPTION
Perhaps there's is a new blog post about the recipe and the line with ["Homepage" entry](https://github.com/kovidgoyal/calibre/blob/master/recipes/instapaper.recipe#L3) should be changed as well.  
It can be left as it is for historical reasons though.