### PR TITLE
Bump supported firmware version for Kobo 4.7.x firmware

### DIFF
--- a/src/calibre/devices/kobo/driver.py
+++ b/src/calibre/devices/kobo/driver.py
@@ -1328,7 +1328,7 @@ class KOBOTOUCH(KOBO):
     # Starting with firmware version 3.19.x, the last number appears to be is a
     # build number. A number will be recorded here but it can be safely ignored
     # when testing the firmware version.
-    max_supported_fwversion         = (4, 6, 9960)
+    max_supported_fwversion         = (4, 7, 10413)
     # The following document firwmare versions where new function or devices were added.
     # Not all are used, but this feels a good place to record it.
     min_fwversion_shelves           = (2, 0, 0)


### PR DESCRIPTION
Kobo is about to release new firmware is about release new firmware. No changes are needed except to bump the support firmware version.