### PR TITLE
Remove space characters from djvu shebangs

### DIFF
--- a/src/calibre/ebooks/djvu/__init__.py
+++ b/src/calibre/ebooks/djvu/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env  python2
+#!/usr/bin/env python2
 from __future__ import (unicode_literals, division, absolute_import,
                         print_function)
 

--- a/src/calibre/ebooks/djvu/djvu.py
+++ b/src/calibre/ebooks/djvu/djvu.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2
+#!/usr/bin/env python2
 # coding: utf-8
 from __future__ import (unicode_literals, division, absolute_import,
                         print_function)

--- a/src/calibre/ebooks/djvu/djvubzzdec.py
+++ b/src/calibre/ebooks/djvu/djvubzzdec.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2
+#!/usr/bin/env python2
 # coding: utf-8
 from __future__ import (unicode_literals, division, absolute_import,
                         print_function)


### PR DESCRIPTION
The surplus space characters may confuse packaging scripts that try to automatically find and delete or modify shebang lines, e.g. to replace "#!/usr/bin/env python3" by "#!/usr/bin/python3".