### PR TITLE
Staged install: misc fixups

### DIFF
--- a/setup/install.py
+++ b/setup/install.py
@@ -214,6 +214,8 @@ class Install(Develop):
             the environment variables:
             XDG_DATA_DIRS=/usr/share equivalent
             XDG_UTILS_INSTALL_MODE=system
+            For staged installs this will be automatically set to:
+            <staging_root>/share
     ''')
     short_description = 'Install calibre from source'
 

--- a/setup/install.py
+++ b/setup/install.py
@@ -135,8 +135,8 @@ class Develop(Command):
         self.opts = opts
         self.regain_privileges()
         self.consolidate_paths()
-        self.write_templates()
         self.install_files()
+        self.write_templates()
         self.run_postinstall()
         self.install_env_module()
         self.success()

--- a/src/calibre/linux.py
+++ b/src/calibre/linux.py
@@ -723,7 +723,8 @@ class PostInstall:
             self.setup_completion()
         if islinux or isbsd:
             self.setup_desktop_integration()
-        self.create_uninstaller()
+        if not getattr(self.opts, 'staged_install', False):
+            self.create_uninstaller()
 
         from calibre.utils.config import config_dir
         if os.path.exists(config_dir):

--- a/src/calibre/linux.py
+++ b/src/calibre/linux.py
@@ -127,11 +127,12 @@ if not frozen_path or not os.path.exists(os.path.join(frozen_path, 'resources', 
     frozen_path = None
 
 for f in {mime_resources!r}:
-    cmd = ['xdg-mime', 'uninstall', f]
-    print ('Removing mime resource:', os.path.basename(f))
-    ret = subprocess.call(cmd, shell=False)
-    if ret != 0:
-        print ('WARNING: Failed to remove mime resource', f)
+    if os.path.exists(f):
+        cmd = ['xdg-mime', 'uninstall', f]
+        print ('Removing mime resource:', os.path.basename(f))
+        ret = subprocess.call(cmd, shell=False)
+        if ret != 0:
+            print ('WARNING: Failed to remove mime resource', f)
 
 for x in tuple({manifest!r}) + tuple({appdata_resources!r}) + (os.path.abspath(__file__), __file__, frozen_path):
     if not x or not os.path.exists(x):
@@ -890,14 +891,16 @@ class PostInstall:
                     ak = x.partition('.')[0]
                     if ak in APPDATA and os.access(appdata, os.W_OK):
                         self.appdata_resources.append(write_appdata(ak, APPDATA[ak], appdata, translators))
-                MIME = P('calibre-mimetypes.xml')
+                MIME_BASE = 'calibre-mimetypes.xml'
+                MIME = P(MIME_BASE)
                 self.mime_resources.append(MIME)
+                self.mime_resources.append(os.path.join(self.opts.staging_sharedir, MIME_BASE))
                 if not getattr(self.opts, 'staged_install', False):
                     cc(['xdg-mime', 'install', MIME])
                     cc(['xdg-desktop-menu', 'forceupdate'])
                 else:
                     from shutil import copyfile
-                    copyfile(MIME, os.path.join(env['XDG_DATA_DIRS'], 'mime', 'packages', os.path.basename(MIME)))
+                    copyfile(MIME, os.path.join(env['XDG_DATA_DIRS'], 'mime', 'packages', MIME_BASE))
         except Exception:
             if self.opts.fatal_errors:
                 raise


### PR DESCRIPTION
When installing calibre for distro packaging, there are some slightly non-intuitive snags. The primary issues are:
- calibre-uninstall is useless as we don't want to give users the option to circumvent the package manager
- xdg-utils doesn't really have a decent mode for doing staged (`DESTDIR`) installs, thus, some hacks are needed. I've long since implemented these hacks in my packaging, but I suspect others have not... and anyway I would like to drop this code from my packaging, so here is my attempt to merge those actions directly into calibre's build system.

The changes I've implemented here are intended to only run when --prefix is not the same as --staging-root, since we can presume in that case that any user who is not installing directly to their final destination (a live system), is instead installing in a packaging build script. In such cases, we can assume in response to the first concern, that the tool which moves files from the staging root, can also delete them when they are no longer wanted, and in response to the second concern, we do not care what the local system administrator has defined for their custom XDG_DATA_DIRS setup -- we will just install to the standard default for packaging purposes.