### PR TITLE
lwn_weekly: fix security section articles parsing

### DIFF
--- a/recipes/lwn_weekly.recipe
+++ b/recipes/lwn_weekly.recipe
@@ -114,7 +114,7 @@ class WeeklyLWN(BasicNewsRecipe):
 
                 # Most articles have anchors in their titles, *except* the
                 # security vulnerabilities
-                article_anchor = curr.findNext(
+                article_anchor = curr.find(
                     name='a', attrs={'href': re.compile('^/Articles/')})
 
                 if article_anchor:


### PR DESCRIPTION
As security section has no URLs in article titles, findNext() boldly returns whatever
next link is encounered after the anchor. This leads to downloading and including in generated
document of heavy CVE reports, as links to them usually placed after the article title.

Instead we'd better search under anchor tag only, this way we'll filter useful articles' links.