### PR TITLE
Enhancement request #1701833: ability to add columns to quickview pane.

### DIFF
--- a/src/calibre/db/backend.py
+++ b/src/calibre/db/backend.py
@@ -471,6 +471,7 @@ class DB(object):
         ('uuid', False), ('comments', True), ('id', False), ('pubdate', False),
         ('last_modified', False), ('size', False), ('languages', False),
         ]
+        defs['qv_display_fields'] = [('title', True), ('authors', True), ('series', True)]
         defs['virtual_libraries'] = {}
         defs['virtual_lib_on_startup'] = defs['cs_virtual_lib_on_startup'] = ''
         defs['virt_libs_hidden'] = defs['virt_libs_order'] = ()

--- a/src/calibre/gui2/__init__.py
+++ b/src/calibre/gui2/__init__.py
@@ -152,6 +152,10 @@ def create_defs():
     defs['hidpi'] = 'auto'
     defs['tag_browser_item_padding'] = 0.5
     defs['paste_isbn_prefixes'] = ['isbn', 'url', 'amazon', 'google']
+    defs['qv_respects_vls'] = True
+    defs['qv_dclick_changes_column'] = True
+    defs['qv_retkey_changes_column'] = True
+    defs['qv_show_on_startup'] = False
 
 
 create_defs()

--- a/src/calibre/gui2/actions/edit_metadata.py
+++ b/src/calibre/gui2/actions/edit_metadata.py
@@ -24,6 +24,7 @@ from calibre.utils.icu import sort_key
 from calibre.db.errors import NoSuchFormat
 from calibre.library.comments import merge_comments
 from calibre.ebooks.metadata.sources.prefs import msprefs
+from calibre.customize.ui import find_plugin
 
 
 class EditMetadataAction(InterfaceAction):
@@ -347,6 +348,9 @@ class EditMetadataAction(InterfaceAction):
         self.gui.refresh_cover_browser()
         m.current_changed(current, previous or current)
         self.gui.tags_view.recount_with_position_based_index()
+        qv = find_plugin('Show Quickview')
+        if qv is not None:
+            qv.actual_plugin_.refill_quickview()
 
     def do_edit_metadata(self, row_list, current_row, editing_multiple):
         from calibre.gui2.metadata.single import edit_metadata

--- a/src/calibre/gui2/actions/show_quickview.py
+++ b/src/calibre/gui2/actions/show_quickview.py
@@ -56,11 +56,10 @@ class ShowQuickviewAction(InterfaceAction):
                   'on the device.')).exec_()
             return
         index = self.gui.library_view.currentIndex()
-        if index.isValid():
-            self.current_instance = Quickview(self.gui, index)
-            self.current_instance.reopen_quickview.connect(self.reopen_quickview)
-            self.set_search_shortcut()
-            self.current_instance.show()
+        self.current_instance = Quickview(self.gui, index)
+        self.current_instance.reopen_quickview.connect(self.reopen_quickview)
+        self.set_search_shortcut()
+        self.current_instance.show()
 
     def set_search_shortcut(self):
         if self.current_instance and not self.current_instance.is_closed:
@@ -72,6 +71,10 @@ class ShowQuickviewAction(InterfaceAction):
             self.current_instance.reject()
         self.current_instance = None
         self.show_quickview()
+
+    def refill_quickview(self):
+        if self.current_instance and not self.current_instance.is_closed:
+            self.current_instance.refill()
 
     def change_quickview_column(self, idx):
         self.show_quickview()

--- a/src/calibre/gui2/dialogs/quickview.ui
+++ b/src/calibre/gui2/dialogs/quickview.ui
@@ -19,7 +19,7 @@
   <property name="windowTitle">
    <string>Quickview</string>
   </property>
-  <layout class="QGridLayout">
+  <layout class="QGridLayout" name="main_grid_layout">
    <item row="0" column="0">
     <widget class="QLabel" name="items_label">
      <property name="buddy">
@@ -63,6 +63,19 @@
    <item row="3" column="0" colspan="2">
     <layout class="QHBoxLayout">
      <item>
+      <spacer>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
       <widget class="QCheckBox" name="lock_qv">
        <property name="text">
         <string>&amp;Lock Quickview contents</string>
@@ -80,7 +93,7 @@
        </property>
        <property name="sizeHint" stdset="0">
         <size>
-         <width>0</width>
+         <width>20</width>
          <height>0</height>
         </size>
        </property>
@@ -144,6 +157,19 @@
         <bool>false</bool>
        </property>
       </widget>
+     </item>
+     <item>
+      <spacer>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
+      </spacer>
      </item>
     </layout>
    </item>

--- a/src/calibre/gui2/init.py
+++ b/src/calibre/gui2/init.py
@@ -164,7 +164,9 @@ class LibraryWidget(Splitter):  # {{{
         av.add_view('grid', parent.grid_view)
         parent.quickview_splitter.addWidget(stack)
 
-        quickview_widget.setLayout(QVBoxLayout())
+        l = QVBoxLayout()
+        l.setContentsMargins(0, 0, 0, 0)
+        quickview_widget.setLayout(l)
         parent.quickview_splitter.addWidget(quickview_widget)
         parent.quickview_splitter.hide_quickview_widget()
 

--- a/src/calibre/gui2/library/views.py
+++ b/src/calibre/gui2/library/views.py
@@ -921,6 +921,15 @@ class BooksView(QTableView):  # {{{
                     sm = self.selectionModel()
                     sm.select(index, sm.ClearAndSelect|sm.Rows)
 
+    def select_cell(self, row_number=0, logical_column=0):
+        if row_number > -1 and row_number < self.model().rowCount(QModelIndex()):
+            index = self.model().index(row_number, logical_column)
+            self.setCurrentIndex(index)
+            sm = self.selectionModel()
+            sm.select(index, sm.ClearAndSelect|sm.Rows)
+            sm.select(index, sm.Current)
+            self.clicked.emit(index)
+
     def row_at_top(self):
         pos = 0
         while pos < 100:

--- a/src/calibre/gui2/preferences/look_feel.ui
+++ b/src/calibre/gui2/preferences/look_feel.ui
@@ -1131,6 +1131,112 @@ them to all have the same width and height</string>
        </item>
       </layout>
      </widget>
+     <widget class="QWidget" name="quickview_tab">
+      <attribute name="icon">
+       <iconset resource="../../../../resources/images.qrc">
+        <normaloff>:/images/search.png</normaloff>:/images/search.png</iconset>
+      </attribute>
+      <attribute name="title">
+       <string>&amp;Quickview</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_122">
+       <item row="1" column="0" colspan="2">
+        <layout class="QGridLayout" name="gridLayout_122">
+         <item row="1" column="0">
+          <widget class="QCheckBox" name="opt_qv_respects_vls">
+           <property name="text">
+            <string>&amp;Apply virtual libraries in Quickview pane</string>
+           </property>
+           <property name="toolTip">
+            <string>Check this box to make Quickview show books only in the
+current virtual library. If unchecked, Quickview ignores virtual libraries.</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QCheckBox" name="opt_qv_show_on_startup">
+           <property name="text">
+            <string>&amp;Show Quickview on startup</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QCheckBox" name="opt_qv_retkey_changes_column">
+           <property name="toolTip">
+            <string>Pressing return in a cell changes both the book and the
+column being examined (the left-hand pane)</string>
+           </property>
+           <property name="text">
+            <string>&amp;Pressing 'return' changes examined column</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QCheckBox" name="opt_qv_dclick_changes_column">
+           <property name="toolTip">
+            <string>Double-clicking in a cell changes both the book and the
+column being examined (the left-hand pane)</string>
+           </property>
+           <property name="text">
+            <string>&amp;Doubleclick changes examined column</string>
+           </property>
+          </widget>
+         </item>
+       </layout>
+       </item>
+       <item row="3" column="0" rowspan="2">
+        <widget class="QGroupBox" name="groupBox">
+         <property name="title">
+          <string>Select displayed columns</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_32">
+          <item row="0" column="1">
+           <widget class="QToolButton" name="qv_up_button">
+            <property name="toolTip">
+             <string>Move up</string>
+            </property>
+            <property name="icon">
+             <iconset resource="../../../../resources/images.qrc">
+              <normaloff>:/images/arrow-up.png</normaloff>:/images/arrow-up.png</iconset>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QToolButton" name="qv_down_button">
+            <property name="toolTip">
+             <string>Move down</string>
+            </property>
+            <property name="icon">
+             <iconset resource="../../../../resources/images.qrc">
+              <normaloff>:/images/arrow-down.png</normaloff>:/images/arrow-down.png</iconset>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0" rowspan="3">
+           <widget class="QListView" name="qv_display_order">
+            <property name="alternatingRowColors">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <spacer name="verticalSpacer_5">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/src/calibre/gui2/ui.py
+++ b/src/calibre/gui2/ui.py
@@ -26,7 +26,7 @@ from calibre.constants import (
 from calibre.utils.config import prefs, dynamic
 from calibre.utils.ipc.pool import Pool
 from calibre.db.legacy import LibraryDatabase
-from calibre.customize.ui import interface_actions, available_store_plugins
+from calibre.customize.ui import interface_actions, available_store_plugins, find_plugin
 from calibre.gui2 import (error_dialog, GetMetadata, open_url,
         gprefs, max_available_height, config, info_dialog, Dispatcher,
         question_dialog, warning_dialog)
@@ -427,6 +427,11 @@ class Main(MainWindow, MainWindowMixin, DeviceMixin, EmailMixin,  # {{{
             self.hide_windows()
         self.auto_adder = AutoAdder(gprefs['auto_add_path'], self)
         self.save_layout_state()
+
+        if gprefs['qv_show_on_startup']:
+            qv = find_plugin('Show Quickview')
+            if qv is not None:
+                qv.actual_plugin_.show_quickview()
 
         # Collect cycles now
         gc.collect()


### PR DESCRIPTION
This commit contains many improvements and changes to Quickview.
- Add preference tab in Look & Feel to choose columns displayed in QV table and their order
- Option to permit changing the selected column from the quickview widget with return or double-click
- Option to show QV at startup
- Option to ignore virtual libraries in QV searches
- Remove margins on the docked window (tighter display
- Better handling of changes made on the booklist
- Many bugs fixed, some refactoring