### PR TITLE
Two Quickview fixes:

### DIFF
--- a/src/calibre/gui2/actions/edit_metadata.py
+++ b/src/calibre/gui2/actions/edit_metadata.py
@@ -24,7 +24,7 @@ from calibre.utils.icu import sort_key
 from calibre.db.errors import NoSuchFormat
 from calibre.library.comments import merge_comments
 from calibre.ebooks.metadata.sources.prefs import msprefs
-from calibre.customize.ui import find_plugin
+from calibre.gui2.actions.show_quickview import get_quickview_action_plugin
 
 
 class EditMetadataAction(InterfaceAction):
@@ -348,9 +348,9 @@ class EditMetadataAction(InterfaceAction):
         self.gui.refresh_cover_browser()
         m.current_changed(current, previous or current)
         self.gui.tags_view.recount_with_position_based_index()
-        qv = find_plugin('Show Quickview')
-        if qv is not None:
-            qv.actual_plugin_.refill_quickview()
+        qv = get_quickview_action_plugin()
+        if qv:
+            qv.refill_quickview()
 
     def do_edit_metadata(self, row_list, current_row, editing_multiple):
         from calibre.gui2.metadata.single import edit_metadata

--- a/src/calibre/gui2/actions/show_quickview.py
+++ b/src/calibre/gui2/actions/show_quickview.py
@@ -43,6 +43,14 @@ class QuickviewButton(LayoutButton):  # {{{
 
 # }}}
 
+current_qv_action_pi = None
+
+def set_quickview_action_plugin(pi):
+    global current_qv_action_pi
+    current_qv_action_pi = pi
+
+def get_quickview_action_plugin():
+    return current_qv_action_pi
 
 class ShowQuickviewAction(InterfaceAction):
 
@@ -72,6 +80,9 @@ class ShowQuickviewAction(InterfaceAction):
         self.search_action.changed.connect(self.set_search_shortcut)
         self.menuless_qaction.changed.connect(self.set_search_shortcut)
         self.qv_button = QuickviewButton(self.gui, self)
+
+    def initialization_complete(self):
+        set_quickview_action_plugin(self)
 
     def _hide_quickview(self):
         '''

--- a/src/calibre/gui2/dialogs/quickview.py
+++ b/src/calibre/gui2/dialogs/quickview.py
@@ -227,6 +227,7 @@ class Quickview(QDialog, Ui_Quickview):
         '''
         self.column_order = [x[0] for x in get_qv_field_list(self.fm) if x[1]]
         self.books_table.clear()
+        self.books_table.setRowCount(0)
         self.books_table.setColumnCount(len(self.column_order))
         for idx,col in enumerate(self.column_order):
             t = QTableWidgetItem(self.fm[col]['name'])
@@ -419,8 +420,7 @@ class Quickview(QDialog, Ui_Quickview):
     def indicate_no_items(self):
         self.no_valid_items = True
         self.items.clear()
-        self.books_table.clear()
-        self.books_table.setRowCount(0)
+        self.add_columns_to_widget()
         self.items.addItem(QListWidgetItem(_('**No items found**')))
         self.books_label.setText(_('Click in a column  in the library view '
                                    'to see the information for that book'))
@@ -542,7 +542,7 @@ class Quickview(QDialog, Ui_Quickview):
         if modifiers in (Qt.CTRL, Qt.SHIFT):
             self.view.select_rows([book_id])
             em = find_plugin('Edit Metadata')
-            if em is not None:
+            if em and em.actual_plugin_:
                 em.actual_plugin_.edit_metadata(None)
         else:
             self.view.select_cell(self.db.data.id_to_index(book_id),

--- a/src/calibre/gui2/library/views.py
+++ b/src/calibre/gui2/library/views.py
@@ -318,15 +318,15 @@ class BooksView(QTableView):  # {{{
             alignment = action.partition('_')[-1]
             self._model.change_alignment(column, alignment)
         elif action == 'quickview':
-            from calibre.customize.ui import find_plugin
-            qv = find_plugin('Show Quickview')
+            from calibre.gui2.actions.show_quickview import get_quickview_action_plugin
+            qv = get_quickview_action_plugin()
             if qv:
                 rows = self.selectionModel().selectedRows()
                 if len(rows) > 0:
                     current_row = rows[0].row()
                     current_col = self.column_map.index(column)
                     index = self.model().index(current_row, current_col)
-                    qv.actual_plugin_.change_quickview_column(index)
+                    qv.change_quickview_column(index)
 
         self.save_state()
 

--- a/src/calibre/gui2/preferences/look_feel.py
+++ b/src/calibre/gui2/preferences/look_feel.py
@@ -36,7 +36,7 @@ from calibre.gui2.dialogs.quickview import get_qv_field_list
 from calibre.gui2.preferences.coloring import EditRules
 from calibre.gui2.library.alternate_views import auto_height, CM_TO_INCH
 from calibre.gui2.widgets2 import Dialog
-from calibre.customize.ui import find_plugin
+from calibre.gui2.actions.show_quickview import get_quickview_action_plugin
 
 
 class BusyCursor(object):
@@ -760,9 +760,9 @@ class ConfigWidget(ConfigWidgetBase, Ui_Form):
             getattr(gui, view + '_view').set_row_header_visibility()
         gui.library_view.refresh_row_sizing()
         gui.grid_view.refresh_settings()
-        qv = find_plugin('Show Quickview')
-        if qv is not None:
-            qv.actual_plugin_.refill_quickview()
+        qv = get_quickview_action_plugin()
+        if qv:
+            qv.refill_quickview()
 
 
 if __name__ == '__main__':

--- a/src/calibre/gui2/ui.py
+++ b/src/calibre/gui2/ui.py
@@ -26,7 +26,7 @@ from calibre.constants import (
 from calibre.utils.config import prefs, dynamic
 from calibre.utils.ipc.pool import Pool
 from calibre.db.legacy import LibraryDatabase
-from calibre.customize.ui import interface_actions, available_store_plugins, find_plugin
+from calibre.customize.ui import interface_actions, available_store_plugins
 from calibre.gui2 import (error_dialog, GetMetadata, open_url,
         gprefs, max_available_height, config, info_dialog, Dispatcher,
         question_dialog, warning_dialog)
@@ -430,9 +430,10 @@ class Main(MainWindow, MainWindowMixin, DeviceMixin, EmailMixin,  # {{{
         # Now that the gui is initialized we can restore the quickview state
         # The same thing will be true for any action-based operation with a
         # layout button
-        qv = find_plugin('Show Quickview')
-        if qv is not None:
-            qv.actual_plugin_.qv_button.restore_state()
+        from calibre.gui2.actions.show_quickview import get_quickview_action_plugin
+        qv = get_quickview_action_plugin()
+        if qv:
+            qv.qv_button.restore_state()
         self.save_layout_state()
 
         # Collect cycles now


### PR DESCRIPTION
1) handle the odd case where the quickview action is initialized but the actual_plugin is not
2) Fix regression causing QV column headers not to be initialized on startup.