### PR TITLE
Suggestion: Add "calibre" to desktop entry names.

### DIFF
--- a/src/calibre/linux.py
+++ b/src/calibre/linux.py
@@ -990,7 +990,7 @@ VIEWER = '''\
 [Desktop Entry]
 Version=1.0
 Type=Application
-Name=LRF Viewer
+Name=calibre LRF Viewer
 GenericName=Viewer for LRF files
 Comment=Viewer for LRF files (SONY ebook format files)
 TryExec=lrfviewer
@@ -1004,7 +1004,7 @@ EVIEWER = '''\
 [Desktop Entry]
 Version=1.0
 Type=Application
-Name=E-book Viewer
+Name=calibre E-book Viewer
 GenericName=Viewer for E-books
 Comment=Viewer for E-books in all the major formats
 TryExec=ebook-viewer
@@ -1017,7 +1017,7 @@ ETWEAK = '''\
 [Desktop Entry]
 Version=1.0
 Type=Application
-Name=E-book Editor
+Name=calibre E-book Editor
 GenericName=Editor for E-books
 Comment=Edit E-books in various formats
 TryExec=ebook-edit


### PR DESCRIPTION
If I happen to have multiple E-book viewers, it's nice to know which one I am opening (currently I have to go back and modify the .desktop files for Gedit, Evince, and Calibre whenever there is an update). Not sure if this has been discussed before.