### PR TITLE
Sort-of fix for #1812560: editing datetimes with iso format doesn't work

### DIFF
--- a/src/calibre/gui2/custom_column_widgets.py
+++ b/src/calibre/gui2/custom_column_widgets.py
@@ -308,6 +308,8 @@ class DateTime(Base):
         format_ = cm['display'].get('date_format','')
         if not format_:
             format_ = 'dd MMM yyyy hh:mm'
+        elif format_ == 'iso':
+            format_ = 'yyyy-MM-ddTHH:mm:ss'
         w.setDisplayFormat(format_)
         w.setCalendarPopup(True)
         w.setMinimumDateTime(UNDEFINED_QDATETIME)
@@ -1027,6 +1029,8 @@ class BulkDateTime(BulkBase):
         format = cm['display'].get('date_format','')
         if not format:
             format = 'dd MMM yyyy'
+        elif format == 'iso':
+            format = 'yyyy-MM-ddTHH:mm:ss'
         w.setDisplayFormat(format)
         w.setCalendarPopup(True)
         w.setMinimumDateTime(UNDEFINED_QDATETIME)

--- a/src/calibre/gui2/custom_column_widgets.py
+++ b/src/calibre/gui2/custom_column_widgets.py
@@ -1026,12 +1026,12 @@ class BulkDateTime(BulkBase):
         l.addStretch(2)
 
         w = self.main_widget
-        format = cm['display'].get('date_format','')
-        if not format:
-            format = 'dd MMM yyyy'
-        elif format == 'iso':
-            format = 'yyyy-MM-ddTHH:mm:ss'
-        w.setDisplayFormat(format)
+        format_ = cm['display'].get('date_format','')
+        if not format_:
+            format_ = 'dd MMM yyyy'
+        elif format_ == 'iso':
+            format_ = 'yyyy-MM-ddTHH:mm:ss'
+        w.setDisplayFormat(format_)
         w.setCalendarPopup(True)
         w.setMinimumDateTime(UNDEFINED_QDATETIME)
         w.setSpecialValueText(_('Undefined'))

--- a/src/calibre/gui2/dialogs/metadata_bulk.py
+++ b/src/calibre/gui2/dialogs/metadata_bulk.py
@@ -515,6 +515,8 @@ class MetadataBulkDialog(QDialog, Ui_MetadataBulkDialog):
         self.adddate_cw = CalendarWidget(self.adddate)
         self.adddate.setCalendarWidget(self.adddate_cw)
         adddate_format = tweaks['gui_timestamp_display_format']
+        if adddate_format == 'iso':
+            adddate_format = 'yyyy-MM-ddTHH:mm:ss'
         if adddate_format is not None:
             self.adddate.setDisplayFormat(adddate_format)
         self.adddate.setSpecialValueText(_('Undefined'))

--- a/src/calibre/gui2/dialogs/metadata_bulk.py
+++ b/src/calibre/gui2/dialogs/metadata_bulk.py
@@ -503,6 +503,8 @@ class MetadataBulkDialog(QDialog, Ui_MetadataBulkDialog):
         self.pubdate_cw = CalendarWidget(self.pubdate)
         self.pubdate.setCalendarWidget(self.pubdate_cw)
         pubdate_format = tweaks['gui_pubdate_display_format']
+        if pubdate_format == 'iso':
+            pubdate_format = 'yyyy-MM-ddTHH:mm:ss'
         if pubdate_format is not None:
             self.pubdate.setDisplayFormat(pubdate_format)
         self.pubdate.setSpecialValueText(_('Undefined'))

--- a/src/calibre/gui2/library/delegates.py
+++ b/src/calibre/gui2/library/delegates.py
@@ -111,13 +111,15 @@ class UpdateEditorGeometry(object):
 
 class DateTimeEdit(QDateTimeEdit):  # {{{
 
-    def __init__(self, parent, format):
+    def __init__(self, parent, format_):
         QDateTimeEdit.__init__(self, parent)
         self.setFrame(False)
         self.setMinimumDateTime(UNDEFINED_QDATETIME)
         self.setSpecialValueText(_('Undefined'))
         self.setCalendarPopup(True)
-        self.setDisplayFormat(format)
+        if format_ == 'iso':
+            format_ = 'yyyy-MM-ddTHH:mm:ss'
+        self.setDisplayFormat(format_)
 
     def contextMenuEvent(self, ev):
         m = QMenu(self)

--- a/src/calibre/gui2/metadata/basic_widgets.py
+++ b/src/calibre/gui2/metadata/basic_widgets.py
@@ -1838,6 +1838,8 @@ class DateEdit(make_undoable(QDateTimeEdit), ToMetadataMixin):
         fmt = tweaks[self.TWEAK]
         if fmt is None:
             fmt = self.FMT
+        elif fmt == 'iso':
+            fmt = 'yyyy-MM-ddTHH:mm:ss'
         self.setDisplayFormat(fmt)
         self.setCalendarPopup(True)
         self.cw = CalendarWidget(self)


### PR DESCRIPTION
This fix is suboptimal in that one cannot edit the timezone. This is AFAIK a QDateTimeEdit restriction.