### PR TITLE
Fix language metadata on device and an option

### DIFF
--- a/src/calibre/devices/kobo/driver.py
+++ b/src/calibre/devices/kobo/driver.py
@@ -24,6 +24,7 @@ from calibre.devices.usbms.books import CollectionsBookList
 from calibre.devices.kobo.books import KTCollectionsBookList
 from calibre.ebooks.metadata import authors_to_string
 from calibre.ebooks.metadata.book.base import Metadata
+from calibre.ebooks.metadata.utils import normalize_languages
 from calibre.devices.kobo.books import Book
 from calibre.devices.kobo.books import ImageWrapper
 from calibre.devices.mime import mime_type_ext
@@ -3080,8 +3081,11 @@ class KOBOTOUCH(KOBO):
                 update_values.append(newmi.isbn)
                 set_clause += ', ISBN = ? '
 
-            if not (newmi.language == kobo_metadata.language):
-                update_values.append(newmi.language)
+            
+            library_language = normalize_languages(kobo_metadata.languages, newmi.languages)
+            library_language = library_language[0] if library_language is not None and len(library_language) > 0 else None
+            if not (library_language == kobo_metadata.language):
+                update_values.append(library_language)
                 set_clause += ', Language = ? '
 
             if self.update_subtitle:

--- a/src/calibre/devices/kobo/kobotouch_config.py
+++ b/src/calibre/devices/kobo/kobotouch_config.py
@@ -112,6 +112,7 @@ class KOBOTOUCHConfig(TabbedDeviceConfig):
         p['show_previews'] = self.show_previews
         p['show_archived_books'] = self.show_archived_books
 
+        p['update_device_metadata'] = self.update_device_metadata
         p['update_series'] = self.update_series
         p['update_core_metadata'] = self.update_core_metadata
         p['update_purchased_kepubs'] = self.update_purchased_kepubs


### PR DESCRIPTION
Kobo changed what format the language is expected to be in the database. Plus I somehow missed saving an option.