### PR TITLE
Add a tweak to allow skipping network check on news download.

### DIFF
--- a/resources/default_tweaks.py
+++ b/resources/default_tweaks.py
@@ -567,3 +567,7 @@ show_saved_search_box = False
 # exclude_fields_on_paste = ['cover', 'timestamp', '#mycolumn']
 # to prevent pasting of the cover, Date and custom column, mycolumn.
 exclude_fields_on_paste = []
+
+#: Skip network check
+# Skip checking the network state before downloading news
+skip_network_check = False

--- a/src/calibre/utils/network.py
+++ b/src/calibre/utils/network.py
@@ -7,7 +7,7 @@ __copyright__ = '2010, Kovid Goyal <kovid@kovidgoyal.net>'
 __docformat__ = 'restructuredtext en'
 
 from calibre.constants import iswindows, islinux, isbsd
-
+from calibre.utils.config_base import tweaks
 
 class LinuxNetworkStatus(object):
 
@@ -55,4 +55,7 @@ _network_status = WindowsNetworkStatus() if iswindows else \
 
 
 def internet_connected():
-    return _network_status()
+    if tweaks['skip_network_check']:
+        return True
+    else:
+        return _network_status()


### PR DESCRIPTION
The mechanism used for checking for available network connections
may not always be accurate, so allow it to be skipped. For instance
network manager may not be aware of all available connection and
so return a false negative.

This has been added as a tweak to allow those who know what they're
doing to use the alternate behavior, without breaking the default
check mechanism.