### PR TITLE
Fixing stroke-dasharray rendering bug (#1821923)

### DIFF
--- a/src/calibre/ebooks/pdf/render/graphics.py
+++ b/src/calibre/ebooks/pdf/render/graphics.py
@@ -430,9 +430,12 @@ class Graphics(object):
         pdf.current_page.write('%d j '%join)
 
         # Dash pattern
-        ps = {Qt.DashLine:[3], Qt.DotLine:[1,2], Qt.DashDotLine:[3,2,1,2],
-              Qt.DashDotDotLine:[3, 2, 1, 2, 1, 2]}.get(pen.style(), [])
-        if ps:
+        if pen.style() == Qt.CustomDashLine:
+            pdf.serialize(Array(pen.dashPattern()))
+            pdf.current_page.write(' %d d ' % pen.dashOffset())
+        else:
+            ps = {Qt.DashLine:[3], Qt.DotLine:[1,2], Qt.DashDotLine:[3,2,1,2],
+                  Qt.DashDotDotLine:[3, 2, 1, 2, 1, 2]}.get(pen.style(), [])
             pdf.serialize(Array(ps))
             pdf.current_page.write(' 0 d ')
 


### PR DESCRIPTION
Reference bug: https://bugs.launchpad.net/calibre/+bug/1821923

The QtPen's `pen.style()` return value for an SVG element with a stroke-dasharray attribute is Qt.CustomDashLine, which was not previously in the list of values checked by graphics.py's `apply_stroke()` method.

This code adds a check for Qt.CustomDashLine and if present, usees the `pen.dashPattern()` and `pen.dashOffset()` values for the dashArray and dashPhase parameters to the 'd' operator respectively.

It also now always sets the 'd' operator. Previously, the 'd' operator would only be set if the `pen.style()` was found in the list. Without this change, the 'd' operator's value persists to future paths, making them dashed even if they wouldn't have been otherwise.