### PR TITLE
sorted library items by name on opds

### DIFF
--- a/src/calibre/srv/opds.py
+++ b/src/calibre/srv/opds.py
@@ -301,7 +301,8 @@ class TopLevel(Feed):  # {{{
             categories]
         for x in subcatalogs:
             self.root.append(x)
-        for library_id, library_name in request_context.library_map.iteritems():
+        sorted_library_items_by_name = sorted(request_context.library_map.items(), key=lambda item:item[1])
+        for library_id, library_name in sorted_library_items_by_name:
             id_ = 'calibre-library:' + library_id
             self.root.append(E.entry(
                 TITLE(_('Library:') + ' ' + library_name),


### PR DESCRIPTION
I found that libraries are not sorted by the name, so I fix the feature for display library items by the name when using opds.