### PR TITLE
Store and access user template functions on a per-library basis. This…

### DIFF
--- a/resources/default_tweaks.py
+++ b/resources/default_tweaks.py
@@ -483,16 +483,6 @@ gui_view_history_size = 15
 # negative number to increase or decrease the font size.
 change_book_details_font_size_by = 0
 
-#: Compile general program mode templates to Python
-# Compiled general program mode templates are significantly faster than
-# interpreted templates. Setting this tweak to True causes calibre to compile
-# (in most cases) general program mode templates. Setting it to False causes
-# calibre to use the old behavior -- interpreting the templates. Set the tweak
-# to False if some compiled templates produce incorrect values.
-# Default:    compile_gpm_templates = True
-# No compile: compile_gpm_templates = False
-compile_gpm_templates = True
-
 #: What format to default to when using the "Unpack book" feature
 # The "Unpack book" feature of calibre allows direct editing of a book format.
 # If multiple formats are available, calibre will offer you a choice

--- a/src/calibre/db/cache.py
+++ b/src/calibre/db/cache.py
@@ -204,6 +204,10 @@ class Cache(object):
         self.formatter_template_cache = {}
 
     @write_api
+    def set_user_template_functions(self, user_template_functions):
+        self.backend.set_user_template_functions(user_template_functions)
+
+    @write_api
     def clear_composite_caches(self, book_ids=None):
         for field in self.composites.itervalues():
             field.clear_caches(book_ids=book_ids)
@@ -351,12 +355,14 @@ class Cache(object):
             bools_are_tristate = self.backend.prefs['bools_are_tristate']
 
             for field, table in self.backend.tables.iteritems():
-                self.fields[field] = create_field(field, table, bools_are_tristate)
+                self.fields[field] = create_field(field, table, bools_are_tristate,
+                                          self.backend.get_user_template_functions)
                 if table.metadata['datatype'] == 'composite':
                     self.composites[field] = self.fields[field]
 
             self.fields['ondevice'] = create_field('ondevice',
-                    VirtualTable('ondevice'), bools_are_tristate)
+                    VirtualTable('ondevice'), bools_are_tristate,
+                    self.backend.get_user_template_functions)
 
             for name, field in self.fields.iteritems():
                 if name[0] == '#' and name.endswith('_index'):

--- a/src/calibre/db/fields.py
+++ b/src/calibre/db/fields.py
@@ -41,7 +41,7 @@ class Field(object):
     is_many_many = False
     is_composite = False
 
-    def __init__(self, name, table, bools_are_tristate):
+    def __init__(self, name, table, bools_are_tristate, get_user_formatter_functions):
         self.name, self.table = name, table
         dt = self.metadata['datatype']
         self.has_text_data = dt in {'text', 'comments', 'series', 'enumeration'}
@@ -88,6 +88,7 @@ class Field(object):
             self.category_formatter = calibre_langcode_to_name
         self.writer = Writer(self)
         self.series_field = None
+        self.get_user_formatter_functions = get_user_formatter_functions
 
     @property
     def metadata(self):
@@ -203,8 +204,8 @@ class CompositeField(OneToOneField):
     is_composite = True
     SIZE_SUFFIX_MAP = {suffix:i for i, suffix in enumerate(('', 'K', 'M', 'G', 'T', 'P', 'E'))}
 
-    def __init__(self, name, table, bools_are_tristate):
-        OneToOneField.__init__(self, name, table, bools_are_tristate)
+    def __init__(self, name, table, bools_are_tristate, get_user_formatter_functions):
+        OneToOneField.__init__(self, name, table, bools_are_tristate, get_user_formatter_functions)
 
         self._render_cache = {}
         self._lock = Lock()
@@ -264,7 +265,8 @@ class CompositeField(OneToOneField):
         ' INTERNAL USE ONLY. DO NOT USE THIS OUTSIDE THIS CLASS! '
         ans = formatter.safe_format(
             self.metadata['display']['composite_template'], mi, _('TEMPLATE ERROR'),
-            mi, column_name=self._composite_name, template_cache=template_cache).strip()
+            mi, column_name=self._composite_name, template_cache=template_cache,
+            user_functions=self.get_user_formatter_functions()).strip()
         with self._lock:
             self._render_cache[book_id] = ans
         return ans
@@ -347,7 +349,7 @@ class CompositeField(OneToOneField):
 
 class OnDeviceField(OneToOneField):
 
-    def __init__(self, name, table, bools_are_tristate):
+    def __init__(self, name, table, bools_are_tristate, get_user_formatter_functions):
         self.name = name
         self.book_on_device_func = None
         self.is_multiple = False
@@ -733,7 +735,7 @@ class TagsField(ManyToManyField):
         return ans
 
 
-def create_field(name, table, bools_are_tristate):
+def create_field(name, table, bools_are_tristate, get_user_formatter_functions):
     cls = {
             ONE_ONE: OneToOneField,
             MANY_ONE: ManyToOneField,
@@ -753,5 +755,5 @@ def create_field(name, table, bools_are_tristate):
         cls = CompositeField
     elif table.metadata['datatype'] == 'series':
         cls = SeriesField
-    return cls(name, table, bools_are_tristate)
+    return cls(name, table, bools_are_tristate, get_user_formatter_functions)
 

--- a/src/calibre/gui2/preferences/template_functions.py
+++ b/src/calibre/gui2/preferences/template_functions.py
@@ -14,7 +14,8 @@ from calibre.gui2.preferences import ConfigWidgetBase, test_widget
 from calibre.gui2.preferences.template_functions_ui import Ui_Form
 from calibre.gui2.widgets import PythonHighlighter
 from calibre.utils.formatter_functions import (formatter_functions,
-                        compile_user_function, load_user_template_functions)
+                        compile_user_function, compile_user_template_functions,
+                        load_user_template_functions)
 
 
 class ConfigWidget(ConfigWidgetBase, Ui_Form):
@@ -225,7 +226,10 @@ class ConfigWidget(ConfigWidgetBase, Ui_Form):
             if name not in self.builtins:
                 pref_value.append((cls.name, cls.doc, cls.arg_count, cls.program_text))
         self.db.new_api.set_pref('user_template_functions', pref_value)
-        load_user_template_functions(self.db.library_id, pref_value)
+        funcs = compile_user_template_functions(pref_value)
+        self.db.new_api.set_user_template_functions(funcs)
+        self.gui.library_view.model().refresh()
+        load_user_template_functions(self.db.library_id, [], funcs)
         return False
 
 

--- a/src/calibre/utils/formatter_functions.py
+++ b/src/calibre/utils/formatter_functions.py
@@ -1622,11 +1622,8 @@ class UserFunction(FormatterUserFunction):
     cls = locals_['UserFunction'](name, doc, arg_count, eval_func)
     return cls
 
-
-def load_user_template_functions(library_uuid, funcs):
-    unload_user_template_functions(library_uuid)
-
-    compiled_funcs = []
+def compile_user_template_functions(funcs):
+    compiled_funcs = {}
     for func in funcs:
         try:
             # Force a name conflict to test the logic
@@ -1637,11 +1634,19 @@ def load_user_template_functions(library_uuid, funcs):
             # source. This helps ensure that if the function already is defined
             # then white space differences don't cause them to compare differently
 
-            compiled_funcs.append(compile_user_function(*func))
+            cls = compile_user_function(*func)
+            compiled_funcs[cls.name] = cls
         except:
             traceback.print_exc()
-    formatter_functions().register_functions(library_uuid, compiled_funcs)
+    return compiled_funcs
 
+def load_user_template_functions(library_uuid, funcs, precompiled_user_functions=None):
+    unload_user_template_functions(library_uuid)
+    if precompiled_user_functions:
+        compiled_funcs = precompiled_user_functions
+    else:
+        compiled_funcs = compile_user_template_functions(funcs)
+    formatter_functions().register_functions(library_uuid, compiled_funcs.values())
 
 def unload_user_template_functions(library_uuid):
     formatter_functions().unregister_functions(library_uuid)


### PR DESCRIPTION
… is used when the DB evaluates composites, avoiding using the global copy.

The ability to pre-compile templates was removed because the one-true list of available functions is known only at execution time. The compiled copy depended on the global state being accurate. And in any event, I was never totally convinced that the compiled version was significantly faster than the pre-lexed version.

Includes a bug fix: the booklist must be refreshed if a user-defined function changed.