### PR TITLE
Further improve handling of books with both old and new style KFX met…

### DIFF
--- a/src/calibre/ebooks/metadata/kfx.py
+++ b/src/calibre/ebooks/metadata/kfx.py
@@ -271,7 +271,7 @@ def extract_metadata(container_data):
             metadata[COVER_KEY] = entity_value
 
     for key, value in metadata_entity.items():
-        if key in METADATA_PROPERTIES:
+        if key in METADATA_PROPERTIES and METADATA_PROPERTIES[key] not in metadata:
             metadata[METADATA_PROPERTIES[key]].append(value)
 
     return metadata


### PR DESCRIPTION
…adata

Refinement to earlier KFX metadata patch. Prevent author names from old-style KFX metadata from being merged with those from new-style KFX metadata. This produces results that match what the Kindle shows for books that contain both forms of metadata.