### PR TITLE
Gnome notifications fix

### DIFF
--- a/src/calibre/gui2/notify.py
+++ b/src/calibre/gui2/notify.py
@@ -76,7 +76,7 @@ class FDONotifier(DBUSNotifier):
         timeout, body, summary = self.get_msg_parms(timeout, body, summary)
         try:
             self._notify.Notify('calibre', replaces_id, self.ICON, summary, body,
-                self.dbus.Array(signature='s'), self.dbus.Dictionary(signature='sv'),
+                self.dbus.Array(signature='s'), self.dbus.Dictionary({"desktop-entry": "calibre-gui"}, signature='sv'),
                 timeout)
         except:
             import traceback

--- a/src/calibre/linux.py
+++ b/src/calibre/linux.py
@@ -1039,6 +1039,7 @@ TryExec=calibre
 Exec=calibre --detach %F
 Icon=calibre-gui
 Categories=Office;
+X-GNOME-UsesNotifications=true
 '''
 
 


### PR DESCRIPTION
Due to Gnome Guidelines https://wiki.gnome.org/Initiatives/GnomeGoals/NotificationSource

Now, due to the absence of these parameters, notifications from the calibre are displayed as "Others"