### PR TITLE
Fix collections not displaying in device list for KoboTouch driver

### DIFF
--- a/src/calibre/devices/kobo/driver.py
+++ b/src/calibre/devices/kobo/driver.py
@@ -3052,7 +3052,12 @@ class KOBOTOUCH(KOBO):
 
     @property
     def collections_columns(self):
-        return self.get_pref('collections_columns')
+        return self.get_pref('collections_columns') if self.manage_collections else ''
+
+    def get_collections_attributes(self):
+        collections_str = self.collections_columns
+        collections = [x.lower().strip() for x in collections_str.split(',')] if collections_str else []
+        return collections
 
     @property
     def delete_empty_collections(self):

--- a/src/calibre/ebooks/metadata/book/__init__.py
+++ b/src/calibre/ebooks/metadata/book/__init__.py
@@ -113,7 +113,7 @@ SC_FIELDS_NOT_COPIED =     frozenset(['title', 'title_sort', 'authors',
                                       'identifiers'])
 
 # Metadata fields that smart update should copy only if the source is not None
-SC_FIELDS_COPY_NOT_NULL =  frozenset(['lpath', 'size', 'comments', 'thumbnail'])
+SC_FIELDS_COPY_NOT_NULL =  frozenset(['device_collections', 'lpath', 'size', 'comments', 'thumbnail'])
 
 # Metadata fields that smart update should copy without special handling
 SC_COPYABLE_FIELDS =       SOCIAL_METADATA_FIELDS.union(


### PR DESCRIPTION
Collections were not being shown in the device list if either the collection management was off in the driver, or no collections column were configured. There were two reasons, one was the empty configuration
string was handled incorrectly. The other was the device_collections attribute could be cleared by the smart_update of the metadata.