### PR TITLE
Detect when format has changed during import

### DIFF
--- a/src/calibre/db/cli/cmd_add.py
+++ b/src/calibre/db/cli/cmd_add.py
@@ -44,6 +44,8 @@ def book(db, notify_changes, is_remote, args):
         else:
             path = data
         path = run_import_plugins([path])[0]
+        fmt = os.path.splitext(path)[1]
+        fmt = fmt[1:] if fmt else None
         with lopen(path, 'rb') as stream:
             mi = get_metadata(stream, stream_type=fmt, use_libprs_metadata=True)
         if not mi.title:


### PR DESCRIPTION
The recent change to the "calibredb add" command is not detecting when filetype plugins have changed the format during import.