### PR TITLE
Add tweak 'exclude_fields_on_usb_send' to NOT put tweak-settable items like thumbnail and user_metadata in metadata.calibre.

### DIFF
--- a/resources/default_tweaks.py
+++ b/resources/default_tweaks.py
@@ -573,3 +573,12 @@ exclude_fields_on_paste = []
 # Useful if for some reason your operating systems network checking
 # facilities are not reliable (for example NetworkManager on Linux).
 skip_network_check = False
+
+#: Exclude fields when sending metadata to USB devices
+# You can ask calibre to not send some metadata fields when saving
+# metadata to metadata.calibre on a USB device.  This can reduce the
+# size of metadata.calibre as much as 95% For example,
+# exclude_fields_on_usb_send = ['cover', 'comments', 'user_metadata', 'thumbnail']
+# to prevent saving the cover file page, comments, custom columns and
+# encoded thumbnail.
+exclude_fields_on_usb_send = []

--- a/src/calibre/devices/usbms/driver.py
+++ b/src/calibre/devices/usbms/driver.py
@@ -20,6 +20,7 @@ from calibre.devices.usbms.cli import CLI
 from calibre.devices.usbms.device import Device
 from calibre.devices.usbms.books import BookList, Book
 from calibre.ebooks.metadata.book.json_codec import JsonCodec
+from calibre.utils.config_base import tweaks
 
 BASE_TIME = None
 
@@ -432,7 +433,8 @@ class USBMS(CLI, Device):
     # at the end just before the return
     def sync_booklists(self, booklists, end_session=True):
         debug_print('USBMS: starting sync_booklists')
-        json_codec = JsonCodec()
+        json_codec = JsonCodec(skip_fields=tweaks['exclude_fields_on_usb_send'])
+#['comments','cover','thumbnail','user_metadata'])
 
         if not os.path.exists(self.normalize_path(self._main_prefix)):
             os.makedirs(self.normalize_path(self._main_prefix))


### PR DESCRIPTION
From [discussion on MR](https://www.mobileread.com/forums/showthread.php?p=3749756).