### PR TITLE
Correct a "=+" typo in readability.py's `sanitize` method.

### DIFF
--- a/src/calibre/ebooks/readability/readability.py
+++ b/src/calibre/ebooks/readability/readability.py
@@ -445,7 +445,7 @@ class Document:
                         # self.debug(sib.text_content())
                         sib_content_length = text_length(sib)
                         if sib_content_length:
-                            i =+ 1
+                            i += 1
                             siblings.append(sib_content_length)
                             if i == x:
                                 break


### PR DESCRIPTION
This was setting `i` to 1 every loop iteration instead of incrementing it.