### PR TITLE
py3: make install/develop targets work

### DIFF
--- a/setup/install.py
+++ b/setup/install.py
@@ -155,7 +155,7 @@ class Develop(Command):
             path = os.path.join(libdir, 'init_calibre.py')
             self.info('Installing calibre environment module: '+path)
             with open(path, 'wb') as f:
-                f.write(HEADER.format(**self.template_args()))
+                f.write(HEADER.format(**self.template_args()).encode('utf-8'))
 
     def install_files(self):
         pass
@@ -189,7 +189,7 @@ class Develop(Command):
         args = self.template_args()
         args['module'] = mod
         args['func'] = func
-        script = template.format(**args)
+        script = template.format(**args).encode('utf-8')
         path = self.j(self.staging_bindir, name)
         if not os.path.exists(self.staging_bindir):
             os.makedirs(self.staging_bindir)

--- a/src/calibre/linux.py
+++ b/src/calibre/linux.py
@@ -800,7 +800,7 @@ class PostInstall:
                     for size in sizes:
                         install_single_icon(iconsrc, basename, size, context, is_last_icon and size is sizes[-1])
 
-                icons = filter(None, [x.strip() for x in '''\
+                icons = list(filter(None, [x.strip() for x in '''\
                     mimetypes/lrf.png application-lrf mimetypes
                     mimetypes/lrf.png text-lrs mimetypes
                     mimetypes/mobi.png application-x-mobipocket-ebook mimetypes
@@ -810,7 +810,7 @@ class PostInstall:
                     lt.png calibre-gui apps
                     viewer.png calibre-viewer apps
                     tweak.png calibre-ebook-edit apps
-                    '''.splitlines()])
+                    '''.splitlines()]))
                 for line in icons:
                     iconsrc, basename, context = line.split()
                     install_icons(iconsrc, basename, context, is_last_icon=line is icons[-1])

--- a/src/calibre/linux.py
+++ b/src/calibre/linux.py
@@ -414,13 +414,13 @@ _ebook_edit() {
                      not x.strip().startswith('%prog')]
             descs[command] = lines[0]
 
-        f.write('\n_calibredb_cmds() {\n  local commands; commands=(\n')
-        f.write('    {-h,--help}":Show help"\n')
-        f.write('    "--version:Show version"\n')
+        f.write(b'\n_calibredb_cmds() {\n  local commands; commands=(\n')
+        f.write(b'    {-h,--help}":Show help"\n')
+        f.write(b'    "--version:Show version"\n')
         for command, desc in iteritems(descs):
-            f.write('    "%s:%s"\n'%(
-                command, desc.replace(':', '\\:').replace('"', '\'')))
-        f.write('  )\n  _describe -t commands "calibredb command" commands \n}\n')
+            f.write(('    "%s:%s"\n'%(
+                command, desc.replace(':', '\\:').replace('"', '\''))).encode('utf-8'))
+        f.write(b'  )\n  _describe -t commands "calibredb command" commands \n}\n')
 
         subcommands = []
         for command, parser in iteritems(parsers):
@@ -441,7 +441,7 @@ _ebook_edit() {
             subcommands.append(txt)
             subcommands.append(';;')
 
-        f.write('\n_calibredb() {')
+        f.write(b'\n_calibredb() {')
         f.write((
             r'''
     local state line state_descr context
@@ -466,25 +466,25 @@ _ebook_edit() {
 
     return ret
     '''%'\n    '.join(subcommands)).encode('utf-8'))
-        f.write('\n}\n\n')
+        f.write(b'\n}\n\n')
 
     def write(self):
         if self.dest:
             for c in ('calibredb', 'ebook-convert', 'ebook-edit'):
                 self.commands[c] = ' _%s "$@"' % c.replace('-', '_')
             with open(self.dest, 'wb') as f:
-                f.write('#compdef ' + ' '.join(self.commands)+'\n')
+                f.write(b'#compdef ' + ' '.join(self.commands).encode('utf-8')+b'\n')
                 self.do_ebook_convert(f)
                 self.do_calibredb(f)
                 self.do_ebook_edit(f)
-                f.write('case $service in\n')
+                f.write(b'case $service in\n')
                 for c, txt in iteritems(self.commands):
                     if isinstance(txt, unicode_type):
                         txt = txt.encode('utf-8')
                     if isinstance(c, unicode_type):
                         c = c.encode('utf-8')
                     f.write(b'%s)\n%s\n;;\n'%(c, txt))
-                f.write('esac\n')
+                f.write(b'esac\n')
 # }}}
 
 
@@ -525,9 +525,9 @@ def write_completion(bash_comp_dest, zsh):
     if bash_comp_dest and not os.path.exists(os.path.dirname(bash_comp_dest)):
         os.makedirs(os.path.dirname(bash_comp_dest))
 
-    complete = 'calibre-complete'
+    complete = b'calibre-complete'
     if getattr(sys, 'frozen_path', None):
-        complete = os.path.join(getattr(sys, 'frozen_path'), complete)
+        complete = os.path.join(getattr(sys, 'frozen_path'), complete).encode('utf-8')
 
     with open(bash_comp_dest or os.devnull, 'wb') as f:
         def o_and_e(*args, **kwargs):
@@ -538,7 +538,7 @@ def write_completion(bash_comp_dest, zsh):
             f.write(opts_and_words(*args, **kwargs))
             zsh.opts_and_words(*args, **kwargs)
 
-        f.write('# calibre Bash Shell Completion\n')
+        f.write(b'# calibre Bash Shell Completion\n')
         o_and_e('calibre', guiop, BOOK_EXTENSIONS)
         o_and_e('lrf2lrs', lrf2lrsop, ['lrf'], file_map={'--output':['lrs']})
         o_and_e('ebook-meta', metaop,
@@ -634,7 +634,7 @@ def write_completion(bash_comp_dest, zsh):
         complete -o nospace  -F _ebook_device ebook-device
 
         complete -o nospace -C %s ebook-convert
-        ''')%complete)
+        ''').encode('utf-8')%complete)
     zsh.write()
 # }}}
 
@@ -733,7 +733,7 @@ class PostInstall:
             appdata_resources=self.appdata_resources, frozen_path=getattr(sys, 'frozen_path', None))
         try:
             with open(dest, 'wb') as f:
-                f.write(raw)
+                f.write(raw.encode('utf-8'))
             os.chmod(dest, stat.S_IRWXU|stat.S_IRGRP|stat.S_IROTH)
             if os.geteuid() == 0:
                 os.chown(dest, 0, 0)
@@ -823,7 +823,7 @@ class PostInstall:
                 mimetypes.discard('application/octet-stream')
 
                 def write_mimetypes(f):
-                    f.write('MimeType=%s;\n'%';'.join(mimetypes))
+                    f.write(b'MimeType=%s;\n'%';'.join(mimetypes).encode('utf-8'))
 
                 from calibre.ebooks.oeb.polish.main import SUPPORTED
                 from calibre.ebooks.oeb.polish.import_book import IMPORTABLE
@@ -836,7 +836,7 @@ class PostInstall:
                 f = open('calibre-ebook-edit.desktop', 'wb')
                 f.write(ETWEAK)
                 mt = {guess_type('a.' + x.lower())[0] for x in (SUPPORTED|IMPORTABLE)} - {None, 'application/octet-stream'}
-                f.write('MimeType=%s;\n'%';'.join(mt))
+                f.write(b'MimeType=%s;\n'%';'.join(mt).encode('utf-8'))
                 f.close()
                 f = open('calibre-gui.desktop', 'wb')
                 f.write(GUI)
@@ -958,7 +958,7 @@ def opts_and_exts(name, op, exts, cover_opts=('--cover',), opf_opts=(),
             extras.append(special_exts_template%(opt, eexts))
     extras = '\n'.join(extras)
 
-    return '_'+fname+'()'+\
+    return ('_'+fname+'()'+\
 '''
 {
     local cur prev opts
@@ -986,10 +986,10 @@ def opts_and_exts(name, op, exts, cover_opts=('--cover',), opf_opts=(),
 
 }
 complete -o filenames -F _'''%dict(pics=spics,
-    opts=opts, extras=extras, exts=exts) + fname + ' ' + name +"\n\n"
+    opts=opts, extras=extras, exts=exts) + fname + ' ' + name +"\n\n").encode('utf-8')
 
 
-VIEWER = '''\
+VIEWER = b'''\
 [Desktop Entry]
 Version=1.0
 Type=Application
@@ -1003,7 +1003,7 @@ MimeType=application/x-sony-bbeb;
 Categories=Graphics;Viewer;
 '''
 
-EVIEWER = '''\
+EVIEWER = b'''\
 [Desktop Entry]
 Version=1.0
 Type=Application
@@ -1016,7 +1016,7 @@ Icon=calibre-viewer
 Categories=Graphics;Viewer;
 '''
 
-ETWEAK = '''\
+ETWEAK = b'''\
 [Desktop Entry]
 Version=1.0
 Type=Application
@@ -1029,7 +1029,7 @@ Icon=calibre-ebook-edit
 Categories=Office;
 '''
 
-GUI = '''\
+GUI = b'''\
 [Desktop Entry]
 Version=1.0
 Type=Application

--- a/src/calibre/utils/smtp.py
+++ b/src/calibre/utils/smtp.py
@@ -169,11 +169,8 @@ def sendmail(msg, from_, to, localhost=None, verbose=0, timeout=None,
 
 
 def option_parser():
-    try:
-        from calibre.utils.config import OptionParser
-        OptionParser
-    except ImportError:
-        from optparse import OptionParser
+    from optparse import OptionGroup
+    from calibre.utils.config import OptionParser
     parser = OptionParser(_('''\
 %prog [options] [from to text]
 
@@ -188,18 +185,20 @@ from is the email address of the sender and to is the email address
 of the recipient. When a complete email is read from STDIN, from and to
 are only used in the SMTP negotiation, the message headers are not modified.
 '''))
-    c=parser.add_option_group('COMPOSE MAIL',
-        _('Options to compose an email. Ignored if text is not specified')).add_option
+    c_group = OptionGroup(parser, 'COMPOSE MAIL',
+        _('Options to compose an email. Ignored if text is not specified'))
+    c=parser.add_option_group(c_group).add_option
     c('-a', '--attachment', help=_('File to attach to the email'))
     c('-s', '--subject', help=_('Subject of the email'))
 
     parser.add_option('-l', '--localhost',
                       help=_('Host name of localhost. Used when connecting '
                             'to SMTP server.'))
-    r=parser.add_option_group('SMTP RELAY',
+    r_group = OptionGroup(parser, 'SMTP RELAY',
         _('Options to use an SMTP relay server to send mail. '
         'calibre will try to send the email directly unless --relay is '
-        'specified.')).add_option
+        'specified.'))
+    r=parser.add_option_group(r_group).add_option
     r('-r', '--relay', help=_('An SMTP relay server to use to send mail.'))
     r('-p', '--port', default=-1,
       help=_('Port to connect to on relay server. Default is to use 465 if '


### PR DESCRIPTION
It's now possible to bootstrap and **install** calibre under python3, even if it doesn't run.