### PR TITLE
Fix Kobo Aura Edition detection (Bug 1756556)

### DIFF
--- a/src/calibre/devices/kobo/driver.py
+++ b/src/calibre/devices/kobo/driver.py
@@ -1374,7 +1374,7 @@ class KOBOTOUCH(KOBO):
                           MINI_PRODUCT_ID + TOUCH_PRODUCT_ID + TOUCH2_PRODUCT_ID + \
                           AURA_ONE_PRODUCT_ID
 
-    BCD = [0x0110, 0x0326]
+    BCD = [0x0110, 0x0326, 0x401]
 
     # Image file name endings. Made up of: image size, min_dbversion, max_dbversion, isFullSize,
     # Note: "200" has been used just as a much larger number than the current versions. It is just a lazy


### PR DESCRIPTION
My brand new Kobo Aura Edition 2 (firmware 4.6.10188), bought today in FNAC shop (France) has these UBS IDs:
VENDOR_ID: 0x2237
PRODUCT_ID: 0x4226
BCD: 0x401

This BCD isn't known by the drivers: adding it into the BCD list variable fix device detection.