### PR TITLE
Always include base_window_title in window title of ebook viewer

### DIFF
--- a/src/calibre/gui2/viewer/main.py
+++ b/src/calibre/gui2/viewer/main.py
@@ -527,7 +527,7 @@ class EbookViewer(MainWindow):
                     value, maximum = self.pos.value(), self.pos.maximum()
                     text = '%g/%g'%(value, maximum)
                     if fmt:
-                        title = '({}) {} [{}]'.format(text, self.current_title, fmt)
+                        title = '({}) {} [{}] - {}'.format(text, self.current_title, fmt, self.base_window_title)
                     else:
                         title = '({}) {} - {}'.format(text, self.current_title, self.base_window_title)
                 else:


### PR DESCRIPTION
As part of commit 470cd53e049b9d7beb2bd6425ba990727b0c855b, the pages were added to the window title when controls aren't visible, but only that variation of the title doesn't include base_window_title at the end.

In my case, it breaks my AutoHotkey script, since the window is not longer recognized in fullscreen mode.