### PR TITLE
setup: add subcommand to update the version in constants.py from git

### DIFF
--- a/setup/commands.py
+++ b/setup/commands.py
@@ -10,6 +10,7 @@ __all__ = [
         'pot', 'translations', 'get_translations', 'iso639', 'iso3166',
         'build', 'mathjax', 'man_pages',
         'gui',
+        'git_version',
         'develop', 'install',
         'kakasi', 'coffee', 'rapydscript', 'cacerts', 'recent_uas', 'resources',
         'check', 'test',
@@ -39,6 +40,9 @@ build = Build()
 
 from setup.mathjax import MathJax
 mathjax = MathJax()
+
+from setup.git_version import GitVersion
+git_version = GitVersion()
 
 from setup.install import Develop, Install, Sdist, Bootstrap
 develop = Develop()

--- a/setup/git_version.py
+++ b/setup/git_version.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python2
+# vim:fileencoding=utf-8
+# License: GPLv3 Copyright: 2019, Eli Schwartz <eschwartz@archlinux.org>
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import re
+import subprocess
+
+from setup import Command
+
+class GitVersion(Command):
+
+    description = 'Update the version from git metadata'
+
+    def run(self, opts):
+        constants_file = self.j(self.SRC, 'calibre', 'constants.py')
+
+        with open(constants_file, 'rb') as f:
+            src = f.read().decode('utf-8')
+
+        try:
+            nv = subprocess.check_output(['git', 'describe'], stderr=subprocess.STDOUT)
+            nv = re.sub(r'([^-]*-g)', r'r\1', nv.decode('utf-8').strip().lstrip('v'))
+            nv = nv.replace('-', '.')
+        except subprocess.CalledProcessError:
+            print('Error: not a git checkout')
+            raise SystemExit(1)
+        newsrc = re.sub(r'(git_version   = ).*', r'\1%s' % repr(nv), src)
+        self.info('new version is:', nv)
+
+        with open(constants_file, 'wb') as f:
+            f.write(newsrc.encode('utf-8'))

--- a/src/calibre/constants.py
+++ b/src/calibre/constants.py
@@ -8,6 +8,7 @@ import sys, locale, codecs, os, importlib, collections
 __appname__   = u'calibre'
 numeric_version = (3, 42, 0)
 __version__   = u'.'.join(map(unicode_type, numeric_version))
+git_version   = None
 __author__    = u"Kovid Goyal <kovid@kovidgoyal.net>"
 
 '''
@@ -285,9 +286,12 @@ del dv
 
 def get_version():
     '''Return version string for display to user '''
-    v = __version__
-    if numeric_version[-1] == 0:
-        v = v[:-2]
+    if git_version is not None:
+        v = git_version
+    else:
+        v = __version__
+        if numeric_version[-1] == 0:
+            v = v[:-2]
     if is_running_from_develop:
         v += '*'
     if iswindows and is64bit:


### PR DESCRIPTION
This creates an additional variable containing the version number extracted from a git checkout via `git describe`, and diverts all human-readable output to use that via get_version.

Take 2, incorporates feedback from #985