### PR TITLE
Fix typo in BS4 changes for fetching annotations

### DIFF
--- a/src/calibre/devices/kindle/driver.py
+++ b/src/calibre/devices/kindle/driver.py
@@ -258,7 +258,7 @@ class KINDLE(USBMS):
                                     typ=user_notes[location]['type']))
 
             for annotation in annotations:
-                annot = BeautifulSoup('<span>' + annotations + '</span>').find('span')
+                annot = BeautifulSoup('<span>' + annotation + '</span>').find('span')
                 divTag.insert(dtc, annot)
                 dtc += 1
 

--- a/src/calibre/devices/kobo/driver.py
+++ b/src/calibre/devices/kobo/driver.py
@@ -1292,7 +1292,7 @@ class KOBO(USBMS):
                               annotation=user_notes[location]['annotation']))
 
             for annotation in annotations:
-                annot = BeautifulSoup('<span>' + annotations + '</span>').find('span')
+                annot = BeautifulSoup('<span>' + annotation + '</span>').find('span')
                 divTag.insert(dtc, annot)
                 dtc += 1
 


### PR DESCRIPTION
I have only tested the Kobo version, but the Kindle is the same at this point.