### PR TITLE
lwn weekly shows "Unknown feed" and "Undefined article title" for almost all TOC items

### DIFF
--- a/recipes/lwn_weekly.recipe
+++ b/recipes/lwn_weekly.recipe
@@ -95,14 +95,14 @@ class WeeklyLWN(BasicNewsRecipe):
 
             text = curr.contents[0].string
 
-            if 'Cat2HL' in curr.attrMap['class']:
+            if 'Cat2HL' in curr['class']:
                 subsection = text
 
-            elif 'Cat1HL' in curr.attrMap['class']:
+            elif 'Cat1HL' in curr['class']:
                 section = text
                 subsection = None
 
-            elif 'SummaryHL' in curr.attrMap['class']:
+            elif 'SummaryHL' in curr['class']:
                 article_title = text
                 if not article_title:
                     article_title = _('Undefined article title')

--- a/recipes/lwn_weekly.recipe
+++ b/recipes/lwn_weekly.recipe
@@ -73,6 +73,7 @@ class WeeklyLWN(BasicNewsRecipe):
         return url
 
     def parse_index(self):
+        # from pprint import pprint
         if self.username is not None and self.password is not None:
             index_url = self.print_version('/current/bigpage')
         else:
@@ -155,7 +156,6 @@ class WeeklyLWN(BasicNewsRecipe):
 
         ans = [(section2, articles[section2])
                for section2 in ans if section2 in articles]
-        # from pprint import pprint
         # pprint(ans)
 
         return ans

--- a/recipes/lwn_weekly.recipe
+++ b/recipes/lwn_weekly.recipe
@@ -83,7 +83,12 @@ class WeeklyLWN(BasicNewsRecipe):
         articles = {}
         ans = []
 
-        section = soup.title.string
+        section = soup.title
+        while True:
+            if section and hasattr(section, 'contents'):
+                section = section.contents[0]
+            else:
+                break
         subsection = None
 
         while True:
@@ -93,7 +98,12 @@ class WeeklyLWN(BasicNewsRecipe):
             if curr is None:
                 break
 
-            text = curr.contents[0].string
+            text = curr
+            while True:
+                if text and hasattr(text, 'contents'):
+                    text = text.contents[0]
+                else:
+                    break
 
             if 'Cat2HL' in curr['class']:
                 subsection = text


### PR DESCRIPTION
I don't know why the ".string" property returns None for every Tag, maybe the HTML contains errors somewhere so tags are not properly ended. This happened on 11/29/2017 and problem persisted. Fedora pushed version calibre-3.12.0-1.fc27 on 11/23/2017, it could also be something changed between 3.12 and 3.11.1. If there is a fix already, please just decline this one. Thanks!