### PR TITLE
Fix #1694757: calibre fails to start if the tweak …

### DIFF
--- a/src/calibre/gui2/tag_browser/model.py
+++ b/src/calibre/gui2/tag_browser/model.py
@@ -994,7 +994,13 @@ class TagsModel(QAbstractItemModel):  # {{{
                 self.categories[category] = tb_categories[category]['name']
 
         # Now build the list of fields in display order
-        order = tweaks['tag_browser_category_order']
+        try:
+            order = tweaks['tag_browser_category_order']
+            if not isinstance(order, dict):
+                raise TypeError()
+        except:
+            print ('Tweak tag_browser_category_order is not valid. Ignored')
+            order = {'*': 100}
         defvalue = order.get('*', 100)
         self.row_map = sorted(self.categories, key=lambda x: order.get(x, defvalue))
         return data


### PR DESCRIPTION
…tag_browser_category_order is malformed.