### PR TITLE
Exclude execute from umask

### DIFF
--- a/setup/linux-installer.py
+++ b/setup/linux-installer.py
@@ -694,9 +694,12 @@ def check_umask():
     mask = os.umask(18)  # 18 = 022
     os.umask(mask)
     forbid_user_read = mask & stat.S_IRUSR
+    forbid_user_exec = mask & stat.S_IXUSR
     forbid_group_read = mask & stat.S_IRGRP
+    forbid_group_exec = mask & stat.S_IXGRP
     forbid_other_read = mask & stat.S_IROTH
-    if forbid_user_read or forbid_group_read or forbid_other_read:
+    forbid_other_exec = mask & stat.S_IXOTH
+    if forbid_user_read or forbid_user_exec or forbid_group_read or forbid_group_exec or forbid_other_read or forbid_other_exec:
         prints(
             'WARNING: Your current umask disallows reading of files by some users,'
             ' this can cause system breakage when running the installer because'
@@ -709,7 +712,7 @@ def check_umask():
                 break
             prints('Response', q, 'not understood')
         if q == 'f':
-            mask = mask & ~stat.S_IRUSR & ~stat.S_IRGRP & ~stat.S_IROTH
+            mask = mask & ~stat.S_IRUSR & ~stat.S_IXUSR & ~stat.S_IRGRP & ~stat.S_IXGRP & ~stat.S_IROTH & ~stat.S_IXOTH
             os.umask(mask)
             prints('umask changed to: {:03o}'.format(mask))
         elif q == 'i':

--- a/setup/linux-installer.sh
+++ b/setup/linux-installer.sh
@@ -743,9 +743,12 @@ def check_umask():
     mask = os.umask(18)  # 18 = 022
     os.umask(mask)
     forbid_user_read = mask & stat.S_IRUSR
+    forbid_user_exec = mask & stat.S_IXUSR
     forbid_group_read = mask & stat.S_IRGRP
+    forbid_group_exec = mask & stat.S_IXGRP
     forbid_other_read = mask & stat.S_IROTH
-    if forbid_user_read or forbid_group_read or forbid_other_read:
+    forbid_other_exec = mask & stat.S_IXOTH
+    if forbid_user_read or forbid_user_exec or forbid_group_read or forbid_group_exec or forbid_other_read or forbid_other_exec:
         prints(
             'WARNING: Your current umask disallows reading of files by some users,'
             ' this can cause system breakage when running the installer because'
@@ -758,7 +761,7 @@ def check_umask():
                 break
             prints('Response', q, 'not understood')
         if q == 'f':
-            mask = mask & ~stat.S_IRUSR & ~stat.S_IRGRP & ~stat.S_IROTH
+            mask = mask & ~stat.S_IRUSR & ~stat.S_IXUSR & ~stat.S_IRGRP & ~stat.S_IXGRP & ~stat.S_IROTH & ~stat.S_IXOTH
             os.umask(mask)
             prints('umask changed to: {:03o}'.format(mask))
         elif q == 'i':


### PR DESCRIPTION
If the umask is set up to exlude execute, the installer will set up
calibre to be unreadable by any user other than the installing user.
When installing as `root`, a starting umask of `0o077` results in the
installer choosing a new umask of `0o033`, which means the calibre
install directory (and child directories) are installed with permissions
`0o744`, so only the installing user can actually use the resulting
calibre install.

To test, start with a system umask of `0o077` and run the installer
script as root:

```
% sudo sh ./setup/linux-installer.sh
Using python executable: /usr/bin/python3
WARNING: Your current umask disallows reading of files by some users, this can cause system breakage when running the installer because of bugs in common system utilities.
Should the installer (f)ix the umask, (i)gnore it or (a)bort [f/i/a Default is abort]: f
umask changed to: 022
Installing to /opt/calibre
Downloading tarball signature securely...
Using previously downloaded calibre-3.26.1-x86_64.txz
Extracting files to /opt/calibre ...
Extracting application files...
Creating symlinks...
	Symlinking /opt/calibre/ebook-edit to /usr/bin/ebook-edit
	Symlinking /opt/calibre/calibre-debug to /usr/bin/calibre-debug
	Symlinking /opt/calibre/web2disk to /usr/bin/web2disk
	Symlinking /opt/calibre/calibre-parallel to /usr/bin/calibre-parallel
	Symlinking /opt/calibre/calibredb to /usr/bin/calibredb
	Symlinking /opt/calibre/lrs2lrf to /usr/bin/lrs2lrf
	Symlinking /opt/calibre/calibre to /usr/bin/calibre
	Symlinking /opt/calibre/ebook-convert to /usr/bin/ebook-convert
	Symlinking /opt/calibre/calibre-server to /usr/bin/calibre-server
	Symlinking /opt/calibre/ebook-viewer to /usr/bin/ebook-viewer
	Symlinking /opt/calibre/calibre-smtp to /usr/bin/calibre-smtp
	Symlinking /opt/calibre/ebook-meta to /usr/bin/ebook-meta
	Symlinking /opt/calibre/ebook-device to /usr/bin/ebook-device
	Symlinking /opt/calibre/fetch-ebook-metadata to /usr/bin/fetch-ebook-metadata
	Symlinking /opt/calibre/ebook-polish to /usr/bin/ebook-polish
	Symlinking /opt/calibre/lrfviewer to /usr/bin/lrfviewer
	Symlinking /opt/calibre/calibre-customize to /usr/bin/calibre-customize
	Symlinking /opt/calibre/lrf2lrs to /usr/bin/lrf2lrs
	Symlinking /opt/calibre/markdown-calibre to /usr/bin/markdown-calibre
Setting up command-line completion...
Installing zsh completion to: /usr/share/zsh/site-functions/_calibre
Installing bash completion to: /usr/share/bash-completion/completions/calibre
Setting up desktop integration...
Creating un-installer: /usr/bin/calibre-uninstall
Run "calibre" to start calibre
```

And the resulting directory:
```
% ls -ld /opt/calibre
drwxr-xr-x. 5 root root 4.0K Jun 22 10:53 /opt/calibre/
```

Also verify the Python version, starting with no `/opt/calibre` and a system umask of `0o077`:
```
% sudo python3 ./setup/linux-installer.py
WARNING: Your current umask disallows reading of files by some users, this can cause system breakage when running the installer because of bugs in common system utilities.
Should the installer (f)ix the umask, (i)gnore it or (a)bort [f/i/a Default is abort]: f
umask changed to: 022
Installing to /opt/calibre
Downloading tarball signature securely...
Using previously downloaded calibre-3.26.1-x86_64.txz
Extracting files to /opt/calibre ...
Extracting application files...
Creating symlinks...
	Symlinking /opt/calibre/calibre-customize to /usr/bin/calibre-customize
	Symlinking /opt/calibre/calibre-smtp to /usr/bin/calibre-smtp
	Symlinking /opt/calibre/calibredb to /usr/bin/calibredb
	Symlinking /opt/calibre/calibre to /usr/bin/calibre
	Symlinking /opt/calibre/ebook-polish to /usr/bin/ebook-polish
	Symlinking /opt/calibre/ebook-meta to /usr/bin/ebook-meta
	Symlinking /opt/calibre/calibre-server to /usr/bin/calibre-server
	Symlinking /opt/calibre/markdown-calibre to /usr/bin/markdown-calibre
	Symlinking /opt/calibre/fetch-ebook-metadata to /usr/bin/fetch-ebook-metadata
	Symlinking /opt/calibre/lrf2lrs to /usr/bin/lrf2lrs
	Symlinking /opt/calibre/calibre-parallel to /usr/bin/calibre-parallel
	Symlinking /opt/calibre/ebook-convert to /usr/bin/ebook-convert
	Symlinking /opt/calibre/ebook-viewer to /usr/bin/ebook-viewer
	Symlinking /opt/calibre/web2disk to /usr/bin/web2disk
	Symlinking /opt/calibre/calibre-debug to /usr/bin/calibre-debug
	Symlinking /opt/calibre/ebook-device to /usr/bin/ebook-device
	Symlinking /opt/calibre/lrfviewer to /usr/bin/lrfviewer
	Symlinking /opt/calibre/ebook-edit to /usr/bin/ebook-edit
	Symlinking /opt/calibre/lrs2lrf to /usr/bin/lrs2lrf
Setting up command-line completion...
Installing zsh completion to: /usr/share/zsh/site-functions/_calibre
Installing bash completion to: /usr/share/bash-completion/completions/calibre
Setting up desktop integration...
Creating un-installer: /usr/bin/calibre-uninstall
Run "calibre" to start calibre

% ls -ld /opt/calibre
drwxr-xr-x. 5 root root 4.0K Jun 22 10:55 /opt/calibre/
```

After each, verify calibre starts as a non-root user.