### PR TITLE
Add context menu with View & Edit to Edit metadata formats list

### DIFF
--- a/src/calibre/gui2/actions/edit_metadata.py
+++ b/src/calibre/gui2/actions/edit_metadata.py
@@ -418,6 +418,7 @@ class EditMetadataAction(InterfaceAction):
         db = self.gui.library_view.model().db
         changed, rows_to_refresh = edit_metadata(db, row_list, current_row,
                 parent=self.gui, view_slot=self.view_format_callback,
+                edit_slot=self.edit_format_callback,
                 set_current_callback=self.set_current_callback, editing_multiple=editing_multiple)
         return changed, rows_to_refresh
 
@@ -434,6 +435,10 @@ class EditMetadataAction(InterfaceAction):
         else:
             db = self.gui.library_view.model().db
             view.view_format(db.row(id_), fmt)
+
+    def edit_format_callback(self, id_, fmt):
+        edit = self.gui.iactions['Tweak ePub']
+        edit.ebook_edit_format(id_, fmt)
 
     def edit_bulk_metadata(self, checked):
         '''

--- a/src/calibre/gui2/actions/tweak_epub.py
+++ b/src/calibre/gui2/actions/tweak_epub.py
@@ -126,6 +126,16 @@ class TweakEpubAction(InterfaceAction):
                 tweakable_fmts = {fmts[0]}
 
         fmt = tuple(tweakable_fmts)[0]
+        self.ebook_edit_format(book_id, fmt)
+
+    def ebook_edit_format(self, book_id, fmt):
+        '''
+        Also called from edit_metadata formats list.  In that context,
+        SUPPORTED check was already done.
+        '''
+        db = self.gui.library_view.model().db
+        from calibre.gui2.tweak_book import tprefs
+        tprefs.refresh()  # In case they were changed in a Tweak Book process
         path = db.new_api.format_abspath(book_id, fmt)
         if path is None:
             return error_dialog(self.gui, _('File missing'), _(

--- a/src/calibre/gui2/metadata/basic_widgets.py
+++ b/src/calibre/gui2/metadata/basic_widgets.py
@@ -779,7 +779,7 @@ class ViewAction(QAction):
 
     def __init__(self, item, parent):
         self.item = item
-        QAction.__init__(self, _('View')+' '+item.ext.upper(), parent)
+        QAction.__init__(self, _('&View')+' '+item.ext.upper(), parent)
         self.triggered.connect(self._triggered)
 
     def _triggered(self):
@@ -791,7 +791,7 @@ class EditAction(QAction):
 
     def __init__(self, item, parent):
         self.item = item
-        QAction.__init__(self, _('Edit')+' '+item.ext.upper(), parent)
+        QAction.__init__(self, _('&Edit')+' '+item.ext.upper(), parent)
         self.triggered.connect(self._triggered)
 
     def _triggered(self):

--- a/src/calibre/gui2/metadata/single.py
+++ b/src/calibre/gui2/metadata/single.py
@@ -51,6 +51,7 @@ class ScrollArea(QScrollArea):
 class MetadataSingleDialogBase(QDialog):
 
     view_format = pyqtSignal(object, object)
+    edit_format = pyqtSignal(object, object)
     cc_two_column = tweaks['metadata_single_use_2_cols_for_custom_fields']
     one_line_comments_toolbar = False
     use_toolbutton_for_config_metadata = True
@@ -352,6 +353,23 @@ class MetadataSingleDialogBase(QDialog):
         else:
             self.view_format.emit(self.book_id, fmt)
 
+    def do_edit_format(self, path, fmt):
+        if self.was_data_edited:
+            from calibre.gui2.tweak_book import tprefs
+            tprefs.refresh()  # In case they were changed in a Tweak Book process
+            from calibre.gui2 import question_dialog
+            if tprefs['update_metadata_from_calibre'] and question_dialog(
+                    self, _('Save Changed Metadata?'),
+                    _("You've changed the metadata for this book."
+                      " Edit book is set to update embedded metadata when opened."
+                      " You need to save your changes for them to be included."),
+                    yes_text=_('&Save'), no_text=_("&Don't Save"),
+                    yes_icon='dot_green.png', no_icon='dot_red.png',
+                    default_yes=False, skip_dialog_name='edit-metadata-save-before-edit-format'):
+                if self.apply_changes():
+                    self.was_data_edited = False
+        self.edit_format.emit(self.book_id, fmt)
+
     def copy_fmt(self, fmt, f):
         self.db.copy_format_to(self.book_id, fmt, f, index_is_id=True)
 
@@ -644,12 +662,14 @@ class MetadataSingleDialogBase(QDialog):
             traceback.print_exc()
 
     # Dialog use methods {{{
-    def start(self, row_list, current_row, view_slot=None,
+    def start(self, row_list, current_row, view_slot=None, edit_slot=None,
             set_current_callback=None):
         self.row_list = row_list
         self.current_row = current_row
         if view_slot is not None:
             self.view_format.connect(view_slot)
+        if edit_slot is not None:
+            self.edit_format.connect(edit_slot)
         self.set_current_callback = set_current_callback
         self.do_one(apply_changes=False)
         ret = self.exec_()
@@ -706,6 +726,7 @@ class MetadataSingleDialogBase(QDialog):
             except:
                 pass  # Fails if view format was never connected
         disconnect(self.view_format)
+        disconnect(self.edit_format)
         for b in ('next_button', 'prev_button'):
             x = getattr(self, b, None)
             if x is not None:
@@ -1164,14 +1185,14 @@ editors = {'default': MetadataSingleDialog, 'alt1': MetadataSingleDialogAlt1,
            'alt2': MetadataSingleDialogAlt2}
 
 
-def edit_metadata(db, row_list, current_row, parent=None, view_slot=None,
+def edit_metadata(db, row_list, current_row, parent=None, view_slot=None, edit_slot=None,
         set_current_callback=None, editing_multiple=False):
     cls = gprefs.get('edit_metadata_single_layout', '')
     if cls not in editors:
         cls = 'default'
     d = editors[cls](db, parent, editing_multiple=editing_multiple)
     try:
-        d.start(row_list, current_row, view_slot=view_slot,
+        d.start(row_list, current_row, view_slot=view_slot, edit_slot=edit_slot,
                 set_current_callback=set_current_callback)
         return d.changed, d.rows_to_refresh
     finally:

--- a/src/calibre/gui2/metadata/single.py
+++ b/src/calibre/gui2/metadata/single.py
@@ -365,7 +365,7 @@ class MetadataSingleDialogBase(QDialog):
                       " You need to save your changes for them to be included."),
                     yes_text=_('&Save'), no_text=_("&Don't Save"),
                     yes_icon='dot_green.png', no_icon='dot_red.png',
-                    default_yes=False, skip_dialog_name='edit-metadata-save-before-edit-format'):
+                    default_yes=True, skip_dialog_name='edit-metadata-save-before-edit-format'):
                 if self.apply_changes():
                     self.was_data_edited = False
         self.edit_format.emit(self.book_id, fmt)


### PR DESCRIPTION
Feature change for Context (right-click) menu in Edit metadata formats list.

- View for any format type, duplicates double-click feature.
- Edit for 'Edit book' supported types only.
- Prompt to save metadata before Edit book, if metadata was changed and `update_metadata_from_calibre`.
- 'Restore XXX from the original' functionality retained as-is.

99% of the time, I want to edit epub.  But for that 1% I want to edit azw3, this gives me a better option than going into Edit book to change the "Ask which format" setting.  (Especially since that setting is kind of hard to find once you've changed it from the dialog in Calibre.  I had to search the source to find it.)

Tested on Win10, Ubuntu18.04(VM), MacOS10.14(VM).

(Tested and committed against v3.31.0 tag because kovidgoyal/calibre master currently fails to start reporting missing calibre\resources\localization\iso639.calibre_msgpack file.)