### PR TITLE
Changes for enhancement #1731750

### DIFF
--- a/src/calibre/gui2/dialogs/metadata_bulk.ui
+++ b/src/calibre/gui2/dialogs/metadata_bulk.ui
@@ -489,7 +489,7 @@ from the value in the box</string>
                 <bool>false</bool>
                </property>
                <property name="minimum">
-                <double>1.000000000000000</double>
+                <double>0.000000000000000</double>
                </property>
                <property name="maximum">
                 <double>99000000.000000000000000</double>
@@ -511,7 +511,10 @@ from the value in the box</string>
                 <string>+ </string>
                </property>
                <property name="minimum">
-                <double>0.010000000000000</double>
+                <double>0.000000000000000</double>
+               </property>
+               <property name="maximum">
+                <double>99999.0</double>
                </property>
                <property name="value">
                 <double>1.000000000000000</double>


### PR DESCRIPTION
1) make the bulk custom and standard series column editors behave similarly
2) allow zero as an increment so that all the books can be set to the same series number (standard and bulk)

The enhancement request suggested that the "Apply changes" checkbox be removed for custom series. I didn't do that because that checkbox is used for all custom columns.