### PR TITLE
cleanup misc neatness issues

### DIFF
--- a/src/calibre/customize/ui.py
+++ b/src/calibre/customize/ui.py
@@ -23,7 +23,7 @@ from calibre.utils.config import (make_config_dir, Config, ConfigProxy,
                                  plugin_dir, OptionParser)
 from calibre.ebooks.metadata.sources.base import Source
 from calibre.constants import DEBUG, numeric_version
-from polyglot.builtins import iteritems, itervalues
+from polyglot.builtins import iteritems, itervalues, unicode_type
 
 builtin_names = frozenset(p.name for p in builtin_plugins)
 BLACKLISTED_PLUGINS = frozenset({'Marvin XD', 'iOS reader applications'})
@@ -750,7 +750,7 @@ def build_plugin(path):
     from calibre import prints
     from calibre.ptempfile import PersistentTemporaryFile
     from calibre.utils.zipfile import ZipFile, ZIP_STORED
-    path = type(u'')(path)
+    path = unicode_type(path)
     names = frozenset(os.listdir(path))
     if u'__init__.py' not in names:
         prints(path, ' is not a valid plugin')

--- a/src/calibre/db/cli/cmd_add.py
+++ b/src/calibre/db/cli/cmd_add.py
@@ -20,6 +20,7 @@ from calibre.ebooks.metadata.meta import get_metadata, metadata_from_formats
 from calibre.ptempfile import TemporaryDirectory
 from calibre.srv.changes import books_added
 from calibre.utils.localization import canonicalize_lang
+from polyglot.builtins import unicode_type
 
 readonly = False
 version = 0  # change this if you change signature of implementation()
@@ -215,7 +216,7 @@ def do_add(
                     prints('   ', path)
 
         if added_ids:
-            prints(_('Added book ids: %s') % (', '.join(map(type(u''), added_ids))))
+            prints(_('Added book ids: %s') % (', '.join(map(unicode_type, added_ids))))
 
 
 def option_parser(get_parser, args):

--- a/src/calibre/db/fields.py
+++ b/src/calibre/db/fields.py
@@ -19,7 +19,7 @@ from calibre.utils.config_base import tweaks
 from calibre.utils.icu import sort_key
 from calibre.utils.date import UNDEFINED_DATE, clean_date_for_sort, parse_date
 from calibre.utils.localization import calibre_langcode_to_name
-from polyglot.builtins import iteritems
+from polyglot.builtins import iteritems, unicode_type
 
 
 def bool_sort_key(bools_are_tristate):
@@ -79,7 +79,7 @@ class Field(object):
             self._sort_key = lambda x: sort_key(author_to_author_sort(x))
             self.sort_sort_key = False
         self.default_value = {} if name == 'identifiers' else () if self.is_multiple else None
-        self.category_formatter = type(u'')
+        self.category_formatter = unicode_type
         if dt == 'rating':
             if self.metadata['display'].get('allow_half_stars', False):
                 self.category_formatter = lambda x: rating_to_stars(x, True)

--- a/src/calibre/debug.py
+++ b/src/calibre/debug.py
@@ -11,7 +11,7 @@ import sys, os, functools
 from calibre.utils.config import OptionParser
 from calibre.constants import iswindows
 from calibre import prints
-from polyglot.builtins import exec_path, raw_input
+from polyglot.builtins import exec_path, raw_input, unicode_type
 
 
 def get_debug_executable():
@@ -215,7 +215,7 @@ def print_basic_debug_info(out=None):
             out('Linux:', platform.linux_distribution())
     except:
         pass
-    out('Interface language:', type(u'')(set_translators.lang))
+    out('Interface language:', unicode_type(set_translators.lang))
     from calibre.customize.ui import has_external_plugins, initialized_plugins
     if has_external_plugins():
         names = ('{0} {1}'.format(p.name, p.version) for p in initialized_plugins() if getattr(p, 'plugin_path', None) is not None)

--- a/src/calibre/devices/kobo/books.py
+++ b/src/calibre/devices/kobo/books.py
@@ -219,7 +219,7 @@ class KTCollectionsBookList(CollectionsBookList):
                 elif fm is not None and fm['datatype'] == 'series':
                     val = [orig_val]
                 elif fm is not None and fm['datatype'] == 'rating':
-                    val = [type(u'')(orig_val / 2.0)]
+                    val = [unicode_type(orig_val / 2.0)]
                 elif fm is not None and fm['datatype'] == 'text' and fm['is_multiple']:
                     if isinstance(orig_val, (list, tuple)):
                         val = orig_val
@@ -264,7 +264,7 @@ class KTCollectionsBookList(CollectionsBookList):
                     if not category:
                         continue
 
-                    cat_name = type(u'')(category).strip(' ,')
+                    cat_name = unicode_type(category).strip(' ,')
 
                     if cat_name not in collections:
                         collections[cat_name] = {}

--- a/src/calibre/devices/udisks.py
+++ b/src/calibre/devices/udisks.py
@@ -114,7 +114,7 @@ class UDisks2(object):
         devs = self.bus.get_object('org.freedesktop.UDisks2',
                         '/org/freedesktop/UDisks2/block_devices')
         xml = devs.Introspect(dbus_interface='org.freedesktop.DBus.Introspectable')
-        for dev in re.finditer(r'name=[\'"](.+?)[\'"]', type(u'')(xml)):
+        for dev in re.finditer(r'name=[\'"](.+?)[\'"]', unicode_type(xml)):
             bd = self.bus.get_object('org.freedesktop.UDisks2',
                 '/org/freedesktop/UDisks2/block_devices/%s2'%dev.group(1))
             try:

--- a/src/calibre/ebooks/metadata/fb2.py
+++ b/src/calibre/ebooks/metadata/fb2.py
@@ -302,7 +302,7 @@ def _parse_pubdate(root, mi, ctx):
     year = ctx.XPath('number(//fb:publish-info/fb:year/text())')(root)
     if float.is_integer(year):
         # only year is available, so use 2nd of June
-        mi.pubdate = parse_only_date(type(u'')(int(year)))
+        mi.pubdate = parse_only_date(unicode_type(int(year)))
 
 
 def _parse_language(root, mi, ctx):

--- a/src/calibre/ebooks/txt/processor.py
+++ b/src/calibre/ebooks/txt/processor.py
@@ -201,7 +201,7 @@ def separate_hard_scene_breaks(txt):
             return '\n%s\n' % line
         else:
             return line
-    txt = re.sub(type(u'')(r'(?miu)^[ \t-=~\/_]+$'), lambda mo: sep_break(mo.group()), txt)
+    txt = re.sub(unicode_type(r'(?miu)^[ \t-=~\/_]+$'), lambda mo: sep_break(mo.group()), txt)
     return txt
 
 

--- a/src/calibre/gui2/add.py
+++ b/src/calibre/gui2/add.py
@@ -144,7 +144,7 @@ class Adder(QObject):
                         self.file_groups[len(self.file_groups)] = files
         else:
             def find_files(root):
-                if isinstance(root, type(u'')):
+                if isinstance(root, unicode_type):
                     root = root.encode(filesystem_encoding)
                 for dirpath, dirnames, filenames in os.walk(root):
                     try:

--- a/src/calibre/gui2/custom_column_widgets.py
+++ b/src/calibre/gui2/custom_column_widgets.py
@@ -89,7 +89,7 @@ class SimpleText(Base):
         self.widgets = [QLabel('&'+self.col_metadata['name']+':', parent), QLineEdit(parent)]
 
     def setter(self, val):
-        self.widgets[1].setText(type(u'')(val or ''))
+        self.widgets[1].setText(unicode_type(val or ''))
 
     def getter(self):
         return self.widgets[1].text().strip()
@@ -112,7 +112,7 @@ class LongText(Base):
         self.widgets = [self._box]
 
     def setter(self, val):
-        self._tb.setPlainText(type(u'')(val or ''))
+        self._tb.setPlainText(unicode_type(val or ''))
 
     def getter(self):
         return self._tb.toPlainText()

--- a/src/calibre/gui2/metadata/single.py
+++ b/src/calibre/gui2/metadata/single.py
@@ -31,7 +31,7 @@ from calibre.ebooks.metadata.book.base import Metadata
 from calibre.utils.localization import canonicalize_lang
 from calibre.utils.date import local_tz
 from calibre.library.comments import merge_comments as merge_two_comments
-from polyglot.builtins import iteritems
+from polyglot.builtins import iteritems, unicode_type
 
 BASE_TITLE = _('Edit Metadata')
 fetched_fields = ('title', 'title_sort', 'authors', 'author_sort', 'series',
@@ -312,7 +312,7 @@ class MetadataSingleDialogBase(QDialog):
     def edit_prefix_list(self):
         prefixes, ok = QInputDialog.getMultiLineText(
             self, _('Edit prefixes'), _('Enter prefixes, one on a line. The first prefix becomes the default.'),
-            '\n'.join(list(map(type(u''), gprefs['paste_isbn_prefixes']))))
+            '\n'.join(list(map(unicode_type, gprefs['paste_isbn_prefixes']))))
         if ok:
             gprefs['paste_isbn_prefixes'] = list(filter(None, (x.strip() for x in prefixes.splitlines()))) or gprefs.defaults['paste_isbn_prefixes']
             self.update_paste_identifiers_menu()

--- a/src/calibre/gui2/preferences/create_custom_column.py
+++ b/src/calibre/gui2/preferences/create_custom_column.py
@@ -558,8 +558,8 @@ class CreateCustomColumn(QDialog):
             else:
                 display_dict = {'number_format': None}
         elif col_type == 'comments':
-            display_dict['heading_position'] = type(u'')(self.comments_heading_position.currentData())
-            display_dict['interpret_as'] = type(u'')(self.comments_type.currentData())
+            display_dict['heading_position'] = unicode_type(self.comments_heading_position.currentData())
+            display_dict['interpret_as'] = unicode_type(self.comments_type.currentData())
         elif col_type == 'rating':
             display_dict['allow_half_stars'] = bool(self.allow_half_stars.isChecked())
 

--- a/src/calibre/gui2/preferences/emailp.py
+++ b/src/calibre/gui2/preferences/emailp.py
@@ -65,7 +65,7 @@ class EmailAccounts(QAbstractTableModel):  # {{{
                 return numeric_sort_key(self.subjects.get(account_key) or '')
         elif col == 3:
             def key(account_key):
-                return numeric_sort_key(type(u'')(self.accounts[account_key][0]) or '')
+                return numeric_sort_key(unicode_type(self.accounts[account_key][0]) or '')
         elif col == 4:
             def key(account_key):
                 return numeric_sort_key(self.aliases.get(account_key) or '')

--- a/src/calibre/gui2/preferences/server.py
+++ b/src/calibre/gui2/preferences/server.py
@@ -32,6 +32,7 @@ from calibre.srv.users import (
     UserManager, create_user_data, validate_password, validate_username
 )
 from calibre.utils.icu import primary_sort_key
+from polyglot.binary import unicode_type
 
 try:
     from PyQt5 import sip
@@ -189,7 +190,7 @@ class Text(QLineEdit):
         return self.text().strip() or None
 
     def set(self, val):
-        self.setText(type(u'')(val or ''))
+        self.setText(unicode_type(val or ''))
 
 
 class Path(QWidget):
@@ -218,7 +219,7 @@ class Path(QWidget):
         return self.text.text().strip() or None
 
     def set(self, val):
-        self.text.setText(type(u'')(val or ''))
+        self.text.setText(unicode_type(val or ''))
 
     def choose(self):
         ans = choose_files(self, 'choose_path_srv_opts_' + self.dname, _('Choose a file'), select_only_single_file=True)

--- a/src/calibre/gui2/store/__init__.py
+++ b/src/calibre/gui2/store/__init__.py
@@ -58,7 +58,7 @@ class StorePlugin(object):  # {{{
         self.name = name
         self.base_plugin = base_plugin
         if config is None:
-            from calibre.gui2 import JSONConfig
+            from calibre.utils.config import JSONConfig
             config = JSONConfig('store/stores/' + ascii_filename(self.name))
         self.config = config
 

--- a/src/calibre/gui2/store/loader.py
+++ b/src/calibre/gui2/store/loader.py
@@ -17,7 +17,7 @@ from calibre.constants import numeric_version, DEBUG
 from calibre.gui2.store import StorePlugin
 from calibre.utils.config import JSONConfig
 from polyglot.urllib import urlencode
-from polyglot.builtins import iteritems, itervalues
+from polyglot.builtins import iteritems, itervalues, unicode_type
 
 
 class VersionMismatch(ValueError):
@@ -29,7 +29,7 @@ class VersionMismatch(ValueError):
 
 def download_updates(ver_map={}, server='https://code.calibre-ebook.com'):
     from calibre.utils.https import get_https_resource_securely
-    data = {k:type(u'')(v) for k, v in iteritems(ver_map)}
+    data = {k:unicode_type(v) for k, v in iteritems(ver_map)}
     data['ver'] = '1'
     url = '%s/stores?%s'%(server, urlencode(data))
     # We use a timeout here to ensure the non-daemonic update thread does not

--- a/src/calibre/linux.py
+++ b/src/calibre/linux.py
@@ -13,7 +13,7 @@ from calibre.constants import islinux, isbsd, ispy3
 from calibre.customize.ui import all_input_formats
 from calibre.ptempfile import TemporaryDirectory
 from calibre import CurrentDir
-from polyglot.builtins import iteritems
+from polyglot.builtins import iteritems, unicode_type
 
 
 entry_points = {
@@ -211,7 +211,7 @@ class ZshCompleter(object):  # {{{
             h = opt.help or ''
             h = h.replace('"', "'").replace('[', '(').replace(
                 ']', ')').replace('\n', ' ').replace(':', '\\:').replace('`', "'")
-            h = h.replace('%default', type(u'')(opt.default))
+            h = h.replace('%default', unicode_type(opt.default))
             arg = ''
             if opt.takes_value():
                 arg = ':"%s":'%h
@@ -369,7 +369,7 @@ class ZshCompleter(object):  # {{{
             h = opt.help or ''
             h = h.replace('"', "'").replace('[', '(').replace(
                 ']', ')').replace('\n', ' ').replace(':', '\\:').replace('`', "'")
-            h = h.replace('%default', type(u'')(opt.default))
+            h = h.replace('%default', unicode_type(opt.default))
             help_txt = u'"[%s]"'%h
             opt_lines.append(ostrings + help_txt + ' \\')
         opt_lines = ('\n' + (' ' * 8)).join(opt_lines)
@@ -479,9 +479,9 @@ _ebook_edit() {
                 self.do_ebook_edit(f)
                 f.write('case $service in\n')
                 for c, txt in iteritems(self.commands):
-                    if isinstance(txt, type(u'')):
+                    if isinstance(txt, unicode_type):
                         txt = txt.encode('utf-8')
-                    if isinstance(c, type(u'')):
+                    if isinstance(c, unicode_type):
                         c = c.encode('utf-8')
                     f.write(b'%s)\n%s\n;;\n'%(c, txt))
                 f.write('esac\n')

--- a/src/calibre/test_build.py
+++ b/src/calibre/test_build.py
@@ -114,7 +114,7 @@ class BuildTest(unittest.TestCase):
             s = msgpack_dumps(obj)
             self.assertEqual(obj, msgpack_loads(s))
         self.assertEqual(type(msgpack_loads(msgpack_dumps(b'b'))), bytes)
-        self.assertEqual(type(msgpack_loads(msgpack_dumps(u'b'))), type(u''))
+        self.assertEqual(type(msgpack_loads(msgpack_dumps(u'b'))), unicode_type)
         large = b'x' * (100 * 1024 * 1024)
         msgpack_loads(msgpack_dumps(large))
 

--- a/src/calibre/utils/config.py
+++ b/src/calibre/utils/config.py
@@ -21,6 +21,7 @@ from calibre.utils.config_base import (
     tweaks, from_json, to_json
 )
 from calibre.utils.lock import ExclusiveFile
+from polyglot.builtins import unicode_type
 
 
 # optparse uses gettext.gettext instead of _ from builtins, so we
@@ -192,7 +193,7 @@ class OptionParser(optparse.OptionParser):
                 upper.__dict__[dest] = lower.__dict__[dest]
 
     def add_option_group(self, *args, **kwargs):
-        if isinstance(args[0], type(u'')):
+        if isinstance(args[0], unicode_type):
             args = [optparse.OptionGroup(self, *args, **kwargs)] + list(args[1:])
         return optparse.OptionParser.add_option_group(self, *args, **kwargs)
 

--- a/src/calibre/utils/filenames.py
+++ b/src/calibre/utils/filenames.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 '''
 Make strings safe for use as ASCII filenames, while trying to preserve as much
 meaning as possible.
@@ -30,11 +31,11 @@ def ascii_text(orig):
     return ascii
 
 
-def ascii_filename(orig, substitute=u'_'):
+def ascii_filename(orig, substitute='_'):
     if isinstance(substitute, bytes):
         substitute = substitute.decode(filesystem_encoding)
-    orig = ascii_text(orig).replace(u'?', u'_')
-    ans = u''.join(x if ord(x) >= 32 else substitute for x in orig)
+    orig = ascii_text(orig).replace('?', '_')
+    ans = ''.join(x if ord(x) >= 32 else substitute for x in orig)
     return sanitize_file_name(ans, substitute=substitute)
 
 
@@ -296,7 +297,7 @@ def windows_hardlink(src, dest):
     try:
         win32file.CreateHardLink(dest, src)
     except pywintypes.error as e:
-        msg = u'Creating hardlink from %s to %s failed: %%s' % (src, dest)
+        msg = 'Creating hardlink from %s to %s failed: %%s' % (src, dest)
         raise OSError(msg % e)
     src_size = os.path.getsize(src)
     # We open and close dest, to ensure its directory entry is updated
@@ -313,7 +314,7 @@ def windows_hardlink(src, dest):
 
     sz = windows_get_size(dest)
     if sz != src_size:
-        msg = u'Creating hardlink from %s to %s failed: %%s' % (src, dest)
+        msg = 'Creating hardlink from %s to %s failed: %%s' % (src, dest)
         raise OSError(msg % ('hardlink size: %d not the same as source size' % sz))
 
 
@@ -322,11 +323,11 @@ def windows_fast_hardlink(src, dest):
     try:
         win32file.CreateHardLink(dest, src)
     except pywintypes.error as e:
-        msg = u'Creating hardlink from %s to %s failed: %%s' % (src, dest)
+        msg = 'Creating hardlink from %s to %s failed: %%s' % (src, dest)
         raise OSError(msg % e)
     ssz, dsz = windows_get_size(src), windows_get_size(dest)
     if ssz != dsz:
-        msg = u'Creating hardlink from %s to %s failed: %%s' % (src, dest)
+        msg = 'Creating hardlink from %s to %s failed: %%s' % (src, dest)
         raise OSError(msg % ('hardlink size: %d not the same as source size: %s' % (dsz, ssz)))
 
 
@@ -424,10 +425,10 @@ class WindowsAtomicFolderMove(object):
                 break
         if handle is None:
             if os.path.exists(path):
-                raise ValueError(u'The file %r did not exist when this move'
+                raise ValueError('The file %r did not exist when this move'
                         ' operation was started'%path)
             else:
-                raise ValueError(u'The file %r does not exist'%path)
+                raise ValueError('The file %r does not exist'%path)
         try:
             windows_hardlink(path, dest)
             return
@@ -439,7 +440,7 @@ class WindowsAtomicFolderMove(object):
             while True:
                 hr, raw = win32file.ReadFile(handle, 1024*1024)
                 if hr != 0:
-                    raise IOError(hr, u'Error while reading from %r'%path)
+                    raise IOError(hr, 'Error while reading from %r'%path)
                 if not raw:
                     break
                 f.write(raw)
@@ -549,10 +550,10 @@ if iswindows:
     def expanduser(path):
         if isinstance(path, bytes):
             path = path.decode(filesystem_encoding)
-        if path[:1] != u'~':
+        if path[:1] != '~':
             return path
         i, n = 1, len(path)
-        while i < n and path[i] not in u'/\\':
+        while i < n and path[i] not in '/\\':
             i += 1
         from win32com.shell import shell, shellcon
         userhome = shell.SHGetFolderPath(0, shellcon.CSIDL_PROFILE, None, 0)

--- a/src/calibre/utils/fonts/metadata.py
+++ b/src/calibre/utils/fonts/metadata.py
@@ -12,7 +12,7 @@ from struct import calcsize, unpack, unpack_from
 from collections import namedtuple
 
 from calibre.utils.fonts.utils import get_font_names2, get_font_characteristics
-from polyglot.builtins import range
+from polyglot.builtins import range, unicode_type
 
 
 class UnsupportedFont(ValueError):
@@ -49,7 +49,7 @@ class FontMetadata(object):
         elif wt == 700:
             wt = 'bold'
         else:
-            wt = type(u'')(wt)
+            wt = unicode_type(wt)
         self.font_weight = wt
 
         self.font_stretch = ('ultra-condensed', 'extra-condensed',

--- a/src/calibre/utils/fonts/sfnt/cff/dict_data.py
+++ b/src/calibre/utils/fonts/sfnt/cff/dict_data.py
@@ -8,7 +8,7 @@ __copyright__ = '2012, Kovid Goyal <kovid at kovidgoyal.net>'
 __docformat__ = 'restructuredtext en'
 
 from struct import unpack, pack
-from polyglot.builtins import range
+from polyglot.builtins import range, unicode_type
 
 t1_operand_encoding = [None] * 256
 t1_operand_encoding[0:32] = (32) * ["do_operator"]
@@ -75,7 +75,7 @@ class ByteCode(dict):
         return float(number), index
 
     def write_float(self, f, encoding='ignored'):
-        s = type(u'')(f).upper()
+        s = unicode_type(f).upper()
         if s[:2] == "0.":
             s = s[1:]
         elif s[:3] == "-0.":

--- a/src/calibre/utils/fonts/sfnt/metrics.py
+++ b/src/calibre/utils/fonts/sfnt/metrics.py
@@ -7,7 +7,7 @@ __license__   = 'GPL v3'
 __copyright__ = '2012, Kovid Goyal <kovid at kovidgoyal.net>'
 __docformat__ = 'restructuredtext en'
 
-from polyglot.builtins import map
+from polyglot.builtins import map, unicode_type
 from calibre.utils.fonts.utils import get_all_font_names
 from calibre.utils.fonts.sfnt.container import UnsupportedFont
 
@@ -95,7 +95,7 @@ class FontMetrics(object):
         Return the advance widths (in pixels) for all glyphs corresponding to
         the characters in string at the specified pixel_size and stretch factor.
         '''
-        if not isinstance(string, type(u'')):
+        if not isinstance(string, unicode_type):
             raise ValueError('Must supply a unicode object')
         chars = tuple(map(ord, string))
         cmap = self.cmap.get_character_map(chars)

--- a/src/calibre/utils/fonts/win_fonts.py
+++ b/src/calibre/utils/fonts/win_fonts.py
@@ -14,7 +14,7 @@ from calibre import prints, isbytestring
 from calibre.constants import plugins, filesystem_encoding
 from calibre.utils.fonts.utils import (is_truetype_font, get_font_names,
         get_font_characteristics)
-from polyglot.builtins import iteritems
+from polyglot.builtins import iteritems, unicode_type
 
 
 class WinFonts(object):
@@ -59,7 +59,7 @@ class WinFonts(object):
         return ft
 
     def fonts_for_family(self, family, normalize=True):
-        family = type(u'')(family)
+        family = unicode_type(family)
         ans = {}
         for weight, is_italic in product((self.w.FW_NORMAL, self.w.FW_BOLD), (False, True)):
             if family in self.app_font_families:


### PR DESCRIPTION
Found while looking at python3 issues:
- import `JSONConfig` from where it is defined, rather than transitively from somewhere it is used
- port old code to use `unicode_type` instead of `type(u'')`, including one place in gui2/store/ which is not actually being loaded dynamically, thus does not need this as a backwards-compat mechanism.
- as a followup on 3bece11b09bc61380a438c7580dc9faf7463015e I think we can just use unicode_literals here, which in general means less work writing new code, and easier removal of python2 compat sometime down the line.