### PR TITLE
Compatibility improvements for FreeBSD systems

### DIFF
--- a/setup/build.py
+++ b/setup/build.py
@@ -9,7 +9,7 @@ __docformat__ = 'restructuredtext en'
 import textwrap, os, shlex, subprocess, glob, shutil, re, sys, json
 from collections import namedtuple
 
-from setup import Command, islinux, isbsd, isosx, ishaiku, SRC, iswindows, __version__
+from setup import Command, islinux, isbsd, isfreebsd, isosx, ishaiku, SRC, iswindows, __version__
 isunix = islinux or isosx or isbsd or ishaiku
 
 py_lib = os.path.join(sys.prefix, 'libs', 'python%d%d.lib' % sys.version_info[:2])
@@ -87,9 +87,9 @@ def expand_file_list(items, is_paths=True):
 def is_ext_allowed(ext):
     only = ext.get('only', '')
     if only:
-        only = only.split()
-        q = 'windows' if iswindows else 'osx' if isosx else 'bsd' if isbsd else 'haiku' if ishaiku else 'linux'
-        return q in only
+        only = set(only.split())
+        q = set(filter(lambda x: globals()["is" + x], ["bsd", "freebsd", "haiku", "linux", "osx", "windows"]))
+        return len(q.intersection(only)) > 0
     return True
 
 
@@ -107,6 +107,8 @@ def parse_extension(ext):
             ans = ext.pop('osx_' + k, ans)
         elif isbsd:
             ans = ext.pop('bsd_' + k, ans)
+        elif isfreebsd:
+            ans = ext.pop('freebsd_' + k, ans)
         elif ishaiku:
             ans = ext.pop('haiku_' + k, ans)
         else:

--- a/setup/build_environment.py
+++ b/setup/build_environment.py
@@ -9,7 +9,7 @@ __docformat__ = 'restructuredtext en'
 import os, subprocess, re, sys, sysconfig
 from distutils.spawn import find_executable
 
-from setup import isosx, iswindows, is64bit, islinux, ishaiku
+from setup import isfreebsd, isosx, iswindows, is64bit, islinux, ishaiku
 is64bit
 
 NMAKE = RC = msvc = MT = win_inc = win_lib = None
@@ -84,7 +84,12 @@ pyqt['sip_bin'] = os.environ.get('SIP_BIN', 'sip')
 from PyQt5.QtCore import PYQT_CONFIGURATION
 pyqt['sip_flags'] = PYQT_CONFIGURATION['sip_flags']
 def get_sip_dir():
-    q = os.environ.get('SIP_DIR', os.path.join(sys.prefix, 'share', 'sip') if iswindows else os.path.join(sys.prefix, 'share', 'sip'))
+    if iswindows:
+        q = os.environ.get('SIP_DIR', os.path.join(sys.prefix, 'share', 'sip'))
+    elif isfreebsd:
+        q = os.environ.get('SIP_DIR', os.path.join(sys.prefix, 'share', 'py-sip'))
+    else:
+        q = os.path.join(sys.prefix, 'share', 'sip')
     for x in ('', 'Py2-PyQt5', 'PyQt5', 'sip/PyQt5'):
         base = os.path.join(q, x)
         if os.path.exists(os.path.join(base, 'QtWidgets')):

--- a/setup/extensions.json
+++ b/setup/extensions.json
@@ -194,8 +194,14 @@
         "libraries": "usb-1.0"
     },
     {
+        "name": "libusb",
+        "only": "freebsd",
+        "sources": "calibre/devices/libusb/libusb.c",
+        "libraries": "usb"
+    },
+    {
         "name": "libmtp",
-        "only": "osx linux haiku",
+        "only": "freebsd osx linux haiku",
         "sources": "calibre/devices/mtp/unix/devices.c calibre/devices/mtp/unix/libmtp.c",
         "headers": "calibre/devices/mtp/unix/devices.h calibre/devices/mtp/unix/upstream/music-players.h calibre/devices/mtp/unix/upstream/device-flags.h",
         "libraries": "mtp"

--- a/src/calibre/constants.py
+++ b/src/calibre/constants.py
@@ -172,7 +172,7 @@ class Plugins(collections.Mapping):
             plugins.extend(['winutil', 'wpd', 'winfonts'])
         if isosx:
             plugins.append('usbobserver')
-        if islinux or isosx:
+        if isfreebsd or ishaiku or islinux or isosx:
             plugins.append('libusb')
             plugins.append('libmtp')
         self.plugins = frozenset(plugins)

--- a/src/calibre/devices/libusb/libusb.c
+++ b/src/calibre/devices/libusb/libusb.c
@@ -8,7 +8,11 @@
 #define UNICODE
 
 #include <Python.h>
+#ifdef __FreeBSD__
+#include <libusb.h>
+#else
 #include <libusb-1.0/libusb.h>
+#endif
 
 static PyObject *Error = NULL;
 static PyObject *cache = NULL;


### PR DESCRIPTION
Don't exclude libmtp on FreeBSD systems.

Don't exclude libusb on FreeBSD systems.  Our libusb has a different include
path structure and libname than Linux, but compiles fine once those are
corrected.

Correct path to py-sip on FreeBSD.  We install it to a different directory
than build_environment.py was looking in.