### PR TITLE
Just use libusb to scan USB devices on FreeBSD

### DIFF
--- a/src/calibre/devices/mtp/unix/driver.py
+++ b/src/calibre/devices/mtp/unix/driver.py
@@ -35,7 +35,7 @@ APPLE = 0x05ac
 class MTP_DEVICE(MTPDeviceBase):
 
     # libusb(x) does not work on OS X. So no MTP support for OS X
-    supported_platforms = ['linux', 'osx']
+    supported_platforms = ['freebsd', 'linux', 'osx']
 
     def __init__(self, *args, **kwargs):
         MTPDeviceBase.__init__(self, *args, **kwargs)

--- a/src/calibre/devices/scanner.py
+++ b/src/calibre/devices/scanner.py
@@ -166,60 +166,6 @@ class LinuxScanner(object):
         return ans
 
 
-class FreeBSDScanner(object):
-
-    def __call__(self):
-        ans = set([])
-        import dbus
-
-        try:
-            bus = dbus.SystemBus()
-            manager = dbus.Interface(bus.get_object('org.freedesktop.Hal',
-                          '/org/freedesktop/Hal/Manager'), 'org.freedesktop.Hal.Manager')
-            paths = manager.FindDeviceStringMatch('freebsd.driver','da')
-            for path in paths:
-                obj = bus.get_object('org.freedesktop.Hal', path)
-                objif = dbus.Interface(obj, 'org.freedesktop.Hal.Device')
-                parentdriver = None
-                while parentdriver != 'umass':
-                    try:
-                        obj = bus.get_object('org.freedesktop.Hal',
-                              objif.GetProperty('info.parent'))
-                        objif = dbus.Interface(obj, 'org.freedesktop.Hal.Device')
-                        try:
-                            parentdriver = objif.GetProperty('freebsd.driver')
-                        except dbus.exceptions.DBusException as e:
-                            continue
-                    except dbus.exceptions.DBusException as e:
-                        break
-                if parentdriver != 'umass':
-                    continue
-                dev = []
-                try:
-                    dev.append(objif.GetProperty('usb.vendor_id'))
-                    dev.append(objif.GetProperty('usb.product_id'))
-                    dev.append(objif.GetProperty('usb.device_revision_bcd'))
-                except dbus.exceptions.DBusException as e:
-                    continue
-                try:
-                    dev.append(objif.GetProperty('info.vendor'))
-                except:
-                    dev.append('')
-                try:
-                    dev.append(objif.GetProperty('info.product'))
-                except:
-                    dev.append('')
-                try:
-                    dev.append(objif.GetProperty('usb.serial'))
-                except:
-                    dev.append('')
-                dev.append(path)
-                ans.add(tuple(dev))
-        except dbus.exceptions.DBusException as e:
-            print >>sys.stderr, "Execution failed:", e
-        return ans
-
-
 if islinux:
     linux_scanner = LinuxScanner()
 
@@ -236,7 +182,7 @@ if False and isosx:
     osx_scanner = usbobserver.get_usb_devices
 
 if isfreebsd:
-    freebsd_scanner = FreeBSDScanner()
+    freebsd_scanner = libusb_scanner
 
 ''' NetBSD support currently not written yet '''
 if isnetbsd:


### PR DESCRIPTION
The HAL scanner adds a needless dependency on a runtime service and the
libusb scanner is perfectly fine.

This fixes detection of MTP devices on FreeBSD.

The logical patch was written by Guido Falsi; additionally, I removed
the legacy FreeBSDScanner class.