### PR TITLE
Remove junk from redesigned wall street journal

### DIFF
--- a/recipes/wsj.recipe
+++ b/recipes/wsj.recipe
@@ -69,9 +69,16 @@ class WSJ(BasicNewsRecipe):
         dict(id='right-rail'),
         dict(id='narrator-nav'),
         dict(name='div', id='ad_and_popular'),
-        dict(classes('comments-count-container')),
-        classes(
-            'insetButton insettipBox author-info media-object-video article_tools nc-exp-artmeta category'),
+        dict(attrs={'class': [
+            'comments-count-container',
+            'insetButton',
+            'insettipBox',
+            'author-info',
+            'media-object-video',
+            'article_tools',
+            'nc-exp-artmeta',
+            'category'
+        ]}),
         dict(name='span', attrs={
              'data-country-code': True, 'data-ticker-code': True}),
         dict(name='meta link'.split()),

--- a/recipes/wsj.recipe
+++ b/recipes/wsj.recipe
@@ -69,16 +69,7 @@ class WSJ(BasicNewsRecipe):
         dict(id='right-rail'),
         dict(id='narrator-nav'),
         dict(name='div', id='ad_and_popular'),
-        dict(attrs={'class': [
-            'comments-count-container',
-            'insetButton',
-            'insettipBox',
-            'author-info',
-            'media-object-video',
-            'article_tools',
-            'nc-exp-artmeta',
-            'category'
-        ]}),
+        classes('right-rail', 'comments-count-container', 'insetButton insettipBox author-info media-object-video article_tools nc-exp-artmeta category'),
         dict(name='span', attrs={
              'data-country-code': True, 'data-ticker-code': True}),
         dict(name='meta link'.split()),

--- a/recipes/wsj.recipe
+++ b/recipes/wsj.recipe
@@ -13,7 +13,6 @@ from lxml import html
 
 from calibre.web.feeds.news import BasicNewsRecipe
 
-
 def CSSSelect(expr):
     expr = {
         'div.whatsNews-simple': '''descendant-or-self::div[@class and contains(concat(' ', normalize-space(@class), ' '), ' whatsNews-simple ')]''',
@@ -67,6 +66,10 @@ class WSJ(BasicNewsRecipe):
     ]
 
     remove_tags = [
+        dict(id='right-rail'),
+        dict(id='narrator-nav'),
+        dict(name='div', id='ad_and_popular'),
+        dict(classes('comments-count-container')),
         classes(
             'insetButton insettipBox author-info media-object-video article_tools nc-exp-artmeta category'),
         dict(name='span', attrs={
@@ -94,7 +97,22 @@ class WSJ(BasicNewsRecipe):
         if found:
             self.log.debug('Found %d dynamic images in:' % found)
         return soup
-
+      
+    def get_cover_url(self):
+        cover = 'https://vir.wsj.net/fp/cdn/fp/assets/images/WSJ_A1.jpg'
+        br = BasicNewsRecipe.get_browser(self)
+        try:
+            br.open(cover)
+        except:
+            index = 'http://en.kiosko.net/us/np/wsj.html'
+            soup = self.index_to_soup(index)
+            for image in soup.findAll('img', src=True):
+                if image['src'].endswith('750.jpg'):
+                    return image['src']
+            self.log("\nCover unavailable")
+            cover = None
+        return cover
+      
     def get_browser(self):
         # To understand the signin logic read signin.js from
         # https://id.wsj.com/access/pages/wsj/us/signin.html


### PR DESCRIPTION
Separately, i've noticed the current recipe includes the "whats news" section which is a compendium of prior days' top posts. This doesn't feel like a fit. I'd propose that a new variable be set, defaulting to False, like include_whats_news that a user could then enable if desired. Thoughts?