### PR TITLE
Fixed New Yorker Magazine recipe

### DIFF
--- a/recipes/new_yorker.recipe
+++ b/recipes/new_yorker.recipe
@@ -57,6 +57,7 @@ class NewYorker(BasicNewsRecipe):
         classes('content-ad-wrapper social-hover background-image'),
         dict(id=['newsletter-signup']),
         dict(attrs={'class': lambda x: x and 'ImageEmbed__button___' in x}),
+        dict(attrs={'class': lambda x: x and 'ArticleLedeImage__button___' in x}),
         dict(name='links source'.split()), ]
     remove_attributes = ['style']
 


### PR DESCRIPTION
The XHTML produced by the recipe had an ill-formed XHTML that, when converted to KEPUB, was not properly parsed on Kobo devices.