### PR TITLE
build: add options to use system mathjax

### DIFF
--- a/setup/mathjax.py
+++ b/setup/mathjax.py
@@ -64,10 +64,10 @@ class MathJax(Command):
             self.info('Compressing MathJax...')
             t = SpooledTemporaryFile()
             with ZipFile(t, 'w', ZIP_STORED) as zf:
-                self.add_file(zf, self.j(src, 'unpacked', 'MathJax.js'), 'MathJax.js')
-                self.add_tree(zf, self.j(src, 'fonts', 'HTML-CSS', self.FONT_FAMILY, 'woff'), 'fonts/HTML-CSS/%s/woff' % self.FONT_FAMILY)
+                self.add_file(zf, self.j(src, 'MathJax.js'), 'MathJax.js')
+                self.add_tree(zf, self.j(src, 'fonts', 'HTML-CSS', self.FONT_FAMILY, 'woff'), 'fonts/HTML-CSS/%s/woff' % self.FONT_FAMILY, lambda x: not x.endswith('.woff'))
                 for d in 'extensions jax/element jax/input jax/output/CommonHTML'.split():
-                    self.add_tree(zf, self.j(src, 'unpacked', *d.split('/')), d)
+                    self.add_tree(zf, self.j(src, *d.split('/')), d)
 
                 zf.comment = self.h.hexdigest()
             t.seek(0)


### PR DESCRIPTION
Some mathjax distributions come with the unpacked versions removed as per the upstream instructions for optimizing an installation. There's no reason to explicitly prefer the unpacked version, regardless of the content server using compression.

Also filter the .woff files to make sure they are actually .woff files, since they may be files like fonts.dir, fonts.scale, .uuid (created by xorg-mkfontdir, xorg-mkfontscale, fontconfig).

My motivation for this change is so I can have my calibre-git distro package use a makedepends on mathjax and pack up the contents of /usr/share/mathjax (which is an optimized version).