### PR TITLE
Create thumbnail images on Kindle for KFX format

### DIFF
--- a/src/calibre/devices/kindle/driver.py
+++ b/src/calibre/devices/kindle/driver.py
@@ -463,18 +463,28 @@ class KINDLE2(KINDLE):
         self.upload_apnx(path, filename, metadata, filepath)
 
     def thumbpath_from_filepath(self, filepath):
+        from calibre.ebooks.metadata.kfx import (CONTAINER_MAGIC, read_book_key_kfx)
         from calibre.ebooks.mobi.reader.headers import MetadataHeader
         from calibre.utils.logging import default_log
         thumb_dir = os.path.join(self._main_prefix, 'system', 'thumbnails')
         if not os.path.exists(thumb_dir):
             return
         with lopen(filepath, 'rb') as f:
-            mh = MetadataHeader(f, default_log)
-        if mh.exth is None or not mh.exth.uuid or not mh.exth.cdetype:
+            is_kfx = f.read(4) == CONTAINER_MAGIC
+            f.seek(0)
+            if is_kfx:
+                uuid,cdetype = read_book_key_kfx(f)
+            else:
+                mh = MetadataHeader(f, default_log)
+                if mh.exth is None:
+                    return
+                uuid = mh.exth.uuid
+                cdetype = mh.exth.cdetype
+        if not uuid or not cdetype:
             return
         return os.path.join(thumb_dir,
                 'thumbnail_{uuid}_{cdetype}_portrait.jpg'.format(
-                    uuid=mh.exth.uuid, cdetype=mh.exth.cdetype))
+                    uuid=uuid, cdetype=cdetype))
 
     def upload_kindle_thumbnail(self, metadata, filepath):
         coverdata = getattr(metadata, 'thumbnail', None)

--- a/src/calibre/ebooks/metadata/kfx.py
+++ b/src/calibre/ebooks/metadata/kfx.py
@@ -278,6 +278,17 @@ def dump_metadata(m):
     pprint(d)
 
 
+def read_book_key_kfx(stream, read_cover=True):
+    ' Read the metadata.kfx file that is found in the sdr book folder for KFX files '
+    c = Container(stream.read())
+    m = extract_metadata(c.decode())
+
+    def val(x):
+        return m[x][0] if x in m else ''
+
+    return (val('content_id') or val('ASIN'), val('cde_content_type'))
+
+
 def read_metadata_kfx(stream, read_cover=True):
     ' Read the metadata.kfx file that is found in the sdr book folder for KFX files '
     c = Container(stream.read())


### PR DESCRIPTION
Add the ability to create Kindle thumbnails for books sent in KFX format. 

The content_id and cde_type are extracted from the KFX file and used to create the thumbnail filename in much the same way that the equivalent fields are extracted from MOBI/AZW3 files.