### PR TITLE
Update Handelsblatt

### DIFF
--- a/recipes/handelsblatt.recipe
+++ b/recipes/handelsblatt.recipe
@@ -22,7 +22,7 @@ class Handelsblatt(BasicNewsRecipe):
     language = 'de'
 
     oldest_article = 2
-    max_articles_per_feed = 30
+    max_articles_per_feed = 15
     simultaneous_downloads = 10
     no_stylesheets = True
     remove_javascript = True
@@ -58,11 +58,15 @@ class Handelsblatt(BasicNewsRecipe):
         dict(name='aside', attrs={'class': ['vhb-article-element vhb-left',
                                             'vhb-article-element vhb-left vhb-teasergallery',
                                             'vhb-article-element vhb-left vhb-shorttexts']}),
+        dict(name='aside', attrs={'class': re.compile('vhb-club-events')}),
         dict(name='article', attrs={'class': ['vhb-imagegallery vhb-teaser',
                                               'vhb-teaser vhb-type-video']}),
         dict(name='small', attrs={'class': ['vhb-credit']}),
         dict(name='div', attrs={'class': ['white_content', 'fb-post',
-                                          'opinary-widget-wrapper']}),
+                                          'opinary-widget-wrapper',
+                                          'vhb-hollow-area vhb-hollow-area--col-1']}),
+        dict(name='div', attrs={'class': re.compile('vhb-imagegallery')}),
+        dict(name='div', attrs={'id': ['highcharts_infografik']}),
         dict(name='div', attrs={'id': re.compile('dax-sentiment')}),
         dict(name=['div', 'section'], attrs={'class': re.compile('slider')}),
         dict(name='a', attrs={'class': ['twitter-follow-button']}),
@@ -141,9 +145,9 @@ class Handelsblatt(BasicNewsRecipe):
         # make sure that all figure captions (including the source) are shown
         # without linebreaks by using the alternative text given within <img/>
         # instead of the original text (which is oddly formatted)
-        for fig in soup.findAll('figure', {'class': 'vhb-image'}):
-            fig.find('div', {'class': 'vhb-caption'}
-                     ).replaceWith(fig.find('img')['alt'])
+        for fig in soup.findAll('figcaption', {'class': 'vhb-inline-picture'}):
+            cap = fig.find('img')['alt']
+            fig.find('div', {'class': 'vhb-caption'}).replaceWith(cap)
         # clean up remainders of embedded content
         for div in soup.findAll('div', {'style': True}):
             if len(div.attrs) == 1:


### PR DESCRIPTION
The Handelsblatt has recently erected a paywall [1]. The number of articles that can be downloaded freely has been restricted, and also the formatting of the pages has changed.
I currently don't have access to the paid content. This commit is thus only a minimally invasive change to make sure that the recipe remains usable for users without a login. There has been a report about the premium access being broken already last year [2], and the paywall has certainly not improved that situation. In the long-term, a more thorough rewrite will be required.

[1] (de) [https://www.handelsblatt.com/unternehmen/it-medien/in-eigener-sache-das-neue-handelsblatt-bezahlmodell/22590618.html](https://www.handelsblatt.com/unternehmen/it-medien/in-eigener-sache-das-neue-handelsblatt-bezahlmodell/22590618.html)
[2] [https://www.mobileread.com/forums/showthread.php?t=272664](https://www.mobileread.com/forums/showthread.php?t=272664)