### PR TITLE
[WIP] Add ability to open books for reading from the console by id.

### DIFF
--- a/src/calibre/db/cli/cmd_path.py
+++ b/src/calibre/db/cli/cmd_path.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python2
+# vim:fileencoding=utf-8
+# License: GPLv3 Copyright: 2018, Nikita Sirgienko <warquark@gmail.com>
+
+from __future__ import division, print_function, unicode_literals
+
+from calibre.db.cli import integers_from_string
+
+import os
+
+def option_parser(get_parser, args):
+    # TODO: translation (update po?)
+    # TODO: more options?
+    parser = get_parser(
+        _(
+            '''\
+%prog open ids
+
+Print absolute paths of one of available formats by book ids.
+'''
+        )
+    )
+    return parser
+
+def main(opts, args, dbctx):
+    if len(args) < 1:
+        raise SystemExit(_('You must specify some ids'))
+    book_ids = set()
+    for arg in args:
+        book_ids |= set(integers_from_string(arg))
+    # TODO: is it normal? Use another API from dbctx?
+    db = dbctx.db
+    for i, book_id in enumerate(book_ids):
+        formats = db.get_field(book_id,'formats', None, True)
+        if formats != None:
+            #TODO: add option for prefered format?
+            format = formats[0]
+            # TODO: Platform independent path escaping!
+            path=db.format_abspath(book_id, format, True)
+            print(path)
+        #else:
+            #print(_("Id %s doesn't contain in library") % book_id)
+    return 0

--- a/src/calibre/db/cli/main.py
+++ b/src/calibre/db/cli/main.py
@@ -22,7 +22,7 @@ from calibre.utils.serialize import MSGPACK_MIME
 
 COMMANDS = (
     'list', 'add', 'remove', 'add_format', 'remove_format', 'show_metadata',
-    'set_metadata', 'export', 'catalog', 'saved_searches', 'add_custom_column',
+    'set_metadata', 'path', 'export', 'catalog', 'saved_searches', 'add_custom_column',
     'custom_columns', 'remove_custom_column', 'set_custom', 'restore_database',
     'check_library', 'list_categories', 'backup_metadata', 'clone', 'embed_metadata',
     'search'


### PR DESCRIPTION
Well, this is needed feature for me (too large library (~3000), GUI become too slow (library on old laptop))
Now, it's just a addition command(`path`) in `calibredb`. It's get list of library ids and return paths to one of available formats for existing ids. This first version some ugly, but I will be improve it.
So, @kovidgoyal, will you agree with adding this feature(new command to open book by id)?
Where place of `open` command, in `calibredb`? Or in another place?