### PR TITLE
Escape part of a template string

### DIFF
--- a/src/calibre/gui2/tweak_book/check.py
+++ b/src/calibre/gui2/tweak_book/check.py
@@ -195,10 +195,12 @@ class Check(QSplitter):
                 activate = '<div>%s</div>' % ('<br>'.join(activate))
                 if many:
                     activate += '<br>'
+                activate = activate.replace('%', '%%')
                 template = header + ((msg + activate) if many else (activate + msg)) + footer
             else:
                 activate = '<div><a href="activate:item" title="%s">%s %s</a></div>' % (
                        open_tt, err.name, loc)
+                activate = activate.replace('%', '%%')
                 template = header + activate + msg + footer
             self.help.setText(
                 template % (err.HELP, ifix, fix_tt, fix_msg, run_tt, run_msg))


### PR DESCRIPTION
In ebook-edit, if a filename contains a '%' clicking 'Run check'
results in an error:

Traceback (most recent call last):
  File "/usr/lib/calibre/calibre/gui2/tweak_book/boss.py", line 72, in ans
    return func(*args, **kwargs)
  File "/usr/lib/calibre/calibre/gui2/tweak_book/boss.py", line 1249, in check_requested
    c.run_checks(current_container())
  File "/usr/lib/calibre/calibre/gui2/tweak_book/check.py", line 221, in run_checks
    self.current_item_changed()
  File "/usr/lib/calibre/calibre/gui2/tweak_book/check.py", line 206, in current_item_changed
    template % (err.HELP, ifix, fix_tt, fix_msg, run_tt, run_msg))
ValueError: unsupported format character '_' (0x5f) at index 167