### PR TITLE
Git versions in constants.py

### DIFF
--- a/setup/__init__.py
+++ b/setup/__init__.py
@@ -98,8 +98,8 @@ def initialize_constants():
     global __version__, __appname__, modules, functions, basenames, scripts
 
     src = open(os.path.join(SRC, 'calibre/constants.py'), 'rb').read().decode('utf-8')
-    nv = re.search(r'numeric_version\s+=\s+\((\d+), (\d+), (\d+)\)', src)
-    __version__ = '%s.%s.%s'%(nv.group(1), nv.group(2), nv.group(3))
+    nv = eval(re.search(r'numeric_version = (\(.*?\))', src).group(1))
+    __version__   = u'.'.join(map(str if ispy3 else unicode, nv))
     __appname__ = re.search(r'__appname__\s+=\s+(u{0,1})[\'"]([^\'"]+)[\'"]',
             src).group(2)
     epsrc = re.compile(r'entry_points = (\{.*?\})', re.DOTALL).\

--- a/setup/__init__.py
+++ b/setup/__init__.py
@@ -97,13 +97,15 @@ def require_clean_git():
 def initialize_constants():
     global __version__, __appname__, modules, functions, basenames, scripts
 
-    src = open(os.path.join(SRC, 'calibre/constants.py'), 'rb').read().decode('utf-8')
+    with open(os.path.join(SRC, 'calibre/constants.py'), 'rb') as f:
+        src = f.read().decode('utf-8')
     nv = eval(re.search(r'numeric_version = (\(.*?\))', src).group(1))
     __version__   = u'.'.join(map(str if ispy3 else unicode, nv))
     __appname__ = re.search(r'__appname__\s+=\s+(u{0,1})[\'"]([^\'"]+)[\'"]',
             src).group(2)
-    epsrc = re.compile(r'entry_points = (\{.*?\})', re.DOTALL).\
-            search(open(os.path.join(SRC, 'calibre/linux.py'), 'rb').read().decode('utf-8')).group(1)
+    with open(os.path.join(SRC, 'calibre/linux.py'), 'rb') as f:
+        epsrc = re.compile(r'entry_points = (\{.*?\})', re.DOTALL).\
+            search(f.read().decode('utf-8')).group(1)
     entry_points = eval(epsrc, {'__appname__': __appname__})
 
     def e2b(ep):

--- a/setup/commands.py
+++ b/setup/commands.py
@@ -10,6 +10,7 @@ __all__ = [
         'pot', 'translations', 'get_translations', 'iso639', 'iso3166',
         'build', 'mathjax', 'man_pages',
         'gui',
+        'git_version',
         'develop', 'install',
         'kakasi', 'coffee', 'rapydscript', 'cacerts', 'recent_uas', 'resources',
         'check', 'test',
@@ -39,6 +40,9 @@ build = Build()
 
 from setup.mathjax import MathJax
 mathjax = MathJax()
+
+from setup.git_version import GitVersion
+git_version = GitVersion()
 
 from setup.install import Develop, Install, Sdist, Bootstrap
 develop = Develop()

--- a/setup/git_version.py
+++ b/setup/git_version.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python2
+# vim:fileencoding=utf-8
+# License: GPLv3 Copyright: 2019, Eli Schwartz <eschwartz@archlinux.org>
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import re
+import subprocess
+
+from setup import Command
+
+class GitVersion(Command):
+
+    description = 'Update the version from git metadata'
+
+    def run(self, opts):
+        def try_int(i):
+            try:
+                return int(i)
+            except:
+                return i
+
+        constants_file = self.j(self.SRC, 'calibre', 'constants.py')
+
+        with open(constants_file, 'rb') as f:
+            src = f.read().decode('utf-8')
+
+        try:
+            nv = subprocess.check_output(['git', 'describe'], stderr=subprocess.STDOUT)
+            nv = re.sub(r'([^-]*-g)', r'r\1', nv.decode('utf-8')[1:].strip())
+            nv = tuple(map(try_int, re.split(r'\.|-', nv)))
+        except subprocess.CalledProcessError:
+            print('Error: not a git checkout')
+            raise SystemExit(1)
+        newsrc = re.sub(r'(numeric_version = )(\(.*?\))', r'\1%s' % repr(nv), src)
+        self.info('new version is:', nv)
+
+        with open(constants_file, 'wb') as f:
+            f.write(newsrc.encode('utf-8'))


### PR DESCRIPTION
I would like to see a git version when running/installing calibre from git; I've been testing the modification of numeric_version for a long time now without ill effects.

This PR:
- prevents setup.py from breaking when it sees such a version that is manually added
- adds a way to conveniently bump this version without requiring custom hacks

For 99% of people and use cases this has no effect, positive or negative.