### PR TITLE
Turn off socket inheritance for the wireless device "find calibre" …

### DIFF
--- a/src/calibre/devices/smart_device_app/driver.py
+++ b/src/calibre/devices/smart_device_app/driver.py
@@ -1937,6 +1937,7 @@ class SMART_DEVICE_APP(DeviceConfig, DevicePlugin):
 
             try:
                 self.broadcast_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+                set_socket_inherit(self.broadcast_socket, False)
             except:
                 message = 'creation of broadcast socket failed. This is not fatal.'
                 self._debug(message)


### PR DESCRIPTION
…broadcast socket. It appears that calibre restarts otherwise keep this socket open.