### PR TITLE
boss.py : show_current_diff allow_revert parameter wasn't used

### DIFF
--- a/src/calibre/gui2/tweak_book/boss.py
+++ b/src/calibre/gui2/tweak_book/boss.py
@@ -531,7 +531,7 @@ class Boss(QObject):
 
     def show_current_diff(self, allow_revert=True, to_container=None):
         self.commit_all_editors_to_container()
-        d = self.create_diff_dialog()
+        d = self.create_diff_dialog(revert_msg=_('&Revert changes') if allow_revert else '')
         d.revert_requested.connect(partial(self.revert_requested, self.global_undo.previous_container))
         other = to_container or self.global_undo.previous_container
         d.container_diff(other, self.global_undo.current_container,


### PR DESCRIPTION
This way works but perhaps you'll find a better one