### PR TITLE
Fix incorrect memcpy

### DIFF
--- a/src/calibre/utils/icu_calibre_utils.h
+++ b/src/calibre/utils/icu_calibre_utils.h
@@ -158,7 +158,7 @@ static UChar* python_to_icu(PyObject *obj, int32_t *osz) {
                 ans[i] = data[i];
             }
         } else {
-            memcpy(ans, data, sz);
+            memcpy(ans, data, sz * sizeof(UChar));
         }
         // add null terminator
         ans[sz] = 0;


### PR DESCRIPTION
I was looking at your changes to `python_to_icu32` and realized that I messed up the call to memcpy in `python_to_icu`.