### PR TITLE
Build hunspell in py3

### DIFF
--- a/src/calibre/utils/spell/hunspell_wrapper.cpp
+++ b/src/calibre/utils/spell/hunspell_wrapper.cpp
@@ -53,7 +53,7 @@ dealloc(Dictionary *self) {
     if (self->handle != NULL) delete self->handle;
     /* We do not free encoding, since it is managed by hunspell */
     self->encoding = NULL; self->handle = NULL;
-	self->ob_type->tp_free((PyObject *)self);
+	Py_TYPE(self)->tp_free((PyObject *)self);
 }
 
 static PyObject *
@@ -112,9 +112,15 @@ remove_word(Dictionary *self, PyObject *args) {
 
 static PyMethodDef HunSpell_methods[] = {
 	{"recognized", (PyCFunction)recognized, METH_VARARGS,
-	 "Checks the spelling of the given word. The word must be a unicode object. If encoding of the word to the encoding of the dictionary fails, a UnicodeEncodeError is raised. Returns False if the input word is not recognized."},
+	 "Checks the spelling of the given word. The word must be a unicode "
+	 "object. If encoding of the word to the encoding of the dictionary fails, "
+	 "a UnicodeEncodeError is raised. Returns False if the input word is not "
+	 "recognized."},
 	{"suggest", (PyCFunction)suggest, METH_VARARGS,
-	 "Provide suggestions for the given word. The input word must be a unicode object. If encoding of the word to the encoding of the dictionary fails, a UnicodeEncodeError is raised. Returns the list of suggested words as unicode objects."},
+	 "Provide suggestions for the given word. The input word must be a unicode "
+	 "object. If encoding of the word to the encoding of the dictionary fails, "
+	 "a UnicodeEncodeError is raised. Returns the list of suggested words as "
+	 "unicode objects."},
 	{"add", (PyCFunction)add, METH_VARARGS,
 	 "Adds the given word into the runtime dictionary"},
 	{"remove", (PyCFunction)remove_word, METH_VARARGS,
@@ -123,65 +129,82 @@ static PyMethodDef HunSpell_methods[] = {
 };
 
 static PyTypeObject DictionaryType = {
-	PyObject_HEAD_INIT(NULL)
-	0,		/* ob_size */
-	"Dictionary",		/* tp_name */
-	sizeof(Dictionary),	/* tp_basicsize */
-	0,			/* tp_itemsize */
-	(destructor) dealloc,	/* tp_dealloc */
-	0,			/* tp_print */
-	0,			/* tp_getattr */
-	0,			/* tp_setattr */
-	0,			/* tp_compare */
-	0,			/* tp_repr */
-	0,			/* tp_as_number */
-	0,			/* tp_as_sequence */
-	0,			/* tp_as_mapping */
-	0,			/* tp_hash */
-	0,			/* tp_call */
-	0,			/* tp_str */
-	0,			/* tp_getattro */
-	0,			/* tp_setattro */
-	0,			/* tp_as_buffer */
-	Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,	/* tp_flags */
-	"Dictionary object",	/* tp_doc */
-	0,			/* tp_traverse */
-	0,			/* tp_clear */
-	0,			/* tp_richcompare */
-	0,			/* tp_weaklistoffset */
-	0,			/* tp_iter */
-	0,			/* tp_iternext */
-	HunSpell_methods,	/* tp_methods */
-	0,			/* tp_members */
-	0,			/* tp_getset */
-	0,			/* tp_base */
-	0,			/* tp_dict */
-	0,			/* tp_descr_get */
-	0,			/* tp_descr_set */
-	0,			/* tp_dictoffset */
-	(initproc) init_type,	/* tp_init */
-	0,			/* tp_alloc */
-	0,			/* tp_new */
+	PyVarObject_HEAD_INIT(NULL, 0)
+    /* tp_name           */ "Dictionary",
+    /* tp_basicsize      */ sizeof(Dictionary),
+    /* tp_itemsize       */ 0,
+    /* tp_dealloc        */ (destructor) dealloc,
+    /* tp_print          */ 0,
+    /* tp_getattr        */ 0,
+    /* tp_setattr        */ 0,
+    /* tp_compare        */ 0,
+    /* tp_repr           */ 0,
+    /* tp_as_number      */ 0,
+    /* tp_as_sequence    */ 0,
+    /* tp_as_mapping     */ 0,
+    /* tp_hash           */ 0,
+    /* tp_call           */ 0,
+    /* tp_str            */ 0,
+    /* tp_getattro       */ 0,
+    /* tp_setattro       */ 0,
+    /* tp_as_buffer      */ 0,
+    /* tp_flags          */ Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    /* tp_doc            */ "Dictionary object",
+    /* tp_traverse       */ 0,
+    /* tp_clear          */ 0,
+    /* tp_richcompare    */ 0,
+    /* tp_weaklistoffset */ 0,
+    /* tp_iter           */ 0,
+    /* tp_iternext       */ 0,
+    /* tp_methods        */ HunSpell_methods,
+    /* tp_members        */ 0,
+    /* tp_getset         */ 0,
+    /* tp_base           */ 0,
+    /* tp_dict           */ 0,
+    /* tp_descr_get      */ 0,
+    /* tp_descr_set      */ 0,
+    /* tp_dictoffset     */ 0,
+    /* tp_init           */ (initproc) init_type,
+    /* tp_alloc          */ 0,
+    /* tp_new            */ 0,
 };
 
+#if PY_MAJOR_VERSION >= 3
+#define INITERROR return NULL
+static struct PyModuleDef hunspell_module = {
+    /* m_base     */ PyModuleDef_HEAD_INIT,
+    /* m_name     */ "hunspell",
+    /* m_doc      */ "A wrapper for the hunspell spell checking library",
+    /* m_size     */ -1,
+    /* m_methods  */ 0,
+    /* m_slots    */ 0,
+    /* m_traverse */ 0,
+    /* m_clear    */ 0,
+    /* m_free     */ 0,
+};
 
-CALIBRE_MODINIT_FUNC
-inithunspell(void) {
-    PyObject *mod;
-
-    // Create the module
-    mod = Py_InitModule3("hunspell", NULL,
-                "A wrapper for the hunspell spell checking library");
-    if (mod == NULL) return;
+CALIBRE_MODINIT_FUNC PyInit_hunspell(void) {
+    PyObject *mod = PyModule_Create(&hunspell_module);
+#else
+#define INITERROR return
+CALIBRE_MODINIT_FUNC inithunspell(void) {
+    PyObject *mod = Py_InitModule3("hunspell", NULL,
+        "A wrapper for the hunspell spell checking library");
+#endif
+    if (mod == NULL) INITERROR;
 
     HunspellError = PyErr_NewException((char*)"hunspell.HunspellError", NULL, NULL);
-    if (HunspellError == NULL) return;
+    if (HunspellError == NULL) INITERROR;
     PyModule_AddObject(mod, "HunspellError", HunspellError);
 
     // Fill in some slots in the type, and make it ready
     DictionaryType.tp_new = PyType_GenericNew;
-    if (PyType_Ready(&DictionaryType) < 0) return;
+    if (PyType_Ready(&DictionaryType) < 0) INITERROR;
     // Add the type to the module.
     Py_INCREF(&DictionaryType);
     PyModule_AddObject(mod, "Dictionary", (PyObject *)&DictionaryType);
+
+#if PY_MAJOR_VERSION >= 3
+    return mod;
+#endif
 }


### PR DESCRIPTION
py27 result:

```
test_dictionaries (calibre.spell.dictionary.TestDictionaries) ... ok [0.2 s]
```

Manually tested on py3 (since it's not possible to import the test on py3):

```
>>> import hunspell
>>> dic = open('/home/user/dev/calibre/resources/dictionaries/en-US/en-US.dic')
>>> aff = open('/home/user/dev/calibre/resources/dictionaries/en-US/en-US.aff')
>>> dic = dic.read()
>>> aff = aff.read()
>>> hunspell.Dictionary(dic, aff)
<Dictionary object at 0x7f2399a26770>
>>> d = hunspell.Dictionary(dic, aff)
>>> d.suggest('foo')
('few', 'foo', 'goo', 'fop', 'foot', 'fool', 'food', 'foe', 'for', 'fro', 'too', 'fol', 'loo', 'coo', 'fog')
>>> d.recognized('foo')
True
>>> d.suggest('ade-quately')
('ad-quately', 'aide-quately', 'lade-quately', 'made-quately', 'bade-quately', 'fade-quately', 'wade-quately', 'adze-quately', 'Sade-quately', 'Wade-quately', 'ads-quately', 'are-quately', 'ate-quately', 'ado-quately', 'ode-quately')
>>> d.suggest('magic.wand')
('magician', 'McGowan', 'Gwendoline')
>>> d.suggest('magic. wand')
('magician', 'magnificent', 'Gwendoline')
>>> dic = open('/home/user/dev/calibre/resources/dictionaries/es-ES/es-ES.dic').read()
>>> aff = open('/home/user/dev/calibre/resources/dictionaries/es-ES/es-ES.aff').read()
>>> d = hunspell.Dictionary(dic, aff)
>>> d.suggest('é')
('e', 'sé', 'té', 'él', 'dé', 'vé', 'a', 'o', 'd', 'u', 'y')
>>> d.recognized('té')
True
>>> d.suggest('foo')
('fio', 'fo', 'foro', 'fono', 'foso', 'foco', 'foto', 'fofo', 'feo', 'roo', 'fon', 'too', 'fol', 'loo', 'zoo')
>>> d.add('foo')
True
>>> d.suggest('foo')
('foo', 'fio', 'fo', 'foro', 'fono', 'foso', 'foco', 'foto', 'fofo', 'feo', 'roo', 'fon', 'too', 'fol', 'loo')
>>> d.remove('foo')
True
>>> d.recognized('té')
True
>>> d.recognized('foo')
False
```