### PR TITLE
Update testsuite for html5-parser 0.4.6 changes

### DIFF
--- a/src/calibre/library/comments.py
+++ b/src/calibre/library/comments.py
@@ -163,7 +163,7 @@ def find_tests():
                         '<p class="description">lineone</p>\n<p class="description">linetwo</p>'),
 
                     ('a <b>b&c</b>\nf',
-                        '<p class="description">a <b>b&amp;c</b><br>f</p>'),
+                        '<p class="description">a <b>b&amp;c</b><br/>f</p>'),
 
                     ('a <?xml asd> b\n\ncd',
                         '<p class="description">a  b</p><p class="description">cd</p>'),


### PR DESCRIPTION
empty `<br />` tags should really have a slash at the end rather than being `<br>`. html5-parser no longer converts the former to the latter as of https://github.com/kovidgoyal/html5-parser/commit/8187842835ca54f78de0a148a02da97df7b6f7e1

In order to pass CI, I believe this will require updating the prebuilt travis sw bundles.