### PR TITLE
fix CLI completion for ebook-convert

### DIFF
--- a/src/calibre/utils/complete.py
+++ b/src/calibre/utils/complete.py
@@ -117,7 +117,7 @@ class EbookConvert(object):
         self.previous = words[-2 if prefix else -1]
         from calibre.utils.serialize import msgpack_loads
         self.cache = msgpack_loads(open(os.path.join(sys.resources_location,
-            'ebook-convert-complete.calibre_msgpack'), 'rb').read())
+            'ebook-convert-complete.calibre_msgpack'), 'rb').read(), use_list=False)
         self.complete(wc)
 
     def complete(self, wc):

--- a/src/calibre/utils/serialize.py
+++ b/src/calibre/utils/serialize.py
@@ -50,9 +50,9 @@ def create_encoder(for_json=False):
     return encoder
 
 
-def msgpack_dumps(obj):
+def msgpack_dumps(obj, **kw):
     import msgpack
-    return msgpack.packb(obj, default=create_encoder(), use_bin_type=True)
+    return msgpack.packb(obj, default=create_encoder(), use_bin_type=True, **kw)
 
 
 def json_dumps(data, **kw):
@@ -107,9 +107,9 @@ def msgpack_decoder(code, data):
     return decoders[code](msgpack_loads(data), False)
 
 
-def msgpack_loads(dump):
+def msgpack_loads(dump, **kw):
     import msgpack
-    return msgpack.unpackb(dump, ext_hook=msgpack_decoder, raw=False)
+    return msgpack.unpackb(dump, ext_hook=msgpack_decoder, raw=False, **kw)
 
 
 def json_loads(data):


### PR DESCRIPTION
msgpack.loads will produce mutable, unhashable lists by default when unpacking values that were originally saved as dicts with tuple keys. Which ebook-convert-complete does. This results in errors when
trying to reassemble the dict.

Fix by allowing our msgpack wrapper to forward arguments, and by having ebook-convert-complete unpack lists as tuples.