### PR TITLE
redirecting legacy /browse/book/ URLs

### DIFF
--- a/src/calibre/srv/legacy.py
+++ b/src/calibre/srv/legacy.py
@@ -251,8 +251,19 @@ def mobile(ctx, rd):
 
 
 @endpoint('/browse/{+rest=""}')
-def browse(ctx, rd, rest):
-    raise HTTPRedirect(ctx.url_for(None))
+def browse(ctx, rd, rest):  # implementation of https://bugs.launchpad.net/calibre/+bug/1698411
+    if rest.find('book/') == 0:
+        redirect = ctx.url_for(None) + '#book_id=' + rest[5:] + "&amp;panel=book_details"
+        from lxml import etree as ET
+        return html(ctx, rd, endpoint,
+                 E.html(E.head(
+                     ET.XML('<meta http-equiv="refresh" content="0;url=' + redirect + '"/>'),
+                     ET.XML('<script language="javascript">' +
+                         'window.location.href = "' + redirect + '"' +
+                         '</script>'
+                         ))))
+    else:
+        raise HTTPRedirect(ctx.url_for(None))
 
 
 @endpoint('/stanza/{+rest=""}')


### PR DESCRIPTION
re: "[Feature Request: calibre-server 3.0 should rewrite pre-3.0 URLs](https://bugs.launchpad.net/calibre/+bug/1698411)":
I have implemented client-side redirection of URLs such as:

https://mysite.com/calibre_prefix/browse/book/2542
→ https://mysite.com/calibre_prefix#book_id=2542&panel=book_details