### PR TITLE
Catch exception if the series index is somehow None

### DIFF
--- a/src/calibre/devices/kobo/driver.py
+++ b/src/calibre/devices/kobo/driver.py
@@ -3033,7 +3033,7 @@ class KOBOTOUCH(KOBO):
 
         series_changed = not (newmi.series == kobo_metadata.series)
         series_number_changed = False
-        if kobo_metadata.series_index:
+        if kobo_metadata.series_index is not None:
             try:
                 kobo_series_number = float(book.kobo_series_number)
             except:
@@ -3041,9 +3041,12 @@ class KOBOTOUCH(KOBO):
             series_number_changed = not (kobo_series_number == newmi.series_index)
 
         if series_changed or series_number_changed:
-            if newmi.series:
+            if newmi.series is not None:
                 new_series = newmi.series
-                new_series_number = "%g" % newmi.series_index
+                try:
+                    new_series_number = "%g" % newmi.series_index
+                except:
+                    new_series_number = None
             else:
                 new_series = None
                 new_series_number = None


### PR DESCRIPTION
I can't see how you can get to this line with the series index not set, but someone has, and it should have been done this way for safety.