### PR TITLE
Updating feed URL for A List Apart Recipe

### DIFF
--- a/recipes/list_apart.recipe
+++ b/recipes/list_apart.recipe
@@ -27,7 +27,7 @@ class AListApart (BasicNewsRecipe):
         return self.extra_css
 
     feeds = [
-        (u'A List Apart', u'http://feeds.feedburner.com/alistapart/abridged'),
+        (u'A List Apart', u'https://alistapart.com/main/feed'),
     ]
 
     def image_url_processor(self, baseurl, url):


### PR DESCRIPTION
Seems like the abridged feedburner URL is no longer active (only adverts) so switching to the main feed. If there is any reason to keep it on feedburner, then here is the other URL: http://feeds.feedburner.com/alistapart