### PR TITLE
Fixed exception not caught in Startup.py thrown by "pthread_setname_np" on Linux

### DIFF
--- a/src/calibre/startup.py
+++ b/src/calibre/startup.py
@@ -199,7 +199,7 @@ if not _run_once:
                             ident = getattr(self, "ident", None)
                             if ident is not None:
                                 pthread_setname_np(ident, name[:15])
-                    except Exception:
+                    except:
                         pass  # Don't care about failure to set name
                 threading.Thread.start = new_start
 


### PR DESCRIPTION
I have noticed that Calibre segfaults during startup on my Void Linux distribution running musl libc.

Turns out, that when the "pthread_setname_np" function throws, the exception handler doesn't catch the exception as it expects a type of Exception, instead, it seems to be something else, which I have not determined, as I deem it insignificant.

Catching all exceptions fixes the issue and doesn't have any side effects.