### PR TITLE
Removes needless whitespace in "Downloading metadata" dialog window

### DIFF
--- a/src/calibre/gui2/metadata/single_download.py
+++ b/src/calibre/gui2/metadata/single_download.py
@@ -511,7 +511,7 @@ class IdentifyWidget(QWidget):  # {{{
             x = ', '.join('%s:%s'%(k, v) for k, v in identifiers.iteritems())
             parts.append(x)
             if 'isbn' in identifiers:
-                simple_desc += ' ISBN: %s' % identifiers['isbn']
+                simple_desc += 'ISBN: %s' % identifiers['isbn']
         self.query.setText(simple_desc)
         self.log(unicode(self.query.text()))
 


### PR DESCRIPTION
There is space after authors names, so space before `ISBN:` produces two whitespace in row.