### PR TITLE
Added a space before image dimensions in “Trim Image” window

### DIFF
--- a/src/calibre/gui2/dialogs/trim_image.py
+++ b/src/calibre/gui2/dialogs/trim_image.py
@@ -76,7 +76,7 @@ class TrimImage(QDialog):
         self.msg.setVisible(not has_selection)
 
     def image_changed(self, qimage):
-        self.sz.setText('\xa0' + _('Size:') + '%dx%d' % (qimage.width(), qimage.height()))
+        self.sz.setText('\xa0' + _('Size:') + ' ' + '%dx%d' % (qimage.width(), qimage.height()))
 
     def cleanup(self):
         self.canvas.break_cycles()


### PR DESCRIPTION
Currently there is no space: https://i.imgur.com/2bW41RX.png