### PR TITLE
build: preserve symlinks when installing

### DIFF
--- a/setup/install.py
+++ b/setup/install.py
@@ -259,7 +259,7 @@ class Install(Develop):
         if os.path.exists(dest):
             shutil.rmtree(dest)
         self.info('Installing resources to', dest)
-        shutil.copytree(self.RESOURCES, dest)
+        shutil.copytree(self.RESOURCES, dest, symlinks=True)
         self.manifest.append(dest)
 
     def success(self):


### PR DESCRIPTION
Without this, python's default behavior was to dereference the mathjax symlinks and install the file contents instead.