### PR TITLE
[Bug] Unable to fetch Douban metadata, due to wrong XML namespace

### DIFF
--- a/src/calibre/ebooks/metadata/sources/douban.py
+++ b/src/calibre/ebooks/metadata/sources/douban.py
@@ -20,7 +20,7 @@ from calibre import as_unicode
 NAMESPACES = {
               'openSearch':'http://a9.com/-/spec/opensearchrss/1.0/',
               'atom' : 'http://www.w3.org/2005/Atom',
-              'db': 'http://www.douban.com/xmlns/',
+              'db': 'https://www.douban.com/xmlns/',
               'gd': 'http://schemas.google.com/g/2005'
             }
 


### PR DESCRIPTION
Reported by calibre user runsun. This bug was introduced in 5f8a7c04, which changed the URL of metadata services from http to https, but forgot to change the namespace URI from http to https. 