### PR TITLE
Improve handling of KFX metadata

### DIFF
--- a/src/calibre/ebooks/metadata/kfx.py
+++ b/src/calibre/ebooks/metadata/kfx.py
@@ -254,11 +254,11 @@ def extract_metadata(container_data):
 
     # locate book metadata within the container data structures
 
+    metadata_entity = {}
+
     for entity_type, entity_id, entity_value in container_data:
         if entity_type == PROP_METADATA:
-            for key, value in entity_value.items():
-                if key in METADATA_PROPERTIES:
-                    metadata[METADATA_PROPERTIES[key]].append(value)
+            metadata_entity = entity_value
 
         elif entity_type == PROP_METADATA2:
             if entity_value is not None:
@@ -269,6 +269,10 @@ def extract_metadata(container_data):
         elif entity_type == PROP_IMAGE and COVER_KEY not in metadata:
             # assume first image is the cover
             metadata[COVER_KEY] = entity_value
+
+    for key, value in metadata_entity.items():
+        if key in METADATA_PROPERTIES:
+            metadata[METADATA_PROPERTIES[key]].append(value)
 
     return metadata
 


### PR DESCRIPTION
KFX format has both an old-style and new-style method of handling metadata. Some older KFX books contain both types of metadata and their content does not always match for reason unknown to me.

Process any old-style metadata present in a KFX book last so that new-style metadata will take precedence if both are present. This makes it consistent with how the KFX Input plugin processes metadata and corrects the occasional mismatch of book titles shown in Device view for a Kindle vs. the title shown in calibre if the book is imported.