### PR TITLE
Fix the tag browser not using the existing user category icon …

### DIFF
--- a/src/calibre/gui2/tag_browser/model.py
+++ b/src/calibre/gui2/tag_browser/model.py
@@ -424,7 +424,9 @@ class TagsModel(QAbstractItemModel):  # {{{
             if self.category_custom_icons.get(key, None) is None:
                 self.category_custom_icons[key] = QIcon(I(
                     category_icon_map['gst'] if is_gst else
-                    category_icon_map.get(key, category_icon_map['custom:'])))
+                        category_icon_map.get(key,
+                            (category_icon_map['user:'] if key.startswith('@') else
+                                category_icon_map['custom:']))))
 
             if key.startswith('@'):
                 path_parts = [p for p in key.split('.')]


### PR DESCRIPTION
…(tb_folder.png). Alternate fix for #1810217.

Note: the icon suggested in the enhancement request requires attribution, so I didn't use it.