### PR TITLE
Fix problem when CC accesses the content server with the option…

### DIFF
--- a/src/calibre/srv/ajax.py
+++ b/src/calibre/srv/ajax.py
@@ -135,7 +135,7 @@ def book_to_json(ctx, rd, db, book_id,
             for device_class in device_plugins():
                 if device_class.__class__.__name__ == device_for_template:
                     template = device_class.save_template()
-                    data['_filename_'] = create_upload_path(mi, book_id,
+                    data['_filename_'] = create_upload_path(mi, unicode(book_id),
                             template, sanitize, path_type=posixpath)
                     break
 


### PR DESCRIPTION
…device_for_template. Fixes exception
Traceback (most recent call last):
  File "C:\CBH_Data\calibre.git\calibre_dev\src\calibre\srv\ajax.py", line 141, in book_to_json
  File "C:\CBH_Data\calibre.git\calibre_dev\src\calibre\devices\utils.py", line 98, in create_upload_path
  File "C:\CBH_Data\calibre.git\calibre_dev\src\calibre\utils\filenames.py", line 40, in ascii_filename
  File "C:\CBH_Data\calibre.git\calibre_dev\src\calibre\utils\filenames.py", line 30, in ascii_text
AttributeError: 'int' object has no attribute 'decode'

It seems to have broken in 3.42 but I can't figure out why.