### PR TITLE
NYTimes: Exclude CN and ES lang content

### DIFF
--- a/recipes/nytimes.recipe
+++ b/recipes/nytimes.recipe
@@ -365,6 +365,10 @@ class NYTimes(BasicNewsRecipe):
             return True
         if 'nytimes.com' not in url:
             return True
+        if 'cn.nytimes.com' in url:
+            return True
+        if '/es/' in url:
+            return True
         if 'podcast' in url:
             return True
         if '/video/' in url:

--- a/recipes/nytimes_sub.recipe
+++ b/recipes/nytimes_sub.recipe
@@ -365,6 +365,10 @@ class NYTimes(BasicNewsRecipe):
             return True
         if 'nytimes.com' not in url:
             return True
+        if 'cn.nytimes.com' in url:
+            return True
+        if '/es/' in url:
+            return True
         if 'podcast' in url:
             return True
         if '/video/' in url:


### PR DESCRIPTION
Currently content links to alternate articles when available in Spanish or Chinese language. These shouldn't be downloaded in a English language paper. Those wishing for foreign language content can acquire this by separately downloading the Chinese or Spanish editions proper.