### PR TITLE
Adds somewhat graceful handling for Ebook split errors.

### DIFF
--- a/src/calibre/ebooks/conversion/plugins/epub_output.py
+++ b/src/calibre/ebooks/conversion/plugins/epub_output.py
@@ -191,11 +191,15 @@ class EPUBOutput(OutputFormatPlugin):
         from calibre.ebooks.oeb.transforms.rescale import RescaleImages
         RescaleImages(check_colorspaces=True)(oeb, opts)
 
-        from calibre.ebooks.oeb.transforms.split import Split
+        from calibre.ebooks.oeb.transforms.split import (Split, SplitError)
         split = Split(not self.opts.dont_split_on_page_breaks,
                 max_flow_size=self.opts.flow_size*1024
                 )
-        split(self.oeb, self.opts)
+        try:
+            split(self.oeb, self.opts)
+        except SplitError as error:
+            self.log.error(str(error))
+            pass
 
         from calibre.ebooks.oeb.transforms.cover import CoverManager
         cm = CoverManager(


### PR DESCRIPTION
It is difficult to reproduce exactly, but some feeds that I have used
will cause a SplitError.  This will occur no matter which preferences
are changed, such as split point, disabling split in the UI, etc.

So, this acts as a last resort to prevent the split error from halting
all processing of the ebook.