### PR TITLE
Search parsing: fix using a parenthesized expression following an …

### DIFF
--- a/src/calibre/utils/search_query_parser.py
+++ b/src/calibre/utils/search_query_parser.py
@@ -221,8 +221,8 @@ class Parser(object):
             return ['and', lhs, self.and_expression()]
 
         # Account for the optional 'and'
-        if (self.token_type() in [self.WORD, self.QUOTED_WORD] and
-                        self.lcase_token() != 'or'):
+        if ((self.token_type() in [self.WORD, self.QUOTED_WORD] or self.token() == '(')
+                    and self.lcase_token() != 'or'):
             return ['and', lhs, self.and_expression()]
         return lhs
 


### PR DESCRIPTION
…implied "and", eg "A (B or C)" now is parsed correctly as "A and (B or C)"