### PR TITLE
Fix syntax error introduced while getting rid of basestring

### DIFF
--- a/src/odf/userfield.py
+++ b/src/odf/userfield.py
@@ -62,7 +62,7 @@ class UserFields(object):
         self.document = None
 
     def loaddoc(self):
-        if isinstance(self.src_file, (bytes, type(u'')):
+        if isinstance(self.src_file, (bytes, type(u''))):
             # src_file is a filename, check if it is a zip-file
             if not zipfile.is_zipfile(self.src_file):
                 raise TypeError("%s is no odt file." % self.src_file)


### PR DESCRIPTION
Commit 55151a3cdd4e595be49f2392731b972439f51408 tried to replace this with python2/python3 compatible code, but missed the closing quote, so it is compatible with neither. :D
