### PR TITLE
Fix Calibre Companion sync on Linux

### DIFF
--- a/src/calibre/devices/smart_device_app/driver.py
+++ b/src/calibre/devices/smart_device_app/driver.py
@@ -1927,7 +1927,7 @@ class SMART_DEVICE_APP(DeviceConfig, DevicePlugin):
                     return message
 
             try:
-                self.listen_socket.listen(0)
+                self.listen_socket.listen(1)
             except:
                 message = 'listen on port %d failed' % port
                 self._debug(message)


### PR DESCRIPTION
- listen(0) doesn't work on Linux, select.select() and socket.accept() return no connection