### PR TITLE
Build tokenizer on py3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ recipes/debug
 /.metadata/
 .idea
 /*env*/
+cmake-build-*

--- a/src/calibre/gui2/tweak_book/editor/syntax/html.c
+++ b/src/calibre/gui2/tweak_book/editor/syntax/html.c
@@ -386,6 +386,18 @@ html_init(PyObject *self, PyObject *args) {
     Py_RETURN_NONE;
 }
 
+static inline long number_to_long(PyObject *number) {
+#if PY_VERSION_HEX >= 0x03030000
+    return PyLong_AsLong(number);
+#else
+    if(PyInt_Check(number)) {
+        return PyInt_AS_LONG(number);
+    } else {
+        return PyLong_AsLong(number);
+    }
+#endif
+}
+
 static PyObject*
 html_check_spelling(PyObject *self, PyObject *args) {
     PyObject *ans = NULL, *temp = NULL, *items = NULL, *text = NULL, *fmt = NULL, *locale = NULL, *sfmt = NULL, *_store_locale = NULL, *t = NULL, *utmp = NULL;
@@ -410,9 +422,9 @@ html_check_spelling(PyObject *self, PyObject *args) {
 
     for (i = 0, j = 0; i < PyList_GET_SIZE(items); i++) {
         temp = PyList_GET_ITEM(items, i);
-        start = PyLong_AsLong(PyTuple_GET_ITEM(temp, 0));
+        start = number_to_long(PyTuple_GET_ITEM(temp, 0));
         if(start == -1 && PyErr_Occurred() != NULL) goto error;
-        length = PyLong_AsLong(PyTuple_GET_ITEM(temp, 1));
+        length = number_to_long(PyTuple_GET_ITEM(temp, 1));
         if(length == -1 && PyErr_Occurred() != NULL) goto error;
         temp = NULL;
 


### PR DESCRIPTION
- The actual unicode manipulation wasn't converted to the new 3.3+
style, since it would lead to lots of ifdefs and become quite ugly. This
can be done when py2 support is dropped. The drawbacks will be
temporary slower code (there will be extra copying required).
- The CLEANUP() macro is also used more extensively to avoid redundant
code

I also used my IDE's formatting tools to add some newlines and make things a little easier to read. If you'd like, I'd be happy to revert these changes. You can ignore the whitespace changes in the github diff by appending `?w=1` to the url.