### PR TITLE
Process conversion options

### DIFF
--- a/src/calibre/web/feeds/recipes/collection.py
+++ b/src/calibre/web/feeds/recipes/collection.py
@@ -50,14 +50,18 @@ def serialize_recipe(urn, recipe_class):
         ns = 'no'
     if ns is True:
         ns = 'yes'
-    return E.recipe({
+    args = {
         'id'                 : str(urn),
         'title'              : attr('title', _('Unknown')),
         'author'             : attr('__author__', default_author),
         'language'           : attr('language', 'und'),
         'needs_subscription' : ns,
         'description'        : attr('description', '')
-        })
+        }
+    co = attr('conversion_options',None)
+    if co is not None and isinstance(co,dict):
+        args.update(co)
+    return E.recipe(args)
 
 
 def serialize_collection(mapping_of_recipe_classes):


### PR DESCRIPTION
Conversion options were introduced by 2e0ad5d1e082ef7339c4e744ed3156c208f84cf0 in 2009, but somehow the processing of this dict has been lost.

This change reintroduces the processing of conversion_options.