### PR TITLE
Fixes for Library Keyboard Shortcuts aren't disabled when location is device

### DIFF
--- a/src/calibre/gui2/actions/__init__.py
+++ b/src/calibre/gui2/actions/__init__.py
@@ -143,6 +143,7 @@ class InterfaceAction(QObject):
         self.gui.addAction(self.qaction)
         self.gui.addAction(self.menuless_qaction)
         self.genesis()
+        self.location_selected('library')
 
     @property
     def unique_name(self):

--- a/src/calibre/gui2/actions/add_to_library.py
+++ b/src/calibre/gui2/actions/add_to_library.py
@@ -23,6 +23,7 @@ class AddToLibraryAction(InterfaceAction):
     def location_selected(self, loc):
         enabled = loc != 'library'
         self.qaction.setEnabled(enabled)
+        self.menuless_qaction.setEnabled(enabled)
 
     def add_books_to_library(self, *args):
         self.gui.iactions['Add Books'].add_books_from_device(

--- a/src/calibre/gui2/actions/catalog.py
+++ b/src/calibre/gui2/actions/catalog.py
@@ -29,6 +29,7 @@ class GenerateCatalogAction(InterfaceAction):
     def location_selected(self, loc):
         enabled = loc == 'library'
         self.qaction.setEnabled(enabled)
+        self.menuless_qaction.setEnabled(enabled)
 
     def generate_catalog(self):
         rows = self.gui.library_view.selectionModel().selectedRows()

--- a/src/calibre/gui2/actions/choose_library.py
+++ b/src/calibre/gui2/actions/choose_library.py
@@ -401,6 +401,7 @@ class ChooseLibraryAction(InterfaceAction):
     def location_selected(self, loc):
         enabled = loc == 'library'
         self.qaction.setEnabled(enabled)
+        self.menuless_qaction.setEnabled(enabled)
 
     def rename_requested(self, name, location):
         LibraryDatabase = db_class()

--- a/src/calibre/gui2/actions/convert.py
+++ b/src/calibre/gui2/actions/convert.py
@@ -69,6 +69,9 @@ class ConvertAction(InterfaceAction):
     def location_selected(self, loc):
         enabled = loc == 'library'
         self.qaction.setEnabled(enabled)
+        self.menuless_qaction.setEnabled(enabled)
+        for action in list(self.convert_menu.actions()):
+            action.setEnabled(enabled)
 
     def auto_convert(self, book_ids, on_card, format):
         previous = self.gui.library_view.currentIndex()

--- a/src/calibre/gui2/actions/copy_to_library.py
+++ b/src/calibre/gui2/actions/copy_to_library.py
@@ -432,6 +432,7 @@ class CopyToLibraryAction(InterfaceAction):
     def location_selected(self, loc):
         enabled = loc == 'library'
         self.qaction.setEnabled(enabled)
+        self.menuless_qaction.setEnabled(enabled)
 
     def build_menus(self):
         self.menu.clear()

--- a/src/calibre/gui2/actions/device.py
+++ b/src/calibre/gui2/actions/device.py
@@ -163,6 +163,7 @@ class SendToDeviceAction(InterfaceAction):
     def location_selected(self, loc):
         enabled = loc == 'library'
         self.qaction.setEnabled(enabled)
+        self.menuless_qaction.setEnabled(enabled)
 
     def do_sync(self, *args):
         self.gui._sync_action_triggered()
@@ -189,6 +190,7 @@ class ConnectShareAction(InterfaceAction):
     def location_selected(self, loc):
         enabled = loc == 'library'
         self.qaction.setEnabled(enabled)
+        self.menuless_qaction.setEnabled(enabled)
 
     def set_state(self, device_connected, device):
         self.share_conn_menu.set_state(device_connected, device)

--- a/src/calibre/gui2/actions/edit_collections.py
+++ b/src/calibre/gui2/actions/edit_collections.py
@@ -23,6 +23,7 @@ class EditCollectionsAction(InterfaceAction):
     def location_selected(self, loc):
         enabled = loc != 'library'
         self.qaction.setEnabled(enabled)
+        self.menuless_qaction.setEnabled(enabled)
 
     def edit_collections(self, *args):
         oncard = None

--- a/src/calibre/gui2/actions/edit_metadata.py
+++ b/src/calibre/gui2/actions/edit_metadata.py
@@ -77,7 +77,7 @@ class EditMetadataAction(InterfaceAction):
                 shortcut='Ctrl+D')
         self.metadata_menu = md
 
-        mb = QMenu()
+        self.metamerge_menu = mb = QMenu()
         cm2 = partial(self.create_menu_action, mb)
         cm2('merge delete', _('Merge into first selected book - delete others'),
                 triggered=self.merge_books)
@@ -102,7 +102,9 @@ class EditMetadataAction(InterfaceAction):
     def location_selected(self, loc):
         enabled = loc == 'library'
         self.qaction.setEnabled(enabled)
-        self.action_merge.setEnabled(enabled)
+        self.menuless_qaction.setEnabled(enabled)
+        for action in self.metamerge_menu.actions() + self.metadata_menu.actions():
+            action.setEnabled(enabled)
 
     def copy_metadata(self):
         rows = self.gui.library_view.selectionModel().selectedRows()

--- a/src/calibre/gui2/actions/fetch_news.py
+++ b/src/calibre/gui2/actions/fetch_news.py
@@ -23,6 +23,7 @@ class FetchNewsAction(InterfaceAction):
     def location_selected(self, loc):
         enabled = loc == 'library'
         self.qaction.setEnabled(enabled)
+        self.menuless_qaction.setEnabled(enabled)
 
     def genesis(self):
         self.conversion_jobs = {}

--- a/src/calibre/gui2/actions/mark_books.py
+++ b/src/calibre/gui2/actions/mark_books.py
@@ -95,6 +95,9 @@ class MarkBooksAction(InterfaceAction):
     def location_selected(self, loc):
         enabled = loc == 'library'
         self.qaction.setEnabled(enabled)
+        self.menuless_qaction.setEnabled(enabled)
+        for action in self.menu.actions():
+            action.setEnabled(enabled)
 
     def toggle_selected(self):
         book_ids = self._get_selected_ids()

--- a/src/calibre/gui2/actions/match_books.py
+++ b/src/calibre/gui2/actions/match_books.py
@@ -27,6 +27,7 @@ class MatchBookAction(InterfaceAction):
     def location_selected(self, loc):
         enabled = loc != 'library'
         self.qaction.setEnabled(enabled)
+        self.menuless_qaction.setEnabled(enabled)
 
     def match_books_in_library(self, *args):
         view = self.gui.current_view()

--- a/src/calibre/gui2/actions/open.py
+++ b/src/calibre/gui2/actions/open.py
@@ -23,5 +23,6 @@ class OpenFolderAction(InterfaceAction):
     def location_selected(self, loc):
         enabled = loc == 'library'
         self.qaction.setEnabled(enabled)
+        self.menuless_qaction.setEnabled(enabled)
 
 

--- a/src/calibre/gui2/actions/polish.py
+++ b/src/calibre/gui2/actions/polish.py
@@ -435,6 +435,7 @@ class PolishAction(InterfaceAction):
     def location_selected(self, loc):
         enabled = loc == 'library'
         self.qaction.setEnabled(enabled)
+        self.menuless_qaction.setEnabled(enabled)
 
     def get_books_for_polishing(self):
         rows = [r.row() for r in

--- a/src/calibre/gui2/actions/random.py
+++ b/src/calibre/gui2/actions/random.py
@@ -25,6 +25,7 @@ class PickRandomAction(InterfaceAction):
     def location_selected(self, loc):
         enabled = loc == 'library'
         self.qaction.setEnabled(enabled)
+        self.menuless_qaction.setEnabled(enabled)
 
     def pick_random(self):
         pick = random.randint(0, self.gui.library_view.model().rowCount(None))

--- a/src/calibre/gui2/actions/sort.py
+++ b/src/calibre/gui2/actions/sort.py
@@ -41,7 +41,9 @@ class SortByAction(InterfaceAction):
         self.qaction.menu().aboutToShow.connect(self.about_to_show)
 
     def location_selected(self, loc):
-        self.qaction.setEnabled(loc == 'library')
+        enabled = loc == 'library'
+        self.qaction.setEnabled(enabled)
+        self.menuless_qaction.setEnabled(enabled)
 
     def about_to_show(self):
         self.update_menu()


### PR DESCRIPTION
As discussed in https://bugs.launchpad.net/bugs/1793800

Tested on Win10, Ubuntu18.04(VM), MacOS10.14(VM).

(Tested and committed against v3.31.0 tag because kovidgoyal/calibre master currently fails to start reporting missing `calibre\resources\localization\iso639.calibre_msgpack` file.)

### Changes:
Everywhere `self.qaction.setEnabled()` called, add `self.menuless_qaction.setEnabled()`.

`__init__.py`
Add `self.location_selected('library')` to end of `InterfaceAction.do_genesis()` for benefit of device-only actions.

`convert.py`
`edit_metadata.py`
`mark_books.py`
Also disable menu items while on device.

### Notable non-changes:
`copy_to_library.py`
`sort.py`
`fetch_news.py`
qaction / menu items don't allow keyboard shortcuts.

`device.py`
Connect/Share menu items are not disabled in device view.  Don't want to risk conflict with existing en/disable code.

`next_match.py`
Includes code that is now redundant with self.location_selected('library') in InterfaceAction.do_genesis()