### PR TITLE
py3: Remove last occurrence of os.getcwdu()

### DIFF
--- a/src/duktape/__init__.py
+++ b/src/duktape/__init__.py
@@ -17,7 +17,7 @@ from polyglot.builtins import reraise
 
 from calibre.constants import iswindows
 from calibre.utils.filenames import atomic_rename
-from polyglot.builtins import error_message
+from polyglot.builtins import error_message, getcwd
 
 Context_, undefined = dukpy.Context, dukpy.undefined
 
@@ -256,12 +256,12 @@ class Context(object):
     def __init__(self, base_dirs=(), builtin_modules=None):
         self._ctx = Context_()
         self.g = self._ctx.g
-        self.g.Duktape.load_file = partial(load_file, base_dirs or (os.getcwdu(),), builtin_modules or {})
+        self.g.Duktape.load_file = partial(load_file, base_dirs or (getcwd(),), builtin_modules or {})
         self.g.Duktape.pyreadfile = readfile
         self.g.Duktape.pywritefile = writefile
         self.g.Duktape.create_context = partial(create_context, base_dirs)
         self.g.Duktape.run_in_context = run_in_context
-        self.g.Duktape.cwd = os.getcwdu
+        self.g.Duktape.cwd = getcwd
         self.g.Duktape.sha1sum = sha1sum
         self.g.Duktape.dirname = os.path.dirname
         self.g.Duktape.errprint = lambda *args: print(*args, file=sys.stderr)


### PR DESCRIPTION
Bootstrapping of Calibre with Python 3 currently fails with the following error message:
```
  File "/home//aimylios/calibre/src/duktape/__init__.py", line 259, in __init__
    self.g.Duktape.load_file = partial(load_file, base_dirs or (os.getcwdu(),), builtin_modules or {})
AttributeError: module 'os' has no attribute 'getcwdu'
```

This commit replaces the last occurrence of os.getcwdu() with getcwd from polyglot.builtins to fix this issue. Bootstrapping with Python 3 still does not work for me, but at least I get a different error message.