### PR TITLE
preferences: fix sort order when moving an action out of the toolbar

### DIFF
--- a/src/calibre/gui2/preferences/toolbar.py
+++ b/src/calibre/gui2/preferences/toolbar.py
@@ -121,7 +121,7 @@ class AllModel(BaseModel):
             actions.append(self.name_to_action(name, self.gui))
         self.beginResetModel()
         self._data.extend(actions)
-        self._data.sort()
+        self._data.sort(key=lambda x: x.action_spec[0] if hasattr(x, 'action_spec') else x.name)
         self.endResetModel()
 
     def remove(self, indices, allowed):


### PR DESCRIPTION
The sort() call is operating on objects that have no comparison functions and span multiple types, so they were always compared by their hash(). This resulted in adding an action, then removing it, causing the entire "Available Actions" box to be sorted seemingly at random.

This was uncovered during python3 porting, as the objects cannot be compared at all and therefore return errors.

The default sort order (before anything is done) is to sort based on pretty names, and therefore use this as the sort key when re-sorting.