### PR TITLE
Fix incorrect tooltip in tag list editor

### DIFF
--- a/src/calibre/gui2/dialogs/tag_list_editor.ui
+++ b/src/calibre/gui2/dialogs/tag_list_editor.ui
@@ -46,7 +46,7 @@
      <item>
       <widget class="QPushButton" name="search_button">
        <property name="toolTip">
-        <string>Copy the selected color name to the clipboard</string>
+        <string>Find the first/next matching item</string>
        </property>
        <property name="text">
         <string>&amp;Find</string>


### PR DESCRIPTION
Fix incorrect tooltip.
If I need to do something else let me know (I had flagged this in transifex, if everything is OK I will mark it as resolved there)