### PR TITLE
py3: Load plugins from the same (correct) path

### DIFF
--- a/src/calibre/gui2/__init__.py
+++ b/src/calibre/gui2/__init__.py
@@ -21,7 +21,7 @@ from PyQt5.QtWidgets import QStyle  # Gives a nicer error message than import fr
 from calibre import as_unicode, prints
 from calibre.constants import (
     DEBUG, __appname__ as APP_UID, __version__, config_dir, filesystem_encoding,
-    is_running_from_develop, isbsd, isfrozen, islinux, isosx, iswindows, isxp,
+    is_running_from_develop, isbsd, isfrozen, islinux, isosx, ispy3, iswindows, isxp,
     plugins
 )
 from calibre.ebooks.metadata import MetaInformation
@@ -821,7 +821,10 @@ class Application(QApplication):
         if headless:
             if not args:
                 args = sys.argv[:1]
-            args.extend(['-platformpluginpath', sys.extensions_location, '-platform', 'headless'])
+            plugins_loc = sys.extensions_location
+            if ispy3:
+                plugins_loc = os.path.join(plugins_loc, '3')
+            args.extend(['-platformpluginpath', plugins_loc, '-platform', 'headless'])
         self.headless = headless
         qargs = [i.encode('utf-8') if isinstance(i, unicode_type) else i for i in args]
         self.pi, pi_err = plugins['progress_indicator']
@@ -1167,7 +1170,10 @@ def ensure_app(headless=True):
             args = sys.argv[:1]
             has_headless = isosx or islinux or isbsd
             if headless and has_headless:
-                args += ['-platformpluginpath', sys.extensions_location, '-platform', 'headless']
+                plugins_loc = sys.extensions_location
+                if ispy3:
+                    plugins_loc = os.path.join(plugins_loc, '3')
+                args += ['-platformpluginpath', plugins_loc, '-platform', 'headless']
             _store_app = QApplication(args)
             if headless and has_headless:
                 _store_app.headless = True

--- a/src/calibre/library/sqlite.py
+++ b/src/calibre/library/sqlite.py
@@ -17,7 +17,7 @@ from functools import partial
 from calibre.ebooks.metadata import title_sort, author_to_author_sort
 from calibre.utils.date import parse_date, isoformat, local_tz, UNDEFINED_DATE
 from calibre import isbytestring, force_unicode
-from calibre.constants import iswindows, DEBUG, plugins
+from calibre.constants import iswindows, DEBUG, plugins, ispy3
 from calibre.utils.icu import sort_key
 from calibre import prints
 from polyglot.builtins import unicode_type, cmp
@@ -238,7 +238,10 @@ def icu_collator(s1, s2):
 def load_c_extensions(conn, debug=DEBUG):
     try:
         conn.enable_load_extension(True)
-        ext_path = os.path.join(sys.extensions_location, 'sqlite_custom.'+
+        plugins_loc = sys.extensions_location
+        if ispy3:
+            plugins_loc = os.path.join(plugins_loc, '3')
+        ext_path = os.path.join(plugins_loc, 'sqlite_custom.'+
                 ('pyd' if iswindows else 'so'))
         conn.load_extension(ext_path)
         conn.enable_load_extension(False)

--- a/src/calibre/test_build.py
+++ b/src/calibre/test_build.py
@@ -87,6 +87,9 @@ class BuildTest(unittest.TestCase):
         del ifaddr
 
     def test_plugins(self):
+        plugins_loc = sys.extensions_location
+        if ispy3:
+            plugins_loc = os.path.join(plugins_loc, '3')
         exclusions = set()
         if is_ci:
             if isosx:
@@ -103,7 +106,7 @@ class BuildTest(unittest.TestCase):
             if name in exclusions:
                 if name in ('libusb', 'libmtp'):
                     # Just check that the DLL can be loaded
-                    ctypes.CDLL(os.path.join(sys.extensions_location, name + ('.dylib' if isosx else '.so')))
+                    ctypes.CDLL(os.path.join(plugins_loc, name + ('.dylib' if isosx else '.so')))
                 continue
             mod, err = plugins[name]
             self.assertFalse(err or not mod, 'Failed to load plugin: ' + name + ' with error:\n' + err)


### PR DESCRIPTION
Running the Calibre test suite in a pure Python 3 build, i.e.
```
CALIBRE_PY3_PORT=1 python3 setup.py bootstrap
CALIBRE_PY3_PORT=1 python3 setup.py build
CALIBRE_PY3_PORT=1 python3 setup.py test
```

currently leads to the following error messages:

```
test_qt (calibre.test_build.BuildTest) ... qt.qpa.plugin: Could not find the Qt platform plugin "headless" in "/home/aimylios/Calibre/calibre/src/calibre/plugins"
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Available platform plugins are: eglfs, linuxfb, minimal, minimalegl, offscreen, vnc, wayland-egl, wayland, wayland-xcomposite-egl, wayland-xcomposite-glx, xcb.
```
```
test_sqlite (calibre.test_build.BuildTest) ... Failed to load high performance sqlite C extension
/home/aimylios/Calibre/calibre/src/calibre/plugins/sqlite_custom.so.so: cannot open shared object file: No such file or directory
FAIL [0.01 s]

======================================================================
FAIL: test_sqlite (calibre.test_build.BuildTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/aimylios/Calibre/calibre/src/calibre/test_build.py", line 173, in test_sqlite
    self.assertTrue(load_c_extensions(conn, True), 'Failed to load sqlite extension')
AssertionError: False is not true : Failed to load sqlite extension
```

Calibre expects to find `libheadless.so` and `sqlite_custom.so` in `calibre/plugins/`, but installs them to `calibre/plugins/3/`. This is caused by the fact that `sys.extensions_location` is referenced to load these two libs.
I fixed this error by copying the approach from `load_plugin()` in `constants.py` to all other occurences where libraries are loaded. This is of course not the most elegant solution, as now there are five different places in four different files where the plugin path is derived from `sys.extensions_location` and the Python version. It might be better to do this only once and export the result or modify `sys.extensions_location` directly (although I don't know how the latter would affect non-Linux builds).