### PR TITLE
py3: fix regression in commit 96a8aeaaf5420dcdbb3cbeb1856a4985e8942395

### DIFF
--- a/recipes/insider.recipe
+++ b/recipes/insider.recipe
@@ -29,7 +29,7 @@ class insider(BasicNewsRecipe):
         br['login-password'] = self.password
         res = br.submit()
         raw = res.read()
-        if b'Odhlásit se' not in raw:
+        if 'Odhlásit se'.encode('utf-8') not in raw:
             raise ValueError('Failed to login to insider.cz'
                              'Check your username and password.')
         return br


### PR DESCRIPTION
Strings that contain non-ascii literal characters cannot be made into bytestrings merely by adding b'' and must either be encoded or use hex escapes.