### PR TITLE
py3: finish up the rest of the C extension ports

### DIFF
--- a/src/calibre/devices/libusb/libusb.c
+++ b/src/calibre/devices/libusb/libusb.c
@@ -115,6 +115,8 @@ static PyObject* get_devices(PyObject *self, PyObject *args) {
     return ans;
 }
 
+static char libusb_doc[] = "Interface to libusb.";
+
 static PyMethodDef libusb_methods[] = {
     {"get_devices", get_devices, METH_VARARGS,
         "get_devices()\n\nGet the list of USB devices on the system."
@@ -123,26 +125,55 @@ static PyMethodDef libusb_methods[] = {
     {NULL, NULL, 0, NULL}
 };
 
-CALIBRE_MODINIT_FUNC
-initlibusb(void) {
+#if PY_MAJOR_VERSION >= 3
+#define INITERROR return NULL
+#define INITMODULE PyModule_Create(&libusb_module)
+static struct PyModuleDef libusb_module = {
+    /* m_base     */ PyModuleDef_HEAD_INIT,
+    /* m_name     */ "libusb",
+    /* m_doc      */ libusb_doc,
+    /* m_size     */ -1,
+    /* m_methods  */ libusb_methods,
+    /* m_slots    */ 0,
+    /* m_traverse */ 0,
+    /* m_clear    */ 0,
+    /* m_free     */ 0,
+};
+CALIBRE_MODINIT_FUNC PyInit_libusb(void) {
+#else
+#define INITERROR return
+#define INITMODULE Py_InitModule3("libusb", libusb_methods, libusb_doc)
+CALIBRE_MODINIT_FUNC initlibusb(void) {
+#endif
+
     PyObject *m;
 
     // We deliberately use the default context. This is the context used by
     // libmtp and we want to ensure that the busnum/devnum numbers are the same
     // here and for libmtp.
-    if(libusb_init(NULL) != 0) return;
+    if(libusb_init(NULL) != 0) {
+        INITERROR;
+    }
 
     Error = PyErr_NewException("libusb.Error", NULL, NULL);
-    if (Error == NULL) return;
+    if (Error == NULL) {
+        INITERROR;
+    }
 
     cache = PyDict_New();
-    if (cache == NULL) return;
+    if (cache == NULL) {
+        INITERROR;
+    }
 
-    m = Py_InitModule3("libusb", libusb_methods, "Interface to libusb.");
-    if (m == NULL) return;
+    m = INITMODULE;
+    if (m == NULL) {
+        INITERROR;
+    }
 
     PyModule_AddObject(m, "Error", Error);
     PyModule_AddObject(m, "cache", cache);
 
+#if PY_MAJOR_VERSION >= 3
+    return m;
+#endif
 }
-

--- a/src/calibre/devices/mtp/windows/device.cpp
+++ b/src/calibre/devices/mtp/windows/device.cpp
@@ -204,43 +204,42 @@ static PyGetSetDef Device_getsetters[] = {
 
 
 PyTypeObject wpd::DeviceType = { // {{{
-    PyObject_HEAD_INIT(NULL)
-    0,                         /*ob_size*/
-    "wpd.Device",            /*tp_name*/
-    sizeof(Device),      /*tp_basicsize*/
-    0,                         /*tp_itemsize*/
-    (destructor)dealloc, /*tp_dealloc*/
-    0,                         /*tp_print*/
-    0,                         /*tp_getattr*/
-    0,                         /*tp_setattr*/
-    0,                         /*tp_compare*/
-    0,                         /*tp_repr*/
-    0,                         /*tp_as_number*/
-    0,                         /*tp_as_sequence*/
-    0,                         /*tp_as_mapping*/
-    0,                         /*tp_hash */
-    0,                         /*tp_call*/
-    0,                         /*tp_str*/
-    0,                         /*tp_getattro*/
-    0,                         /*tp_setattro*/
-    0,                         /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE,        /*tp_flags*/
-    "Device",                  /* tp_doc */
-    0,		               /* tp_traverse */
-    0,		               /* tp_clear */
-    0,		               /* tp_richcompare */
-    0,		               /* tp_weaklistoffset */
-    0,		               /* tp_iter */
-    0,		               /* tp_iternext */
-    Device_methods,             /* tp_methods */
-    0,             /* tp_members */
-    Device_getsetters,                         /* tp_getset */
-    0,                         /* tp_base */
-    0,                         /* tp_dict */
-    0,                         /* tp_descr_get */
-    0,                         /* tp_descr_set */
-    0,                         /* tp_dictoffset */
-    (initproc)init,      /* tp_init */
-    0,                         /* tp_alloc */
-    0,                 /* tp_new */
+    PyVarObject_HEAD_INIT(NULL, 0)
+    /* tp_name           */ "wpd.Device",
+    /* tp_basicsize      */ sizeof(Device),
+    /* tp_itemsize       */ 0,
+    /* tp_dealloc        */ (destructor)dealloc,
+    /* tp_print          */ 0,
+    /* tp_getattr        */ 0,
+    /* tp_setattr        */ 0,
+    /* tp_compare        */ 0,
+    /* tp_repr           */ 0,
+    /* tp_as_number      */ 0,
+    /* tp_as_sequence    */ 0,
+    /* tp_as_mapping     */ 0,
+    /* tp_hash           */ 0,
+    /* tp_call           */ 0,
+    /* tp_str            */ 0,
+    /* tp_getattro       */ 0,
+    /* tp_setattro       */ 0,
+    /* tp_as_buffer      */ 0,
+    /* tp_flags          */ Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE,
+    /* tp_doc            */ "Device",
+    /* tp_traverse       */ 0,
+    /* tp_clear          */ 0,
+    /* tp_richcompare    */ 0,
+    /* tp_weaklistoffset */ 0,
+    /* tp_iter           */ 0,
+    /* tp_iternext       */ 0,
+    /* tp_methods        */ Device_methods,
+    /* tp_members        */ 0,
+    /* tp_getset         */ Device_getsetters,
+    /* tp_base           */ 0,
+    /* tp_dict           */ 0,
+    /* tp_descr_get      */ 0,
+    /* tp_descr_set      */ 0,
+    /* tp_dictoffset     */ 0,
+    /* tp_init           */ (initproc)init,
+    /* tp_alloc          */ 0,
+    /* tp_new            */ 0,
 }; // }}}

--- a/src/calibre/devices/mtp/windows/wpd.cpp
+++ b/src/calibre/devices/mtp/windows/wpd.cpp
@@ -161,6 +161,8 @@ wpd_device_info(PyObject *self, PyObject *args) {
     return ans;
 } // }}}
 
+static char wpd_doc[] = "Interface to the WPD windows service.";
+
 static PyMethodDef wpd_methods[] = {
     {"init", wpd_init, METH_VARARGS,
         "init(name, major_version, minor_version, revision)\n\n Initializes this module. Call this method *only* in the thread in which you intend to use this module. Also remember to call uninit before the thread exits."
@@ -181,33 +183,60 @@ static PyMethodDef wpd_methods[] = {
     {NULL, NULL, 0, NULL}
 };
 
+#if PY_MAJOR_VERSION >= 3
+#define INITERROR return NULL
+#define INITMODULE PyModule_Create(&wpd_module)
+static struct PyModuleDef wpd_module = {
+    /* m_base     */ PyModuleDef_HEAD_INIT,
+    /* m_name     */ "wpd",
+    /* m_doc      */ wpd_doc,
+    /* m_size     */ -1,
+    /* m_methods  */ wpd_methods,
+    /* m_slots    */ 0,
+    /* m_traverse */ 0,
+    /* m_clear    */ 0,
+    /* m_free     */ 0,
+};
+CALIBRE_MODINIT_FUNC PyInit_wpd(void) {
+#else
+#define INITERROR return
+#define INITMODULE Py_InitModule3("wpd", wpd_methods, wpd_doc)
+CALIBRE_MODINIT_FUNC initwpd(void) {
+#endif
 
-CALIBRE_MODINIT_FUNC
-initwpd(void) {
     PyObject *m;
 
     wpd::DeviceType.tp_new = PyType_GenericNew;
     if (PyType_Ready(&wpd::DeviceType) < 0)
         return;
 
-    m = Py_InitModule3("wpd", wpd_methods, "Interface to the WPD windows service.");
-    if (m == NULL) return;
+    m = INITMODULE;
+    if (m == NULL) {
+        INITERROR;
+    }
 
     WPDError = PyErr_NewException("wpd.WPDError", NULL, NULL);
-    if (WPDError == NULL) return;
+    if (WPDError == NULL) {
+        INITERROR;
+    }
     PyModule_AddObject(m, "WPDError", WPDError);
 
     NoWPD = PyErr_NewException("wpd.NoWPD", NULL, NULL);
-    if (NoWPD == NULL) return;
+    if (NoWPD == NULL) {
+        INITERROR;
+    }
     PyModule_AddObject(m, "NoWPD", NoWPD);
 
     WPDFileBusy = PyErr_NewException("wpd.WPDFileBusy", NULL, NULL);
-    if (WPDFileBusy == NULL) return;
+    if (WPDFileBusy == NULL) {
+        INITERROR;
+    }
     PyModule_AddObject(m, "WPDFileBusy", WPDFileBusy);
 
     Py_INCREF(&DeviceType);
     PyModule_AddObject(m, "Device", (PyObject *)&DeviceType);
 
+#if PY_MAJOR_VERSION >= 3
+    return m;
+#endif
 }
-
-

--- a/src/calibre/devices/usbobserver/usbobserver.c
+++ b/src/calibre/devices/usbobserver/usbobserver.c
@@ -457,6 +457,8 @@ end:
     return ans;
 }
 
+static char usbobserver_doc[] = "USB interface glue for OSX.";
+
 static PyMethodDef usbobserver_methods[] = {
     {"get_usb_devices", usbobserver_get_usb_devices, METH_VARARGS,
      "Get list of connected USB devices. Returns a list of tuples. Each tuple is of the form (vendor_id, product_id, bcd, manufacturer, product, serial number)."
@@ -483,7 +485,31 @@ static PyMethodDef usbobserver_methods[] = {
     {NULL, NULL, 0, NULL}
 };
 
-CALIBRE_MODINIT_FUNC
-initusbobserver(void) {
-    (void) Py_InitModule("usbobserver", usbobserver_methods);
+#if PY_MAJOR_VERSION >= 3
+#define INITERROR return NULL
+#define INITMODULE PyModule_Create(&usbobserver_module)
+static struct PyModuleDef usbobserver_module = {
+    /* m_base     */ PyModuleDef_HEAD_INIT,
+    /* m_name     */ "usbobserver",
+    /* m_doc      */ usbobserver_doc,
+    /* m_size     */ -1,
+    /* m_methods  */ usbobserver_methods,
+    /* m_slots    */ 0,
+    /* m_traverse */ 0,
+    /* m_clear    */ 0,
+    /* m_free     */ 0,
+};
+CALIBRE_MODINIT_FUNC PyInit_usbobserver(void) {
+#else
+#define INITERROR return
+#define INITMODULE Py_InitModule3("usbobserver", usbobserver_methods, usbobserver_doc)
+CALIBRE_MODINIT_FUNC initusbobserver(void) {
+#endif
+
+    PyObject *m = NULL;
+    m = INITMODULE;
+
+#if PY_MAJOR_VERSION >= 3
+    return m;
+#endif
 }

--- a/src/calibre/ebooks/compression/palmdoc.c
+++ b/src/calibre/ebooks/compression/palmdoc.c
@@ -190,7 +190,9 @@ cpalmdoc_compress(PyObject *self, PyObject *args) {
     return ans;
 }
 
-static PyMethodDef cPalmdocMethods[] = {
+static char cPalmdoc_doc[] = "Compress and decompress palmdoc strings.";
+
+static PyMethodDef cPalmdoc_methods[] = {
     {"decompress", cpalmdoc_decompress, METH_VARARGS,
     "decompress(bytestring) -> decompressed bytestring\n\n"
     		"Decompress a palmdoc compressed byte string. "
@@ -203,11 +205,34 @@ static PyMethodDef cPalmdocMethods[] = {
     {NULL, NULL, 0, NULL}
 };
 
-CALIBRE_MODINIT_FUNC
-initcPalmdoc(void) {
+#if PY_MAJOR_VERSION >= 3
+#define INITERROR return NULL
+#define INITMODULE PyModule_Create(&cPalmdoc_module)
+static struct PyModuleDef cPalmdoc_module = {
+    /* m_base     */ PyModuleDef_HEAD_INIT,
+    /* m_name     */ "cPalmdoc",
+    /* m_doc      */ cPalmdoc_doc,
+    /* m_size     */ -1,
+    /* m_methods  */ cPalmdoc_methods,
+    /* m_slots    */ 0,
+    /* m_traverse */ 0,
+    /* m_clear    */ 0,
+    /* m_free     */ 0,
+};
+CALIBRE_MODINIT_FUNC PyInit_cPalmdoc(void) {
+#else
+#define INITERROR return
+#define INITMODULE Py_InitModule3("cPalmdoc", cPalmdoc_methods, cPalmdoc_doc)
+CALIBRE_MODINIT_FUNC initcPalmdoc(void) {
+#endif
+
     PyObject *m;
-    m = Py_InitModule3("cPalmdoc", cPalmdocMethods,
-    "Compress and decompress palmdoc strings."
-    );
-    if (m == NULL) return;
+    m = INITMODULE;
+    if (m == NULL) {
+        INITERROR;
+    }
+
+#if PY_MAJOR_VERSION >= 3
+    return m;
+#endif
 }

--- a/src/calibre/utils/fonts/winfonts.cpp
+++ b/src/calibre/utils/fonts/winfonts.cpp
@@ -208,8 +208,9 @@ static PyObject* remove_system_font(PyObject *self, PyObject *args) {
     return Py_BuildValue("O", ok);
 }
 
-static
-PyMethodDef winfonts_methods[] = {
+static char winfonts_doc[] = "Windows font API";
+
+static PyMethodDef winfonts_methods[] = {
     {"enum_font_families", enum_font_families, METH_VARARGS,
     "enum_font_families()\n\n"
         "Enumerate all regular (not italic/bold/etc. variants) font families on the system. Note there will be multiple entries for every family (corresponding to each charset of the font)."
@@ -239,14 +240,32 @@ PyMethodDef winfonts_methods[] = {
 };
 
 
-CALIBRE_MODINIT_FUNC
-initwinfonts(void) {
+#if PY_MAJOR_VERSION >= 3
+#define INITERROR return NULL
+#define INITMODULE PyModule_Create(&winfonts_module)
+static struct PyModuleDef winfonts_module = {
+    /* m_base     */ PyModuleDef_HEAD_INIT,
+    /* m_name     */ "winfonts",
+    /* m_doc      */ winfonts_doc,
+    /* m_size     */ -1,
+    /* m_methods  */ winfonts_methods,
+    /* m_slots    */ 0,
+    /* m_traverse */ 0,
+    /* m_clear    */ 0,
+    /* m_free     */ 0,
+};
+CALIBRE_MODINIT_FUNC PyInit_winfonts(void) {
+#else
+#define INITERROR return
+#define INITMODULE Py_InitModule3("winfonts", winfonts_methods, winfonts_doc)
+CALIBRE_MODINIT_FUNC initwinfonts(void) {
+#endif
+
     PyObject *m;
-    m = Py_InitModule3(
-            "winfonts", winfonts_methods,
-            "Windows font API"
-    );
-    if (m == NULL) return;
+    m = INITMODULE;
+    if (m == NULL) {
+        INITERROR;
+    }
 
     PyModule_AddIntMacro(m, FW_DONTCARE);
     PyModule_AddIntMacro(m, FW_THIN);
@@ -263,4 +282,8 @@ initwinfonts(void) {
     PyModule_AddIntMacro(m, FW_ULTRABOLD);
     PyModule_AddIntMacro(m, FW_HEAVY);
     PyModule_AddIntMacro(m, FW_BLACK);
+
+#if PY_MAJOR_VERSION >= 3
+    return m;
+#endif
 }

--- a/src/calibre/utils/windows/winutil.c
+++ b/src/calibre/utils/windows/winutil.c
@@ -387,8 +387,9 @@ winutil_strftime(PyObject *self, PyObject *args)
     return NULL;
 }
 
+static char winutil_doc[] = "Defines utility methods to interface with windows.";
 
-static PyMethodDef WinutilMethods[] = {
+static PyMethodDef winutil_methods[] = {
     {"special_folder_path", winutil_folder_path, METH_VARARGS,
     "special_folder_path(csidl_id) -> path\n\n"
             "Get paths to common system folders. "
@@ -461,13 +462,33 @@ be a unicode string. Returns unicode strings."
     {NULL, NULL, 0, NULL}
 };
 
-CALIBRE_MODINIT_FUNC
-initwinutil(void) {
+#if PY_MAJOR_VERSION >= 3
+#define INITERROR return NULL
+#define INITMODULE PyModule_Create(&winutil_module)
+static struct PyModuleDef winutil_module = {
+    /* m_base     */ PyModuleDef_HEAD_INIT,
+    /* m_name     */ "winutil",
+    /* m_doc      */ winutil_doc,
+    /* m_size     */ -1,
+    /* m_methods  */ winutil_methods,
+    /* m_slots    */ 0,
+    /* m_traverse */ 0,
+    /* m_clear    */ 0,
+    /* m_free     */ 0,
+};
+CALIBRE_MODINIT_FUNC PyInit_winutil(void) {
+#else
+#define INITERROR return
+#define INITMODULE Py_InitModule3("winutil", winutil_methods, winutil_doc)
+CALIBRE_MODINIT_FUNC initwinutil(void) {
+#endif
+
     PyObject *m;
-    m = Py_InitModule3("winutil", WinutilMethods,
-    "Defines utility methods to interface with windows."
-    );
-    if (m == NULL) return;
+    m = INITMODULE;
+
+    if (m == NULL) {
+        INITERROR;
+    }
 
     PyModule_AddIntConstant(m, "CSIDL_ADMINTOOLS", CSIDL_ADMINTOOLS);
     PyModule_AddIntConstant(m, "CSIDL_APPDATA", CSIDL_APPDATA);
@@ -491,4 +512,7 @@ initwinutil(void) {
     PyModule_AddIntConstant(m, "CSIDL_STARTUP", CSIDL_STARTUP);
     PyModule_AddIntConstant(m, "CSIDL_COMMON_STARTUP", CSIDL_COMMON_STARTUP);
 
+#if PY_MAJOR_VERSION >= 3
+    return m;
+#endif
 }


### PR DESCRIPTION
Just some more basic translation to python3 compatible module definitions, but I cannot even test that they compile properly for the Windows/OSX specific ones. Still, they "should" work.

EDIT: now they do