### PR TITLE
py3: add polyglot wrapper for cPickle and use it everywhere

### DIFF
--- a/src/calibre/db/utils.py
+++ b/src/calibre/db/utils.py
@@ -6,10 +6,11 @@ from __future__ import (unicode_literals, division, absolute_import,
 __license__ = 'GPL v3'
 __copyright__ = '2013, Kovid Goyal <kovid at kovidgoyal.net>'
 
-import os, errno, cPickle, sys, re
+import os, errno, sys, re
 from locale import localeconv
 from collections import OrderedDict, namedtuple
 from polyglot.builtins import map, unicode_type, string_or_bytes
+from polyglot.pickle import pickle
 from threading import Lock
 
 from calibre import as_unicode, prints
@@ -229,7 +230,7 @@ class ThumbnailCache(object):
         if hasattr(self, 'items'):
             try:
                 with open(os.path.join(self.location, 'order'), 'wb') as f:
-                    f.write(cPickle.dumps(tuple(map(hash, self.items)), -1))
+                    f.write(pickle.dumps(tuple(map(hash, self.items)), -1))
             except EnvironmentError as err:
                 self.log('Failed to save thumbnail cache order:', as_unicode(err))
 
@@ -237,7 +238,7 @@ class ThumbnailCache(object):
         order = {}
         try:
             with open(os.path.join(self.location, 'order'), 'rb') as f:
-                order = cPickle.loads(f.read())
+                order = pickle.loads(f.read())
                 order = {k:i for i, k in enumerate(order)}
         except Exception as err:
             if getattr(err, 'errno', None) != errno.ENOENT:

--- a/src/calibre/ebooks/metadata/book/render.py
+++ b/src/calibre/ebooks/metadata/book/render.py
@@ -6,7 +6,7 @@ from __future__ import (unicode_literals, division, absolute_import,
 __license__ = 'GPL v3'
 __copyright__ = '2014, Kovid Goyal <kovid at kovidgoyal.net>'
 
-import os, cPickle
+import os
 from functools import partial
 from binascii import hexlify
 
@@ -21,6 +21,7 @@ from calibre.utils.formatter import EvalFormatter
 from calibre.utils.date import is_date_undefined
 from calibre.utils.localization import calibre_langcode_to_name
 from polyglot.builtins import unicode_type
+from polyglot.pickle import pickle
 
 default_sort = ('title', 'title_sort', 'authors', 'author_sort', 'series', 'rating', 'pubdate', 'tags', 'publisher', 'identifiers')
 
@@ -79,7 +80,7 @@ def author_search_href(which, title=None, author=None):
 
 
 def item_data(field_name, value, book_id):
-    return hexlify(cPickle.dumps((field_name, value, book_id), -1))
+    return hexlify(pickle.dumps((field_name, value, book_id), -1))
 
 
 def mi_to_html(mi, field_list=None, default_author_link=None, use_roman_numbers=True, rating_font='Liberation Serif', rtl=False):

--- a/src/calibre/gui2/book_details.py
+++ b/src/calibre/gui2/book_details.py
@@ -2,7 +2,6 @@
 # vim:fileencoding=UTF-8:ts=4:sw=4:sta:et:sts=4:ai
 # License: GPLv3 Copyright: 2010, Kovid Goyal <kovid at kovidgoyal.net>
 
-import cPickle
 import os
 import re
 from binascii import unhexlify
@@ -35,6 +34,7 @@ from calibre.utils.config import tweaks
 from calibre.utils.img import blend_image, image_from_x
 from calibre.utils.localization import is_rtl
 from polyglot.builtins import unicode_type
+from polyglot.pickle import pickle
 
 _css = None
 InternetSearch = namedtuple('InternetSearch', 'author where')
@@ -286,7 +286,7 @@ def details_context_menu_event(view, ev, book_info):  # {{{
                                    lambda : book_info.search_requested('authors:"={}"'.format(author.replace('"', r'\"'))))
             if data:
                 try:
-                    field, value, book_id = cPickle.loads(unhexlify(data))
+                    field, value, book_id = pickle.loads(unhexlify(data))
                 except Exception:
                     field = value = book_id = None
                 if field:

--- a/src/calibre/gui2/convert/single.py
+++ b/src/calibre/gui2/convert/single.py
@@ -6,7 +6,7 @@ __license__   = 'GPL v3'
 __copyright__ = '2009, Kovid Goyal <kovid@kovidgoyal.net>'
 __docformat__ = 'restructuredtext en'
 
-import cPickle, shutil
+import shutil
 
 from PyQt5.Qt import QAbstractListModel, Qt, QFont, QModelIndex, QDialog, QCoreApplication, QSize
 
@@ -29,6 +29,7 @@ from calibre.ebooks.conversion.config import delete_specifics
 from calibre.customize.conversion import OptionRecommendation
 from calibre.utils.config import prefs
 from polyglot.builtins import unicode_type, range
+from polyglot.pickle import pickle
 
 
 class GroupModel(QAbstractListModel):
@@ -231,7 +232,7 @@ class Config(QDialog, Ui_Dialog):
     def recommendations(self):
         recs = [(k, v, OptionRecommendation.HIGH) for k, v in
                 self._recommendations.items()]
-        return cPickle.dumps(recs, -1)
+        return pickle.dumps(recs, -1)
 
     def show_group_help(self, index):
         widget = self._groups_model.widgets[index.row()]

--- a/src/calibre/gui2/main.py
+++ b/src/calibre/gui2/main.py
@@ -174,9 +174,10 @@ def repair_library(library_path):
 
 def windows_repair(library_path=None):
     from binascii import hexlify, unhexlify
-    import cPickle, subprocess
+    import subprocess
+    from polyglot.pickle import pickle
     if library_path:
-        library_path = hexlify(cPickle.dumps(library_path, -1))
+        library_path = hexlify(pickle.dumps(library_path, -1))
         winutil.prepare_for_restart()
         os.environ['CALIBRE_REPAIR_CORRUPTED_DB'] = library_path
         subprocess.Popen([sys.executable])
@@ -184,7 +185,7 @@ def windows_repair(library_path=None):
         try:
             app = Application([])
             from calibre.gui2.dialogs.restore_library import repair_library_at
-            library_path = cPickle.loads(unhexlify(os.environ.pop('CALIBRE_REPAIR_CORRUPTED_DB')))
+            library_path = pickle.loads(unhexlify(os.environ.pop('CALIBRE_REPAIR_CORRUPTED_DB')))
             done = repair_library_at(library_path, wait_time=4)
         except Exception:
             done = False

--- a/src/calibre/gui2/tag_browser/model.py
+++ b/src/calibre/gui2/tag_browser/model.py
@@ -8,7 +8,7 @@ __license__   = 'GPL v3'
 __copyright__ = '2011, Kovid Goyal <kovid@kovidgoyal.net>'
 __docformat__ = 'restructuredtext en'
 
-import traceback, cPickle, copy, os
+import traceback, copy, os
 from collections import OrderedDict
 
 from PyQt5.Qt import (QAbstractItemModel, QIcon, QFont, Qt,
@@ -24,6 +24,7 @@ from calibre.library.field_metadata import category_icon_map
 from calibre.gui2.dialogs.confirm_delete import confirm
 from calibre.utils.formatter import EvalFormatter
 from polyglot.builtins import range
+from polyglot.pickle import pickle
 
 TAG_SEARCH_STATES = {'clear': 0, 'mark_plus': 1, 'mark_plusplus': 2,
                      'mark_minus': 3, 'mark_minusminus': 4}
@@ -740,7 +741,7 @@ class TagsModel(QAbstractItemModel):  # {{{
                 data.append(d)
             else:
                 data.append(None)
-        raw = bytearray(cPickle.dumps(data, -1))
+        raw = bytearray(pickle.dumps(data, -1))
         ans = QMimeData()
         ans.setData('application/calibre+from_tag_browser', raw)
         return ans
@@ -765,7 +766,7 @@ class TagsModel(QAbstractItemModel):  # {{{
         if not md.hasFormat('application/calibre+from_tag_browser'):
             return False
         data = str(md.data('application/calibre+from_tag_browser'))
-        src = cPickle.loads(data)
+        src = pickle.loads(data)
         for s in src:
             if s[0] != TagTreeItem.TAG:
                 return False

--- a/src/calibre/gui2/tag_browser/view.py
+++ b/src/calibre/gui2/tag_browser/view.py
@@ -7,7 +7,7 @@ __license__   = 'GPL v3'
 __copyright__ = '2011, Kovid Goyal <kovid@kovidgoyal.net>'
 __docformat__ = 'restructuredtext en'
 
-import cPickle, os, re
+import os, re
 from functools import partial
 from itertools import izip
 
@@ -25,6 +25,7 @@ from calibre.gui2.tag_browser.model import (TagTreeItem, TAG_SEARCH_STATES,
 from calibre.gui2 import config, gprefs, choose_files, pixmap_to_data, rating_font, empty_index
 from calibre.utils.icu import sort_key
 from polyglot.builtins import unicode_type, range
+from polyglot.pickle import pickle
 
 
 class TagDelegate(QStyledItemDelegate):  # {{{
@@ -752,7 +753,7 @@ class TagsView(QTreeView):  # {{{
                 if src_is_tb:
                     if event.dropAction() == Qt.MoveAction:
                         data = str(event.mimeData().data('application/calibre+from_tag_browser'))
-                        src = cPickle.loads(data)
+                        src = pickle.loads(data)
                         for s in src:
                             if s[0] == TagTreeItem.TAG and \
                                     (not s[1].startswith('@') or s[2]):

--- a/src/calibre/gui2/tools.py
+++ b/src/calibre/gui2/tools.py
@@ -7,7 +7,7 @@ __docformat__ = 'restructuredtext en'
 Logic for setting up conversion jobs
 '''
 
-import cPickle, os
+import os
 
 from PyQt5.Qt import QDialog, QProgressDialog, QTimer
 
@@ -23,6 +23,7 @@ from calibre.ebooks.conversion.config import (
         get_input_format_for_book, NoSupportedInputFormats)
 from calibre.gui2.convert import bulk_defaults_for_input_format
 from polyglot.builtins import unicode_type
+from polyglot.pickle import pickle
 
 
 def convert_single_ebook(parent, db, book_ids, auto_conversion=False,  # {{{
@@ -71,7 +72,7 @@ def convert_single_ebook(parent, db, book_ids, auto_conversion=False,  # {{{
                 desc = _('Convert book %(num)d of %(total)d (%(title)s)') % \
                         {'num':i + 1, 'total':total, 'title':dtitle}
 
-                recs = cPickle.loads(d.recommendations)
+                recs = pickle.loads(d.recommendations)
                 if d.opf_file is not None:
                     recs.append(('read_metadata_from_opf', d.opf_file.name,
                         OptionRecommendation.HIGH))
@@ -145,7 +146,7 @@ def convert_bulk_ebook(parent, queue, db, book_ids, out_format=None, args=[]):
         return None
 
     output_format = d.output_format
-    user_recs = cPickle.loads(d.recommendations)
+    user_recs = pickle.loads(d.recommendations)
 
     book_ids = convert_existing(parent, db, book_ids, output_format)
     use_saved_single_settings = d.opt_individual_saved_settings.isChecked()

--- a/src/calibre/gui2/tweak_book/completion/worker.py
+++ b/src/calibre/gui2/tweak_book/completion/worker.py
@@ -6,7 +6,7 @@ from __future__ import (unicode_literals, division, absolute_import,
 __license__ = 'GPL v3'
 __copyright__ = '2014, Kovid Goyal <kovid at kovidgoyal.net>'
 
-import cPickle, os, sys
+import os, sys
 from threading import Thread, Event, RLock
 from Queue import Queue
 from contextlib import closing
@@ -16,6 +16,7 @@ from calibre.constants import iswindows
 from calibre.gui2.tweak_book.completion.basic import Request
 from calibre.gui2.tweak_book.completion.utils import DataError
 from calibre.utils.ipc import eintr_retry_call
+from polyglot.pickle import pickle
 
 COMPLETION_REQUEST = 'completion request'
 CLEAR_REQUEST = 'clear request'
@@ -46,7 +47,7 @@ class CompletionWorker(Thread):
             'from {0} import run_main, {1}; run_main({1})'.format(self.__class__.__module__, self.worker_entry_point))
         auth_key = os.urandom(32)
         address, self.listener = create_listener(auth_key)
-        eintr_retry_call(p.stdin.write, cPickle.dumps((address, auth_key), -1))
+        eintr_retry_call(p.stdin.write, pickle.dumps((address, auth_key), -1))
         p.stdin.flush(), p.stdin.close()
         self.control_conn = eintr_retry_call(self.listener.accept)
         self.data_conn = eintr_retry_call(self.listener.accept)
@@ -172,7 +173,7 @@ def completion_worker():
 
 def run_main(func):
     from multiprocessing.connection import Client
-    address, key = cPickle.loads(eintr_retry_call(sys.stdin.read))
+    address, key = pickle.loads(eintr_retry_call(sys.stdin.read))
     with closing(Client(address, authkey=key)) as control_conn, closing(Client(address, authkey=key)) as data_conn:
         func(control_conn, data_conn)
 

--- a/src/calibre/gui2/update.py
+++ b/src/calibre/gui2/update.py
@@ -1,8 +1,9 @@
 __license__   = 'GPL v3'
 __copyright__ = '2008, Kovid Goyal <kovid at kovidgoyal.net>'
 
-import re, binascii, cPickle, ssl, json
+import re, binascii, ssl, json
 from polyglot.builtins import map, unicode_type
+from polyglot.pickle import pickle
 from threading import Thread, Event
 
 from PyQt5.Qt import (QObject, pyqtSignal, Qt, QUrl, QDialog, QGridLayout,
@@ -194,7 +195,7 @@ class UpdateMixin(object):
         has_calibre_update = calibre_version != NO_CALIBRE_UPDATE
         has_plugin_updates = number_of_plugin_updates > 0
         self.plugin_update_found(number_of_plugin_updates)
-        version_url = binascii.hexlify(cPickle.dumps((calibre_version, number_of_plugin_updates), -1))
+        version_url = binascii.hexlify(pickle.dumps((calibre_version, number_of_plugin_updates), -1))
         calibre_version = u'.'.join(map(unicode_type, calibre_version))
 
         if not has_calibre_update and not has_plugin_updates:
@@ -248,7 +249,7 @@ class UpdateMixin(object):
     def update_link_clicked(self, url):
         url = unicode_type(url)
         if url.startswith('update:'):
-            calibre_version, number_of_plugin_updates = cPickle.loads(binascii.unhexlify(url[len('update:'):]))
+            calibre_version, number_of_plugin_updates = pickle.loads(binascii.unhexlify(url[len('update:'):]))
             self.update_found(calibre_version, number_of_plugin_updates, force=True)
 
 

--- a/src/calibre/gui2/viewer/printing.py
+++ b/src/calibre/gui2/viewer/printing.py
@@ -6,7 +6,7 @@ from __future__ import (unicode_literals, division, absolute_import,
 __license__ = 'GPL v3'
 __copyright__ = '2015, Kovid Goyal <kovid at kovidgoyal.net>'
 
-import os, subprocess, cPickle, sys
+import os, subprocess, sys
 from threading import Thread
 
 from PyQt5.Qt import (
@@ -22,6 +22,7 @@ from calibre.gui2.viewer.main import vprefs
 from calibre.utils.icu import numeric_sort_key
 from calibre.utils.ipc.simple_worker import start_pipe_worker
 from calibre.utils.filenames import expanduser
+from polyglot.pickle import pickle
 
 
 class PrintDialog(Dialog):
@@ -143,7 +144,7 @@ class DoPrint(Thread):
         try:
             with PersistentTemporaryFile('print-to-pdf-log.txt') as f:
                 p = self.worker = start_pipe_worker('from calibre.gui2.viewer.printing import do_print; do_print()', stdout=f, stderr=subprocess.STDOUT)
-                p.stdin.write(cPickle.dumps(self.data, -1)), p.stdin.flush(), p.stdin.close()
+                p.stdin.write(pickle.dumps(self.data, -1)), p.stdin.flush(), p.stdin.close()
                 rc = p.wait()
                 if rc != 0:
                     f.seek(0)
@@ -159,7 +160,7 @@ class DoPrint(Thread):
 
 def do_print():
     from calibre.customize.ui import plugin_for_input_format
-    data = cPickle.loads(sys.stdin.read())
+    data = pickle.loads(sys.stdin.read())
     ext = data['input'].lower().rpartition('.')[-1]
     input_plugin = plugin_for_input_format(ext)
     args = ['ebook-convert', data['input'], data['output'], '--paper-size', data['paper_size'], '--pdf-add-toc',

--- a/src/calibre/library/database.py
+++ b/src/calibre/library/database.py
@@ -5,13 +5,14 @@ __copyright__ = '2008, Kovid Goyal <kovid at kovidgoyal.net>'
 Backend that implements storage of ebooks in an sqlite database.
 '''
 import sqlite3 as sqlite
-import datetime, re, cPickle, sre_constants
+import datetime, re, sre_constants
 from zlib import compress, decompress
 
 from calibre.ebooks.metadata import MetaInformation
 from calibre.ebooks.metadata import string_to_authors
 from calibre import isbytestring
 from polyglot.builtins import unicode_type
+from polyglot.pickle import pickle
 
 
 class Concatenate(object):
@@ -1090,7 +1091,7 @@ ALTER TABLE books ADD COLUMN isbn TEXT DEFAULT "" COLLATE NOCASE;
     def conversion_options(self, id, format):
         data = self.conn.get('SELECT data FROM conversion_options WHERE book=? AND format=?', (id, format.upper()), all=False)
         if data:
-            return cPickle.loads(str(data))
+            return pickle.loads(str(data))
         return None
 
     def has_conversion_options(self, ids, format='PIPE'):
@@ -1166,7 +1167,7 @@ ALTER TABLE books ADD COLUMN isbn TEXT DEFAULT "" COLLATE NOCASE;
             self.set_tags(id, val.split(','), append=False)
 
     def set_conversion_options(self, id, format, options):
-        data = sqlite.Binary(cPickle.dumps(options, -1))
+        data = sqlite.Binary(pickle.dumps(options, -1))
         oid = self.conn.get('SELECT id FROM conversion_options WHERE book=? AND format=?', (id, format.upper()), all=False)
         if oid:
             self.conn.execute('UPDATE conversion_options SET data=? WHERE id=?', (data, oid))

--- a/src/calibre/ptempfile.py
+++ b/src/calibre/ptempfile.py
@@ -105,9 +105,10 @@ def base_dir():
     if _base_dir is None:
         td = os.environ.get('CALIBRE_WORKER_TEMP_DIR', None)
         if td is not None:
-            import cPickle, binascii
+            import binascii
+            from polyglot.pickle import pickle
             try:
-                td = cPickle.loads(binascii.unhexlify(td))
+                td = pickle.loads(binascii.unhexlify(td))
             except:
                 td = None
         if td and os.path.exists(td):

--- a/src/calibre/srv/books.py
+++ b/src/calibre/srv/books.py
@@ -7,7 +7,6 @@ from __future__ import (unicode_literals, division, absolute_import,
 from hashlib import sha1
 from functools import partial
 from threading import RLock, Lock
-from cPickle import dumps
 import errno, os, tempfile, shutil, time, json as jsonlib
 
 from calibre.constants import cache_dir, iswindows
@@ -17,6 +16,7 @@ from calibre.srv.render_book import RENDER_VERSION
 from calibre.srv.errors import HTTPNotFound, BookNotFound
 from calibre.srv.routes import endpoint, json
 from calibre.srv.utils import get_library_data, get_db
+from polyglot.pickle import pickle
 
 cache_lock = RLock()
 queued_jobs = {}
@@ -49,7 +49,7 @@ def books_cache_dir():
 
 
 def book_hash(library_uuid, book_id, fmt, size, mtime):
-    raw = dumps((library_uuid, book_id, fmt.upper(), size, mtime, RENDER_VERSION))
+    raw = pickle.dumps((library_uuid, book_id, fmt.upper(), size, mtime, RENDER_VERSION))
     return sha1(raw).hexdigest().decode('ascii')
 
 

--- a/src/calibre/srv/code.py
+++ b/src/calibre/srv/code.py
@@ -4,7 +4,6 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import cPickle
 import hashlib
 import random
 import shutil
@@ -29,6 +28,7 @@ from calibre.utils.config import prefs, tweaks
 from calibre.utils.icu import sort_key, numeric_sort_key
 from calibre.utils.localization import get_lang, lang_map_for_ui, localize_website_link
 from calibre.utils.search_query_parser import ParseException
+from polyglot.pickle import pickle
 
 POSTABLE = frozenset({'GET', 'POST', 'HEAD'})
 
@@ -384,7 +384,7 @@ def tag_browser(ctx, rd):
     db, library_id = get_library_data(ctx, rd)[:2]
     opts = categories_settings(rd.query, db)
     vl = rd.query.get('vl') or ''
-    etag = cPickle.dumps([db.last_modified().isoformat(), rd.username, library_id, vl, list(opts)], -1)
+    etag = pickle.dumps([db.last_modified().isoformat(), rd.username, library_id, vl, list(opts)], -1)
     etag = hashlib.sha1(etag).hexdigest()
 
     def generate():

--- a/src/calibre/utils/config.py
+++ b/src/calibre/utils/config.py
@@ -7,7 +7,7 @@ __docformat__ = 'restructuredtext en'
 '''
 Manage application-wide preferences.
 '''
-import os, cPickle, base64, datetime, json, plistlib
+import os, base64, datetime, json, plistlib
 from copy import deepcopy
 import optparse
 
@@ -17,6 +17,7 @@ from calibre.utils.lock import ExclusiveFile
 from calibre.utils.config_base import (make_config_dir, Option, OptionValues,
         OptionSet, ConfigInterface, Config, prefs, StringConfig, ConfigProxy,
         read_raw_tweaks, read_tweaks, write_tweaks, tweaks, plugin_dir)
+from polyglot.pickle import pickle
 
 # optparse uses gettext.gettext instead of _ from builtins, so we
 # monkey patch it.
@@ -218,7 +219,7 @@ class DynamicConfig(dict):
             with ExclusiveFile(self.file_path) as f:
                 raw = f.read()
                 try:
-                    d = cPickle.loads(raw) if raw.strip() else {}
+                    d = pickle.loads(raw) if raw.strip() else {}
                 except SystemError:
                     pass
                 except:
@@ -255,7 +256,7 @@ class DynamicConfig(dict):
             if not os.path.exists(self.file_path):
                 make_config_dir()
             with ExclusiveFile(self.file_path) as f:
-                raw = cPickle.dumps(self, -1)
+                raw = pickle.dumps(self, -1)
                 f.seek(0)
                 f.truncate()
                 f.write(raw)

--- a/src/calibre/utils/config_base.py
+++ b/src/calibre/utils/config_base.py
@@ -6,7 +6,7 @@ __license__   = 'GPL v3'
 __copyright__ = '2011, Kovid Goyal <kovid@kovidgoyal.net>'
 __docformat__ = 'restructuredtext en'
 
-import os, re, cPickle, traceback
+import os, re, traceback
 from functools import partial
 from collections import defaultdict
 from copy import deepcopy
@@ -14,6 +14,7 @@ from copy import deepcopy
 from calibre.utils.lock import ExclusiveFile
 from calibre.constants import config_dir, CONFIG_DIR_MODE
 from polyglot.builtins import unicode_type
+from polyglot.pickle import pickle
 
 plugin_dir = os.path.join(config_dir, 'plugins')
 
@@ -196,7 +197,7 @@ class OptionSet(object):
         return ''
 
     def parse_string(self, src):
-        options = {'cPickle':cPickle}
+        options = {'cPickle':pickle}
         if src is not None:
             try:
                 if not isinstance(src, unicode_type):
@@ -236,8 +237,8 @@ class OptionSet(object):
         if val is val is True or val is False or val is None or \
            isinstance(val, (int, float, long, bytes, unicode_type)):
             return repr(val)
-        pickle = cPickle.dumps(val, -1)
-        return 'cPickle.loads(%s)'%repr(pickle)
+        pickled = pickle.dumps(val, -1)
+        return 'cPickle.loads(%s)'%repr(pickled)
 
     def serialize(self, opts):
         src = '# %s\n\n'%(self.description.replace('\n', '\n# '))

--- a/src/calibre/utils/ipc/launch.py
+++ b/src/calibre/utils/ipc/launch.py
@@ -6,13 +6,14 @@ __license__   = 'GPL v3'
 __copyright__ = '2009, Kovid Goyal <kovid@kovidgoyal.net>'
 __docformat__ = 'restructuredtext en'
 
-import subprocess, os, sys, time, binascii, cPickle
+import subprocess, os, sys, time, binascii
 from functools import partial
 
 from calibre.constants import iswindows, isosx, isfrozen, filesystem_encoding
 from calibre.utils.config import prefs
 from calibre.ptempfile import PersistentTemporaryFile, base_dir
 from polyglot.builtins import unicode_type, string_or_bytes
+from polyglot.pickle import pickle
 
 if iswindows:
     import win32process
@@ -105,7 +106,7 @@ class Worker(object):
             except:
                 pass
         env[b'CALIBRE_WORKER'] = b'1'
-        td = binascii.hexlify(cPickle.dumps(base_dir()))
+        td = binascii.hexlify(pickle.dumps(base_dir()))
         env[b'CALIBRE_WORKER_TEMP_DIR'] = bytes(td)
         env.update(self._env)
         return env
@@ -176,11 +177,11 @@ class Worker(object):
         exe = self.gui_executable if self.gui else self.executable
         env = self.env
         try:
-            env[b'ORIGWD'] = binascii.hexlify(cPickle.dumps(
+            env[b'ORIGWD'] = binascii.hexlify(pickle.dumps(
                 cwd or os.path.abspath(os.getcwdu())))
         except EnvironmentError:
             # cwd no longer exists
-            env[b'ORIGWD'] = binascii.hexlify(cPickle.dumps(
+            env[b'ORIGWD'] = binascii.hexlify(pickle.dumps(
                 cwd or os.path.expanduser(u'~')))
 
         _cwd = cwd

--- a/src/calibre/utils/ipc/pool.py
+++ b/src/calibre/utils/ipc/pool.py
@@ -6,7 +6,7 @@ from __future__ import (unicode_literals, division, absolute_import,
 __license__ = 'GPL v3'
 __copyright__ = '2014, Kovid Goyal <kovid at kovidgoyal.net>'
 
-import os, cPickle, sys
+import os, sys
 from threading import Thread
 from collections import namedtuple
 from Queue import Queue
@@ -16,6 +16,7 @@ from calibre.constants import iswindows, DEBUG
 from calibre.ptempfile import PersistentTemporaryFile
 from calibre.utils import join_with_timeout
 from calibre.utils.ipc import eintr_retry_call
+from polyglot.pickle import pickle
 
 Job = namedtuple('Job', 'id module func args kwargs')
 Result = namedtuple('Result', 'value err traceback')
@@ -95,7 +96,7 @@ class Worker(object):
         self.name = name or ''
 
     def __call__(self, job):
-        eintr_retry_call(self.conn.send_bytes, cPickle.dumps(job, -1))
+        eintr_retry_call(self.conn.send_bytes, pickle.dumps(job, -1))
         if job is not None:
             self.job_id = job.id
             t = Thread(target=self.recv, name='PoolWorker-'+self.name)
@@ -104,7 +105,7 @@ class Worker(object):
 
     def recv(self):
         try:
-            result = cPickle.loads(eintr_retry_call(self.conn.recv_bytes))
+            result = pickle.loads(eintr_retry_call(self.conn.recv_bytes))
             wr = WorkerResult(self.job_id, result, False, self)
         except Exception as err:
             import traceback
@@ -130,7 +131,7 @@ class Pool(Thread):
         self.results = Queue()
         self.tracker = Queue()
         self.terminal_failure = None
-        self.common_data = cPickle.dumps(None, -1)
+        self.common_data = pickle.dumps(None, -1)
         self.worker_data = None
         self.shutting_down = False
 
@@ -192,7 +193,7 @@ class Pool(Thread):
         p.stdin.flush(), p.stdin.close()
         conn = eintr_retry_call(self.listener.accept)
         w = Worker(p, conn, self.events, self.name)
-        if self.common_data != cPickle.dumps(None, -1):
+        if self.common_data != pickle.dumps(None, -1):
             w.set_common_data(self.common_data)
         return w
 
@@ -211,7 +212,7 @@ class Pool(Thread):
         from calibre.utils.ipc.server import create_listener
         self.auth_key = os.urandom(32)
         self.address, self.listener = create_listener(self.auth_key)
-        self.worker_data = cPickle.dumps((self.address, self.auth_key), -1)
+        self.worker_data = pickle.dumps((self.address, self.auth_key), -1)
         if self.start_worker() is False:
             return
 
@@ -243,12 +244,12 @@ class Pool(Thread):
                 return False
             self.results.put(worker_result)
         else:
-            self.common_data = cPickle.dumps(event, -1)
+            self.common_data = pickle.dumps(event, -1)
             if len(self.common_data) > MAX_SIZE:
                 self.cd_file = PersistentTemporaryFile('pool_common_data')
                 with self.cd_file as f:
                     f.write(self.common_data)
-                self.common_data = cPickle.dumps(File(f.name), -1)
+                self.common_data = pickle.dumps(File(f.name), -1)
             for worker in self.available_workers:
                 try:
                     worker.set_common_data(self.common_data)
@@ -340,7 +341,7 @@ def worker_main(conn):
     common_data = None
     while True:
         try:
-            job = cPickle.loads(eintr_retry_call(conn.recv_bytes))
+            job = pickle.loads(eintr_retry_call(conn.recv_bytes))
         except EOFError:
             break
         except KeyboardInterrupt:
@@ -354,7 +355,7 @@ def worker_main(conn):
             break
         if not isinstance(job, Job):
             if isinstance(job, File):
-                common_data = cPickle.load(open(job.name, 'rb'))
+                common_data = pickle.load(open(job.name, 'rb'))
             else:
                 common_data = job
             continue
@@ -374,7 +375,7 @@ def worker_main(conn):
             import traceback
             result = Result(None, as_unicode(err), traceback.format_exc())
         try:
-            eintr_retry_call(conn.send_bytes, cPickle.dumps(result, -1))
+            eintr_retry_call(conn.send_bytes, pickle.dumps(result, -1))
         except EOFError:
             break
         except Exception:
@@ -388,7 +389,7 @@ def worker_main(conn):
 def run_main(func):
     from multiprocessing.connection import Client
     from contextlib import closing
-    address, key = cPickle.loads(eintr_retry_call(sys.stdin.read))
+    address, key = pickle.loads(eintr_retry_call(sys.stdin.read))
     with closing(Client(address, authkey=key)) as conn:
         raise SystemExit(func(conn))
 

--- a/src/calibre/utils/ipc/proxy.py
+++ b/src/calibre/utils/ipc/proxy.py
@@ -7,7 +7,7 @@ __license__   = 'GPL v3'
 __copyright__ = '2011, Kovid Goyal <kovid@kovidgoyal.net>'
 __docformat__ = 'restructuredtext en'
 
-import os, cPickle, struct
+import os, struct
 from threading import Thread
 from Queue import Queue, Empty
 from multiprocessing.connection import arbitrary_address, Listener
@@ -17,10 +17,11 @@ from calibre import as_unicode, prints
 from calibre.constants import iswindows, DEBUG
 from calibre.utils.ipc import eintr_retry_call
 from polyglot.builtins import unicode_type
+from polyglot.pickle import pickle
 
 
 def _encode(msg):
-    raw = cPickle.dumps(msg, -1)
+    raw = pickle.dumps(msg, -1)
     size = len(raw)
     header = struct.pack('!Q', size)
     return header + raw
@@ -33,7 +34,7 @@ def _decode(raw):
     header, = struct.unpack('!Q', raw[:sz])
     if len(raw) != sz + header or header == 0:
         return 'invalid', None
-    return cPickle.loads(raw[sz:])
+    return pickle.loads(raw[sz:])
 
 
 class Writer(Thread):

--- a/src/calibre/utils/ipc/server.py
+++ b/src/calibre/utils/ipc/server.py
@@ -7,7 +7,7 @@ __license__   = 'GPL v3'
 __copyright__ = '2009, Kovid Goyal <kovid@kovidgoyal.net>'
 __docformat__ = 'restructuredtext en'
 
-import sys, os, cPickle, time, tempfile, errno, itertools
+import sys, os, time, tempfile, errno, itertools
 from math import ceil
 from threading import Thread, RLock
 from Queue import Queue, Empty
@@ -22,6 +22,7 @@ from calibre import detect_ncpus as cpu_count
 from calibre.constants import iswindows, DEBUG, islinux
 from calibre.ptempfile import base_dir
 from polyglot.builtins import string_or_bytes
+from polyglot.pickle import pickle
 
 _counter = 0
 
@@ -212,7 +213,7 @@ class Server(Thread):
             redirect_output = not gui
 
         env = {
-                'CALIBRE_WORKER_ADDRESS' : hexlify(cPickle.dumps(self.listener.address, -1)),
+                'CALIBRE_WORKER_ADDRESS' : hexlify(pickle.dumps(self.listener.address, -1)),
                 'CALIBRE_WORKER_KEY' : hexlify(self.auth_key),
                 'CALIBRE_WORKER_RESULT' : hexlify(rfile.encode('utf-8')),
               }
@@ -281,7 +282,7 @@ class Server(Thread):
                     job.returncode = worker.returncode
                 elif os.path.exists(worker.rfile):
                     try:
-                        job.result = cPickle.load(open(worker.rfile, 'rb'))
+                        job.result = pickle.load(open(worker.rfile, 'rb'))
                         os.remove(worker.rfile)
                     except:
                         pass

--- a/src/calibre/utils/ipc/simple_worker.py
+++ b/src/calibre/utils/ipc/simple_worker.py
@@ -7,7 +7,7 @@ __license__   = 'GPL v3'
 __copyright__ = '2012, Kovid Goyal <kovid@kovidgoyal.net>'
 __docformat__ = 'restructuredtext en'
 
-import os, cPickle, traceback, time, importlib
+import os, traceback, time, importlib
 from binascii import hexlify, unhexlify
 from multiprocessing.connection import Client
 from threading import Thread
@@ -17,6 +17,7 @@ from calibre.constants import iswindows
 from calibre.utils.ipc import eintr_retry_call
 from calibre.utils.ipc.launch import Worker
 from polyglot.builtins import unicode_type, string_or_bytes
+from polyglot.pickle import pickle
 
 
 class WorkerError(Exception):
@@ -130,7 +131,7 @@ def create_worker(env, priority='normal', cwd=None, func='main'):
 
     env = dict(env)
     env.update({
-        'CALIBRE_WORKER_ADDRESS': hexlify(cPickle.dumps(listener.address, -1)),
+        'CALIBRE_WORKER_ADDRESS': hexlify(pickle.dumps(listener.address, -1)),
         'CALIBRE_WORKER_KEY': hexlify(auth_key),
         'CALIBRE_SIMPLE_WORKER': 'calibre.utils.ipc.simple_worker:%s' % func,
     })
@@ -270,7 +271,7 @@ def compile_code(src):
 
 def main():
     # The entry point for the simple worker process
-    address = cPickle.loads(unhexlify(os.environ['CALIBRE_WORKER_ADDRESS']))
+    address = pickle.loads(unhexlify(os.environ['CALIBRE_WORKER_ADDRESS']))
     key     = unhexlify(os.environ['CALIBRE_WORKER_KEY'])
     with closing(Client(address, authkey=key)) as conn:
         args = eintr_retry_call(conn.recv)
@@ -300,7 +301,7 @@ def main():
 
 def offload():
     # The entry point for the offload worker process
-    address = cPickle.loads(unhexlify(os.environ['CALIBRE_WORKER_ADDRESS']))
+    address = pickle.loads(unhexlify(os.environ['CALIBRE_WORKER_ADDRESS']))
     key     = unhexlify(os.environ['CALIBRE_WORKER_KEY'])
     func_cache = {}
     with closing(Client(address, authkey=key)) as conn:

--- a/src/calibre/utils/ipc/worker.py
+++ b/src/calibre/utils/ipc/worker.py
@@ -7,7 +7,7 @@ __license__   = 'GPL v3'
 __copyright__ = '2009, Kovid Goyal <kovid@kovidgoyal.net>'
 __docformat__ = 'restructuredtext en'
 
-import os, cPickle, sys, importlib
+import os, sys, importlib
 from multiprocessing.connection import Client
 from threading import Thread
 from Queue import Queue
@@ -18,6 +18,7 @@ from zipimport import ZipImportError
 from calibre import prints
 from calibre.constants import iswindows, isosx
 from calibre.utils.ipc import eintr_retry_call
+from polyglot.pickle import pickle
 
 PARALLEL_FUNCS = {
     'lrfviewer'    :
@@ -182,7 +183,7 @@ def main():
             print('Failed to run pipe worker with command:', sys.argv[-1])
             raise
         return
-    address = cPickle.loads(unhexlify(os.environ['CALIBRE_WORKER_ADDRESS']))
+    address = pickle.loads(unhexlify(os.environ['CALIBRE_WORKER_ADDRESS']))
     key     = unhexlify(os.environ['CALIBRE_WORKER_KEY'])
     resultf = unhexlify(os.environ['CALIBRE_WORKER_RESULT']).decode('utf-8')
     with closing(Client(address, authkey=key)) as conn:
@@ -198,7 +199,7 @@ def main():
 
         result = func(*args, **kwargs)
         if result is not None and os.path.exists(os.path.dirname(resultf)):
-            cPickle.dump(result, open(resultf, 'wb'), -1)
+            pickle.dump(result, open(resultf, 'wb'), -1)
 
         notifier.queue.put(None)
 

--- a/src/calibre/utils/open_with/linux.py
+++ b/src/calibre/utils/open_with/linux.py
@@ -6,7 +6,7 @@ from __future__ import (unicode_literals, division, absolute_import,
 __license__ = 'GPL v3'
 __copyright__ = '2015, Kovid Goyal <kovid at kovidgoyal.net>'
 
-import re, shlex, os, cPickle
+import re, shlex, os
 from collections import defaultdict
 
 from calibre import walk, guess_type, prints, force_unicode
@@ -114,7 +114,7 @@ def find_icons():
 
     try:
         with open(cache_file, 'rb') as f:
-            cache = cPickle.load(f)
+            cache = pickle.load(f)
             mtimes, cache = cache['mtimes'], cache['data']
     except Exception:
         mtimes, cache = defaultdict(int), defaultdict(dict)
@@ -153,7 +153,7 @@ def find_icons():
     if changed:
         try:
             with open(cache_file, 'wb') as f:
-                cPickle.dump({'data':cache, 'mtimes':mtimes}, f, -1)
+                pickle.dump({'data':cache, 'mtimes':mtimes}, f, -1)
         except Exception:
             import traceback
             traceback.print_exc()

--- a/src/polyglot/pickle.py
+++ b/src/polyglot/pickle.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python2
+# vim:fileencoding=utf-8
+# License: GPL v3 Copyright: 2019, Eli Schwartz <eschwartz@archlinux.org>
+
+from polyglot.builtins import is_py3
+
+if is_py3:
+    import pickle #noqa
+else:
+    import cPickle as pickle  # noqa


### PR DESCRIPTION
Actually, almost everywhere. src/calibre/utils/config_base.py uses it twice, but both times it shouldn't matter as it is only being used to proxy/load settings files, so they should probably be left alone in order to preserve people's settings.