### PR TITLE
Correct fix for bug  #1812560: 'iso' format not working. The pattern …

### DIFF
--- a/src/calibre/gui2/custom_column_widgets.py
+++ b/src/calibre/gui2/custom_column_widgets.py
@@ -13,7 +13,7 @@ from PyQt5.Qt import (QComboBox, QLabel, QSpinBox, QDoubleSpinBox, QDateTimeEdit
         QSpacerItem, QIcon, QCheckBox, QWidget, QHBoxLayout, QLineEdit,
         QPushButton, QMessageBox, QToolButton, Qt, QPlainTextEdit)
 
-from calibre.utils.date import qt_to_dt, now, as_local_time, as_utc
+from calibre.utils.date import qt_to_dt, now, as_local_time, as_utc, internal_iso_format_string
 from calibre.gui2.complete2 import EditWithComplete
 from calibre.gui2.comments_editor import Editor as CommentsEditor
 from calibre.gui2 import UNDEFINED_QDATETIME, error_dialog
@@ -309,7 +309,7 @@ class DateTime(Base):
         if not format_:
             format_ = 'dd MMM yyyy hh:mm'
         elif format_ == 'iso':
-            format_ = 'yyyy-MM-ddTHH:mm:ss'
+            format_ = internal_iso_format_string()
         w.setDisplayFormat(format_)
         w.setCalendarPopup(True)
         w.setMinimumDateTime(UNDEFINED_QDATETIME)
@@ -1030,7 +1030,7 @@ class BulkDateTime(BulkBase):
         if not format_:
             format_ = 'dd MMM yyyy'
         elif format_ == 'iso':
-            format_ = 'yyyy-MM-ddTHH:mm:ss'
+            format_ = internal_iso_format_string()
         w.setDisplayFormat(format_)
         w.setCalendarPopup(True)
         w.setMinimumDateTime(UNDEFINED_QDATETIME)

--- a/src/calibre/gui2/dialogs/metadata_bulk.py
+++ b/src/calibre/gui2/dialogs/metadata_bulk.py
@@ -28,7 +28,7 @@ from calibre.gui2.dialogs.tag_editor import TagEditor
 from calibre.gui2.dialogs.template_line_editor import TemplateLineEditor
 from calibre.gui2.metadata.basic_widgets import CalendarWidget
 from calibre.utils.config import JSONConfig, dynamic, prefs, tweaks
-from calibre.utils.date import qt_to_dt
+from calibre.utils.date import qt_to_dt, internal_iso_format_string
 from calibre.utils.icu import capitalize, sort_key
 from calibre.utils.titlecase import titlecase
 from calibre.gui2.widgets import LineEditECM
@@ -504,7 +504,7 @@ class MetadataBulkDialog(QDialog, Ui_MetadataBulkDialog):
         self.pubdate.setCalendarWidget(self.pubdate_cw)
         pubdate_format = tweaks['gui_pubdate_display_format']
         if pubdate_format == 'iso':
-            pubdate_format = 'yyyy-MM-ddTHH:mm:ss'
+            pubdate_format = internal_iso_format_string()
         if pubdate_format is not None:
             self.pubdate.setDisplayFormat(pubdate_format)
         self.pubdate.setSpecialValueText(_('Undefined'))
@@ -516,7 +516,7 @@ class MetadataBulkDialog(QDialog, Ui_MetadataBulkDialog):
         self.adddate.setCalendarWidget(self.adddate_cw)
         adddate_format = tweaks['gui_timestamp_display_format']
         if adddate_format == 'iso':
-            adddate_format = 'yyyy-MM-ddTHH:mm:ss'
+            adddate_format = internal_iso_format_string()
         if adddate_format is not None:
             self.adddate.setDisplayFormat(adddate_format)
         self.adddate.setSpecialValueText(_('Undefined'))

--- a/src/calibre/gui2/library/delegates.py
+++ b/src/calibre/gui2/library/delegates.py
@@ -18,7 +18,8 @@ from calibre.constants import iswindows
 from calibre.gui2.widgets import EnLineEdit
 from calibre.gui2.widgets2 import populate_standard_spinbox_context_menu, RatingEditor
 from calibre.gui2.complete2 import EditWithComplete
-from calibre.utils.date import now, format_date, qt_to_dt, is_date_undefined
+from calibre.utils.date import now, format_date, qt_to_dt, is_date_undefined, internal_iso_format_string
+
 from calibre.utils.config import tweaks
 from calibre.utils.icu import sort_key
 from calibre.gui2.dialogs.comments_dialog import CommentsDialog, PlainTextDialog
@@ -118,7 +119,7 @@ class DateTimeEdit(QDateTimeEdit):  # {{{
         self.setSpecialValueText(_('Undefined'))
         self.setCalendarPopup(True)
         if format_ == 'iso':
-            format_ = 'yyyy-MM-ddTHH:mm:ss'
+            format_ = internal_iso_format_string()
         self.setDisplayFormat(format_)
 
     def contextMenuEvent(self, ev):
@@ -431,9 +432,11 @@ class CcDateDelegate(QStyledItemDelegate, UpdateEditorGeometry):  # {{{
         QStyledItemDelegate.__init__(self, parent)
         self.table_widget = parent
 
-    def set_format(self, format):
-        if not format:
+    def set_format(self, _format):
+        if not _format:
             self.format = 'dd MMM yyyy'
+        elif _format == 'iso':
+            self.format = internal_iso_format_string()
         else:
             self.format = format
 

--- a/src/calibre/gui2/metadata/basic_widgets.py
+++ b/src/calibre/gui2/metadata/basic_widgets.py
@@ -29,7 +29,7 @@ from calibre.gui2 import (file_icon_provider, UNDEFINED_QDATETIME,
 from calibre.gui2.complete2 import EditWithComplete
 from calibre.utils.date import (
     local_tz, qt_to_dt, as_local_time, UNDEFINED_DATE, is_date_undefined,
-    utcfromtimestamp, parse_only_date)
+    utcfromtimestamp, parse_only_date, internal_iso_format_string)
 from calibre import strftime
 from calibre.ebooks import BOOK_EXTENSIONS
 from calibre.customize.ui import run_plugins_on_import
@@ -1839,7 +1839,7 @@ class DateEdit(make_undoable(QDateTimeEdit), ToMetadataMixin):
         if fmt is None:
             fmt = self.FMT
         elif fmt == 'iso':
-            fmt = 'yyyy-MM-ddTHH:mm:ss'
+            fmt = internal_iso_format_string()
         self.setDisplayFormat(fmt)
         self.setCalendarPopup(True)
         self.cw = CalendarWidget(self)

--- a/src/calibre/utils/date.py
+++ b/src/calibre/utils/date.py
@@ -194,6 +194,8 @@ def isoformat(date_time, assume_utc=False, as_utc=True, sep='T'):
     # str(sep) because isoformat barfs with unicode sep on python 2.x
     return unicode(date_time.isoformat(str(sep)))
 
+def internal_iso_format_string():
+    return 'yyyy-MM-ddThh:mm:ss'
 
 def w3cdtf(date_time, assume_utc=False):
     if hasattr(date_time, 'tzinfo'):


### PR DESCRIPTION
…HH doesn't appear to work in the current Qt, and one place where 'iso' needed to be matched was missed.