### PR TITLE
Use builtin zlib in py3

### DIFF
--- a/setup/extensions.json
+++ b/setup/extensions.json
@@ -31,7 +31,8 @@
         "inc_dirs": "!zlib_inc_dirs",
         "lib_dirs": "!zlib_lib_dirs",
         "libraries": "z",
-        "windows_libraries": "zlib"
+        "windows_libraries": "zlib",
+        "needs_py2": true
     },
     {
         "name": "certgen",

--- a/src/calibre/srv/http_response.py
+++ b/src/calibre/srv/http_response.py
@@ -12,9 +12,8 @@ from io import BytesIO, DEFAULT_BUFFER_SIZE
 from itertools import chain, repeat, izip_longest
 from operator import itemgetter
 from functools import wraps
-from polyglot.builtins import map
 
-from polyglot.builtins import reraise
+from polyglot.builtins import reraise, map, is_py3
 
 from calibre import guess_type, force_unicode
 from calibre.constants import __version__, plugins
@@ -31,10 +30,13 @@ from calibre.utils.monotonic import monotonic
 Range = namedtuple('Range', 'start stop size')
 MULTIPART_SEPARATOR = uuid.uuid4().hex.decode('ascii')
 COMPRESSIBLE_TYPES = {'application/json', 'application/javascript', 'application/xml', 'application/oebps-package+xml'}
-zlib, zlib2_err = plugins['zlib2']
-if zlib2_err:
-    raise RuntimeError('Failed to laod the zlib2 module with error: ' + zlib2_err)
-del zlib2_err
+if is_py3:
+    import zlib
+else:
+    zlib, zlib2_err = plugins['zlib2']
+    if zlib2_err:
+        raise RuntimeError('Failed to load the zlib2 module with error: ' + zlib2_err)
+    del zlib2_err
 
 
 def header_list_to_file(buf):  # {{{


### PR DESCRIPTION
Done by disabling building zlib extension in py3, and falling back to
py's zlib when calibre's zlib extension fails to load.

However, I can't see much point in calibre shipping it's own zlib2 module, in either py2 or py3:

With calibre's zlib2:

```console
$ python2 -m timeit -s  'import test; f = open("./rand", "rb")' -n 2 'list(test.compress_readable_output(f))'
2 loops, best of 3: 1.39 sec per loop
```

With python's zlib2:

```console
$ python3 -m timeit -s  'import test; f = open("./rand", "rb")' -n 2 'list(test.compress_readable_output(f))'
2 loops, best of 5: 1.39 sec per loop
$ python2 -m timeit -s  'import test; f = open("./rand", "rb")' -n 2 'list(test.compress_readable_output(f))'
2 loops, best of 3: 1.4 sec per loop
```

test.py:

```python
import struct
#import zlib2 as zlib
import zlib
from io import DEFAULT_BUFFER_SIZE
def gzip_prefix():
    # See http://www.gzip.org/zlib/rfc-gzip.html
    return b''.join((
        b'\x1f\x8b',       # ID1 and ID2: gzip marker
        b'\x08',           # CM: compression method
        b'\x00',           # FLG: none set
        # MTIME: 4 bytes, set to zero so as not to leak timezone information
        b'\0\0\0\0',
        b'\x02',           # XFL: max compression, slowest algo
        b'\xff',           # OS: unknown
    ))

def compress_readable_output(src_file, compress_level=6):
    crc = zlib.crc32(b"")
    size = 0
    zobj = zlib.compressobj(compress_level,
                            zlib.DEFLATED, -zlib.MAX_WBITS,
                            zlib.DEF_MEM_LEVEL, zlib.Z_DEFAULT_STRATEGY)
    prefix_written = False
    while True:
        data = src_file.read(DEFAULT_BUFFER_SIZE)
        if not data:
            break
        size += len(data)
        crc = zlib.crc32(data, crc)
        data = zobj.compress(data)
        if not prefix_written:
            prefix_written = True
            data = gzip_prefix() + data
        yield data
    yield zobj.flush() + struct.pack(b"<L", crc & 0xfffff
```

`./rand` is 256MiB of random data.

Unless there's something I'm missing, I propose rejecting this PR and instead deleting `zlib2.c`. I'd be happy to make a PR for that too.