### PR TITLE
Only spell check files with the media-type application/xhtml+xml

### DIFF
--- a/src/calibre/ebooks/oeb/polish/spell.py
+++ b/src/calibre/ebooks/oeb/polish/spell.py
@@ -192,7 +192,7 @@ def group_sort(locations):
 
 
 def get_checkable_file_names(container):
-    file_names = [name for name, linear in container.spine_names] + [container.opf_name]
+    file_names = [name for name in container.manifest_items_of_type("application/xhtml+xml")] + [container.opf_name]
     for f in (find_existing_ncx_toc, find_existing_nav_toc):
         toc = f(container)
         if toc is not None and container.exists(toc) and toc not in file_names:


### PR DESCRIPTION
Instead of spell checking all spine items, it is a safer bet to only check application/xhtml+xml content files.

Since the spell check code is parsing the files and retrieving lang attributes from tags, let's first do a sanity check and filter out whatever is not an XML or HTML file. 

I have a properly formatted EPUB (according to epubcheck) version 3.0.1, but calibre's spell check was breaking when trying to get the lang attribute from a plain text file (a CHANGELOG) which is in the spine as a non-linear item (so I don't know if the linear condition in the original code was applying correctly).


