### PR TITLE
Check type of the parsed data before spell check

### DIFF
--- a/src/calibre/ebooks/oeb/polish/spell.py
+++ b/src/calibre/ebooks/oeb/polish/spell.py
@@ -175,12 +175,13 @@ def locale_from_tag(tag):
 
 
 def read_words_from_html(root, words, file_name, book_locale):
-    stack = [(root, book_locale)]
-    while stack:
-        parent, parent_locale = stack.pop()
-        locale = locale_from_tag(parent) or parent_locale
-        read_words_from_html_tag(parent, words, file_name, parent_locale, locale)
-        stack.extend((tag, locale) for tag in parent.iterchildren('*'))
+    if type(root) is not str:
+        stack = [(root, book_locale)]
+        while stack:
+            parent, parent_locale = stack.pop()
+            locale = locale_from_tag(parent) or parent_locale
+            read_words_from_html_tag(parent, words, file_name, parent_locale, locale)
+            stack.extend((tag, locale) for tag in parent.iterchildren('*'))
 
 
 def group_sort(locations):
@@ -192,7 +193,7 @@ def group_sort(locations):
 
 
 def get_checkable_file_names(container):
-    file_names = [name for name in container.manifest_items_of_type("application/xhtml+xml")] + [container.opf_name]
+    file_names = [name for name, linear in container.spine_names] + [container.opf_name]
     for f in (find_existing_ncx_toc, find_existing_nav_toc):
         toc = f(container)
         if toc is not None and container.exists(toc) and toc not in file_names:

--- a/src/calibre/ebooks/oeb/polish/spell.py
+++ b/src/calibre/ebooks/oeb/polish/spell.py
@@ -192,7 +192,7 @@ def group_sort(locations):
 
 
 def get_checkable_file_names(container):
-    file_names = [name for name, linear in container.spine_names] + [container.opf_name]
+    file_names = [name for name in container.manifest_items_of_type("application/xhtml+xml")] + [container.opf_name]
     for f in (find_existing_ncx_toc, find_existing_nav_toc):
         toc = f(container)
         if toc is not None and container.exists(toc) and toc not in file_names:


### PR DESCRIPTION
If the root is `str`, then the file is binary or plain text and it could not be parsed as X/HTML. Parsed root of OEB_DOCS is of type `lxml.etree._Element`