### PR TITLE
Add option in preferences / Look & Feel to display the layout buttons…

### DIFF
--- a/src/calibre/gui2/__init__.py
+++ b/src/calibre/gui2/__init__.py
@@ -123,6 +123,7 @@ def create_defs():
     defs['tag_browser_old_look'] = False
     defs['tag_browser_hide_empty_categories'] = False
     defs['book_list_tooltips'] = True
+    defs['show_layout_buttons'] = False
     defs['bd_show_cover'] = True
     defs['bd_overlay_cover_size'] = False
     defs['tags_browser_category_icons'] = {}

--- a/src/calibre/gui2/init.py
+++ b/src/calibre/gui2/init.py
@@ -588,9 +588,7 @@ class LayoutMixin(object):  # {{{
                 ''')
             self.status_bar.addPermanentWidget(button)
         if gprefs['show_layout_buttons']:
-            from calibre.utils.icu import primary_sort_key
-            for b in sorted(self.layout_buttons, key=lambda b: primary_sort_key(b.label)):
-                print(b.label)
+            for b in self.layout_buttons:
                 b.setVisible(True)
                 self.status_bar.addPermanentWidget(b)
         else:

--- a/src/calibre/gui2/init.py
+++ b/src/calibre/gui2/init.py
@@ -587,15 +587,22 @@ class LayoutMixin(object):  # {{{
                         QToolButton:checked { background: rgba(0, 0, 0, 25%); }
                 ''')
             self.status_bar.addPermanentWidget(button)
-        self.layout_button = b = QToolButton(self)
-        b.setAutoRaise(True), b.setCursor(Qt.PointingHandCursor)
-        b.setPopupMode(b.InstantPopup)
-        b.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
-        b.setText(_('Layout')), b.setIcon(QIcon(I('config.png')))
-        b.setMenu(LayoutMenu(self))
-        b.setToolTip(_(
-            'Show and hide various parts of the calibre main window'))
-        self.status_bar.addPermanentWidget(b)
+        if gprefs['show_layout_buttons']:
+            from calibre.utils.icu import primary_sort_key
+            for b in sorted(self.layout_buttons, key=lambda b: primary_sort_key(b.label)):
+                print(b.label)
+                b.setVisible(True)
+                self.status_bar.addPermanentWidget(b)
+        else:
+            self.layout_button = b = QToolButton(self)
+            b.setAutoRaise(True), b.setCursor(Qt.PointingHandCursor)
+            b.setPopupMode(b.InstantPopup)
+            b.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+            b.setText(_('Layout')), b.setIcon(QIcon(I('config.png')))
+            b.setMenu(LayoutMenu(self))
+            b.setToolTip(_(
+                'Show and hide various parts of the calibre main window'))
+            self.status_bar.addPermanentWidget(b)
         self.status_bar.addPermanentWidget(self.jobs_button)
         self.setStatusBar(self.status_bar)
         self.status_bar.update_label.linkActivated.connect(self.update_link_clicked)

--- a/src/calibre/gui2/preferences/look_feel.py
+++ b/src/calibre/gui2/preferences/look_feel.py
@@ -348,6 +348,7 @@ class ConfigWidget(ConfigWidgetBase, Ui_Form):
             self.opt_hidpi.setVisible(False), self.label_hidpi.setVisible(False)
         r('ui_style', gprefs, restart_required=True, choices=[(_('System default'), 'system'), (_('calibre style'), 'calibre')])
         r('book_list_tooltips', gprefs)
+        r('show_layout_buttons', gprefs, restart_required=True)
         r('row_numbers_in_book_list', gprefs)
         r('tag_browser_old_look', gprefs, restart_required=True)
         r('tag_browser_hide_empty_categories', gprefs)

--- a/src/calibre/gui2/preferences/look_feel.ui
+++ b/src/calibre/gui2/preferences/look_feel.ui
@@ -126,6 +126,13 @@
          </property>
         </widget>
        </item>
+       <item row="7" column="1">
+        <widget class="QCheckBox" name="opt_show_layout_buttons">
+         <property name="text">
+          <string>Show &amp;layout buttons in the status bar (needs restart)</string>
+         </property>
+        </widget>
+       </item>
        <item row="12" column="0">
         <spacer name="verticalSpacer_3">
          <property name="orientation">


### PR DESCRIPTION
… directly on the status bar. Default is False.

Although I prefer the buttons directly on the status bar, I don't feel strongly enough to argue. And I certainly won't listen to the zillions of people who will kibbitz ad nauseam.