### PR TITLE
do not exit with an error when $command --help is successfully used

### DIFF
--- a/src/calibre/db/cli/main.py
+++ b/src/calibre/db/cli/main.py
@@ -238,6 +238,9 @@ def main(args=sys.argv):
     if len(args) < 2:
         parser.print_help()
         return 1
+    if args[1] in ('-h', '--help'):
+        parser.print_help()
+        return 0
     if args[1] == '--version':
         parser.print_version()
         return 0

--- a/src/calibre/ebooks/conversion/cli.py
+++ b/src/calibre/ebooks/conversion/cli.py
@@ -308,7 +308,10 @@ def create_option_parser(args, log):
     parser = option_parser()
     if len(args) < 3:
         print_help(parser, log)
-        raise SystemExit(1)
+        if any(x in args for x in ('-h', '--help')):
+            raise SystemExit(0)
+        else:
+            raise SystemExit(1)
 
     input, output = check_command_line_options(parser, args, log)
 


### PR DESCRIPTION
When checking for a minimum requirement of arguments and aborting with the help text otherwise, we should first check to see if the help text was explicitly asked for.

Found while otherwise fiddling with python3 stuff