### PR TITLE
Fix (sort of) bug #1759222. The "sort of" comes from the fact that …

### DIFF
--- a/src/calibre/gui2/dialogs/metadata_bulk.py
+++ b/src/calibre/gui2/dialogs/metadata_bulk.py
@@ -439,7 +439,8 @@ class MyBlockingBusy(QDialog):  # {{{
                 self.s_r_func(book_id)
                 self.progress_update.emit(1)
             if self.sr_calls:
-                self.progress_next_step_range.emit(len(self.ids))
+                self.progress_next_step_range.emit(len(self.sr_calls))
+                self.progress_update.emit(0)
                 for field, book_id_val_map in self.sr_calls.iteritems():
                     self.refresh_books.update(self.db.new_api.set_field(field, book_id_val_map))
                     self.progress_update.emit(1)


### PR DESCRIPTION
…the last step is usually only one step long but can take an arbitrary amount of time. Consider if the title changes for 100 books. The update must rename all 100 book folders, which from S/R's point of view all happen in a single step.