### PR TITLE
Greater control over Kobo thumbnails & sleep cover processing

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -399,6 +399,9 @@ Files: src/calibre/translations/msgfmt.py
 Copyright: Martin v. Loewis
 License: Python Software Foundation License
 
+Files: src/calibre/utils/imageops/ordered_dither.cpp
+Copyright: Copyright 1999-2019 ImageMagick Studio LLC
+License: ImageMagick License
 
 BSD License (for all the BSD licensed code indicated above)
 -----------------------------------------------------------
@@ -581,3 +584,110 @@ whether future versions of the GNU Lesser General Public License shall
 apply, that proxy's public statement of acceptance of any version is
 permanent authorization for you to choose that version for the
 Library.
+
+ImageMagick License (for all the ImageMagick licensed code indicated above)
+-----------------------------------------------------------
+
+Before we get to the text of the license, lets just review what the license says in simple terms:
+
+It allows you to:
+
+  * freely download and use ImageMagick software, in whole or in part, for personal, company internal, or commercial purposes;
+  * use ImageMagick software in packages or distributions that you create;
+  * link against a library under a different license;
+  * link code under a different license against a library under this license;
+  * merge code into a work under a different license;
+  * extend patent grants to any code using code under this license;
+  * and extend patent protection.
+
+It forbids you to:
+
+  * redistribute any piece of ImageMagick-originated software without proper attribution;
+  * use any marks owned by ImageMagick Studio LLC in any way that might state or imply that ImageMagick Studio LLC endorses your distribution;
+  * use any marks owned by ImageMagick Studio LLC in any way that might state or imply that you created the ImageMagick software in question.
+
+It requires you to:
+
+  * include a copy of the license in any redistribution you may make that includes ImageMagick software;
+  * provide clear attribution to ImageMagick Studio LLC for any distributions that include ImageMagick software.
+
+It does not require you to:
+
+  * include the source of the ImageMagick software itself, or of any modifications you may have made to it, in any redistribution you may assemble that includes it;
+  * submit changes that you make to the software back to the ImageMagick Studio LLC (though such feedback is encouraged).
+
+A few other clarifications include:
+
+  * ImageMagick is freely available without charge;
+  * you may include ImageMagick on a DVD as long as you comply with the terms of the license;
+  * you can give modified code away for free or sell it under the terms of the ImageMagick license or distribute the result under a different license, but you need to acknowledge the use of the ImageMagick software;
+  * the license is compatible with the GPL V3.
+  * when exporting the ImageMagick software, review its export classification.
+
+Terms and Conditions for Use, Reproduction, and Distribution
+
+The legally binding and authoritative terms and conditions for use, reproduction, and distribution of ImageMagick follow:
+
+Copyright 1999-2019 ImageMagick Studio LLC, a non-profit organization dedicated to making software imaging solutions freely available.
+
+1. Definitions.
+
+License shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+Licensor shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+Legal Entity shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, control means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+You (or Your) shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+Source form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+Object form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+Work shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+Derivative Works shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+Contribution shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as Not a Contribution.
+
+Contributor shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+  * You must give any other recipients of the Work or Derivative Works a copy of this License; and
+  * You must cause any modified files to carry prominent notices stating that You changed the files; and
+  * You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+  * If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+How to Apply the License to your Work
+
+To apply the ImageMagick License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information (don't include the brackets). The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the ImageMagick License (the "License"); you may not use
+   this file except in compliance with the License.  You may obtain a copy
+   of the License at
+
+     https://imagemagick.org/script/license.php
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+   License for the specific language governing permissions and limitations
+   under the License.

--- a/setup/extensions.json
+++ b/setup/extensions.json
@@ -139,7 +139,7 @@
     },
     {
         "name": "imageops",
-        "sources": "calibre/utils/imageops/imageops.cpp calibre/utils/imageops/quantize.cpp",
+        "sources": "calibre/utils/imageops/imageops.cpp calibre/utils/imageops/quantize.cpp calibre/utils/imageops/ordered_dither.cpp",
         "headers": "calibre/utils/imageops/imageops.h",
         "sip_files": "calibre/utils/imageops/imageops.sip",
         "inc_dirs": "calibre/utils/imageops"

--- a/src/calibre/devices/kobo/driver.py
+++ b/src/calibre/devices/kobo/driver.py
@@ -1023,7 +1023,7 @@ class KOBO(USBMS):
             debug_print('FAILED to upload cover', filepath)
 
     def _upload_cover(self, path, filename, metadata, filepath, uploadgrayscale, ditheredcovers, letterboxcovers, pngcovers):
-        from calibre.utils.img import save_cover_data_to, optimize_png
+        from calibre.utils.img import save_cover_data_to
         if metadata.cover:
             cover = self.normalize_path(metadata.cover.replace('/', os.sep))
 
@@ -1076,9 +1076,6 @@ class KOBO(USBMS):
                             with lopen(fpath, 'wb') as f:
                                 f.write(data)
                                 fsync(f)
-
-                            if pngcovers:
-                                optimize_png(fpath)
 
                 else:
                     debug_print("ImageID could not be retreived from the database")
@@ -2700,7 +2697,6 @@ class KOBOTOUCH(KOBO):
 
     def _upload_cover(self, path, filename, metadata, filepath, upload_grayscale, dithered_covers=False, keep_cover_aspect=False, letterbox_fs_covers=False, png_covers=False):
         from calibre.utils.imghdr import identify
-        from calibre.utils.img import optimize_png
         debug_print("KoboTouch:_upload_cover - filename='%s' upload_grayscale='%s' dithered_covers='%s' "%(filename, upload_grayscale, dithered_covers))
 
         if not metadata.cover:
@@ -2784,9 +2780,6 @@ class KOBOTOUCH(KOBO):
                         with lopen(fpath, 'wb') as f:
                             f.write(data)
                             fsync(f)
-
-                        if png_covers:
-                            optimize_png(fpath)
         except Exception as e:
             err = unicode_type(e)
             debug_print("KoboTouch:_upload_cover - Exception string: %s"%err)

--- a/src/calibre/devices/kobo/driver.py
+++ b/src/calibre/devices/kobo/driver.py
@@ -1442,7 +1442,7 @@ class KOBOTOUCH(KOBO):
     # NOTE: Values pulled from Nickel by @geek1011,
     #       c.f., this handy recap: https://github.com/shermp/Kobo-UNCaGED/issues/16#issuecomment-494229994
     #       Only the N3_FULL values differ, as they should match the screen's effective resolution.
-    #       Note that All Kobo devices share a common AR at roughly 0.75,
+    #       Note that all Kobo devices share a common AR at roughly 0.75,
     #       so results should be similar, no matter the exact device.
     COVER_FILE_ENDINGS = {
                           # Used for screensaver, home screen
@@ -2683,12 +2683,11 @@ class KOBOTOUCH(KOBO):
         :param kobo_size:     Size of the cover image on the device.
         :param upload_grayscale: boolean True if driver configured to send grayscale thumbnails
         :param dithered_covers: boolean True if driver configured to quantize to 16-col grayscale
-                        at calibre end
         :param keep_cover_aspect: boolean - True if the aspect ratio of the cover in the library is to be kept.
         :param is_full_size:  True if this is the kobo_size is for the full size cover image
                         Passed to allow ability to process screensaver differently
                         to smaller thumbnails
-        :param letterbox:     True if we were asked to handle the letterboxing at calibre end
+        :param letterbox:     True if we were asked to handle the letterboxing
         :param png_covers:    True if we were asked to encode those images in PNG instead of JPG
         '''
 

--- a/src/calibre/devices/kobo/driver.py
+++ b/src/calibre/devices/kobo/driver.py
@@ -1444,62 +1444,42 @@ class KOBOTOUCH(KOBO):
     #       Only the N3_FULL values differ, as they should match the screen's effective resolution.
     #       Note that all Kobo devices share a common AR at roughly 0.75,
     #       so results should be similar, no matter the exact device.
-    COVER_FILE_ENDINGS = {
-                          # Used for screensaver, home screen
-                          ' - N3_FULL.parsed':[(600,800),0, 200,True,],
+    # Common to all Kobo models
+    COMMON_COVER_FILE_ENDINGS = {
                           # Used for Details screen before FW2.8.1, then for current book tile on home screen
-                          ' - N3_LIBRARY_FULL.parsed':[(355,530),0, 200,False,],
+                          ' - N3_LIBRARY_FULL.parsed':              [(355,530),0, 200,False,],
                           # Used for library lists
-                          ' - N3_LIBRARY_GRID.parsed':[(149,223),0, 200,False,],
+                          ' - N3_LIBRARY_GRID.parsed':              [(149,223),0, 200,False,],
                           # Used for library lists
-                          ' - N3_LIBRARY_LIST.parsed':[(60,90),0, 53,False,],
+                          ' - N3_LIBRARY_LIST.parsed':              [(60,90),0, 53,False,],
                           # Used for Details screen from FW2.8.1
-                          ' - AndroidBookLoadTablet_Aspect.parsed':[(355,530), 82, 100,False,],
+                          ' - AndroidBookLoadTablet_Aspect.parsed': [(355,530), 82, 100,False,],
+                          }
+    # Legacy 6" devices
+    LEGACY_COVER_FILE_ENDINGS = {
+                          # Used for screensaver, home screen
+                          ' - N3_FULL.parsed':        [(600,800),0, 200,True,],
                           }
     # Glo
     GLO_COVER_FILE_ENDINGS = {
                           # Used for screensaver, home screen
-                          ' - N3_FULL.parsed':[(758,1024),0, 200,True,],
-                          # Used for Details screen before FW2.8.1, then for current book tile on home screen
-                          ' - N3_LIBRARY_FULL.parsed':[(355,530),0, 200,False,],
-                          # Used for library lists
-                          ' - N3_LIBRARY_GRID.parsed':[(149,223),0, 200,False,],
-                          # Used for Details screen from FW2.8.1
-                          ' - AndroidBookLoadTablet_Aspect.parsed':[(355,530), 88, 100,False,],
+                          ' - N3_FULL.parsed':        [(758,1024),0, 200,True,],
                           }
     # Aura
     AURA_COVER_FILE_ENDINGS = {
                           # Used for screensaver, home screen
                           # NOTE: The Aura's bezel covers 10 pixels at the bottom.
                           #       Kobo officially advertised the screen resolution with those chopped off.
-                          ' - N3_FULL.parsed':[(758,1014),0, 200,True,],
-                          # Used for Details screen before FW2.8.1, then for current book tile on home screen
-                          ' - N3_LIBRARY_FULL.parsed':[(355,530),0, 200,False,],
-                          # Used for library lists
-                          ' - N3_LIBRARY_GRID.parsed':[(149,223),0, 200,False,],
-                          # Used for Details screen from FW2.8.1
-                          ' - AndroidBookLoadTablet_Aspect.parsed':[(355,530), 88, 100,False,],
+                          ' - N3_FULL.parsed':        [(758,1014),0, 200,True,],
                           }
     # Glo HD and Clara HD share resolution, so the image sizes should be the same.
     GLO_HD_COVER_FILE_ENDINGS = {
                           # Used for screensaver, home screen
                           ' - N3_FULL.parsed':        [(1072,1448), 0, 200,True,],
-                          # Used for Details screen before FW2.8.1, then for current book tile on home screen
-                          ' - N3_LIBRARY_FULL.parsed':[(355,530),0, 200,False,],
-                          # Used for library lists
-                          ' - N3_LIBRARY_GRID.parsed':[(149,223),0, 200,False,],
-                          # Used for Details screen from FW2.8.1
-                          ' - AndroidBookLoadTablet_Aspect.parsed':[(355,530), 88, 100,False,],
                           }
     AURA_HD_COVER_FILE_ENDINGS = {
                           # Used for screensaver, home screen
                           ' - N3_FULL.parsed':        [(1080,1440), 0, 200,True,],
-                          # Used for Details screen before FW2.8.1, then for current book tile on home screen
-                          ' - N3_LIBRARY_FULL.parsed':[(355,530),0, 200,False,],
-                          # Used for library lists
-                          ' - N3_LIBRARY_GRID.parsed':[(149,223),0, 200,False,],
-                          # Used for Details screen from FW2.8.1
-                          ' - AndroidBookLoadTablet_Aspect.parsed':[(355,530), 88, 100,False,],
                           }
     AURA_H2O_COVER_FILE_ENDINGS = {
                           # Used for screensaver, home screen
@@ -1507,30 +1487,16 @@ class KOBOTOUCH(KOBO):
                           #       Unlike on the Aura, Nickel fails to account for this when generating covers.
                           #       c.f., https://github.com/shermp/Kobo-UNCaGED/pull/17#discussion_r286209827
                           ' - N3_FULL.parsed':        [(1080,1429), 0, 200,True,],
-                          # Used for Details screen before FW2.8.1, then for current book tile on home screen
-                          ' - N3_LIBRARY_FULL.parsed':[(355,530),0, 200,False,],
-                          # Used for library lists
-                          ' - N3_LIBRARY_GRID.parsed':[(149,223),0, 200,False,],
-                          # Used for Details screen from FW2.8.1
-                          ' - AndroidBookLoadTablet_Aspect.parsed':[(355,530), 88, 100,False,],
                           }
     AURA_ONE_COVER_FILE_ENDINGS = {
                           # Used for screensaver, home screen
                           ' - N3_FULL.parsed':        [(1404,1872), 0, 200,True,],
-                          # Used for Details screen before FW2.8.1, then for current book tile on home screen
-                          ' - N3_LIBRARY_FULL.parsed':[(355,530),0, 200,False,],
-                          # Used for library lists
-                          ' - N3_LIBRARY_GRID.parsed':[(149,223),0, 200,False,],
                           }
     FORMA_COVER_FILE_ENDINGS = {
                           # Used for screensaver, home screen
                           # NOTE: Nickel currently fails to honor the real screen resolution when generating covers,
                           #       choosing instead to follow the Aura One codepath.
                           ' - N3_FULL.parsed':        [(1440,1920), 0, 200,True,],
-                          # Used for Details screen before FW2.8.1, then for current book tile on home screen
-                          ' - N3_LIBRARY_FULL.parsed':[(355,530),0, 200,False,],
-                          # Used for library lists
-                          ' - N3_LIBRARY_GRID.parsed':[(149,223),0, 200,False,],
                           }
     # Following are the sizes used with pre2.1.4 firmware
 #    COVER_FILE_ENDINGS = {
@@ -3366,15 +3332,18 @@ class KOBOTOUCH(KOBO):
         elif self.isGloHD():
             _cover_file_endings = self.GLO_HD_COVER_FILE_ENDINGS
         elif self.isMini():
-            _cover_file_endings = self.COVER_FILE_ENDINGS
+            _cover_file_endings = self.LEGACY_COVER_FILE_ENDINGS
         elif self.isTouch():
-            _cover_file_endings = self.COVER_FILE_ENDINGS
+            _cover_file_endings = self.LEGACY_COVER_FILE_ENDINGS
         elif self.isTouch2():
-            _cover_file_endings = self.COVER_FILE_ENDINGS
+            _cover_file_endings = self.LEGACY_COVER_FILE_ENDINGS
         else:
-            _cover_file_endings = self.COVER_FILE_ENDINGS
+            _cover_file_endings = self.LEGACY_COVER_FILE_ENDINGS
 
-        return _cover_file_endings
+        # Don't forget to merge that on top of the common dictionary (c.f., https://stackoverflow.com/q/38987)
+        _all_cover_file_endings = self.COMMON_COVER_FILE_ENDINGS.copy()
+        _all_cover_file_endings.update(_cover_file_endings)
+        return _all_cover_file_endings
 
     def set_device_name(self):
         device_name = self.gui_name

--- a/src/calibre/devices/kobo/driver.py
+++ b/src/calibre/devices/kobo/driver.py
@@ -2616,10 +2616,9 @@ class KOBOTOUCH(KOBO):
 
         # NOTE: Loosely based on Qt's QSize::scaled implementation
         if keep_cover_aspect:
-            # NOTE: Py3k wouldn't need explicit casts to return a float
             # NOTE: Unlike Qt, we round to avoid accumulating errors,
             #       as ImageOps will then floor via fit_image
-            aspect_ratio = library_size[0] / float(library_size[1])
+            aspect_ratio = library_size[0] / library_size[1]
             rescaled_width = int(round(kobo_size[1] * aspect_ratio))
 
             if expand:

--- a/src/calibre/devices/kobo/driver.py
+++ b/src/calibre/devices/kobo/driver.py
@@ -2705,7 +2705,7 @@ class KOBOTOUCH(KOBO):
                         fpath = self.normalize_path(fpath.replace('/', os.sep))
 
                         # Never letterbox thumbnails, that's ugly. But for fullscreen covers, honor the setting.
-                        letterbox = letterbox_fs_covers if is_full_size else False
+                        letterbox = letterbox_fs_covers and is_full_size
 
                         # NOTE: Full size means we have to fit *inside* the given boundaries. Thumbnails, on the other hand, are *expanded* around those boundaries.
                         #       In Qt, it'd mean full-screen covers are resized using Qt::KeepAspectRatio, while thumbnails are resized using Qt::KeepAspectRatioByExpanding

--- a/src/calibre/devices/kobo/driver.py
+++ b/src/calibre/devices/kobo/driver.py
@@ -3576,13 +3576,7 @@ class KOBOTOUCH(KOBO):
         count_options += 1
         OPT_UPLOAD_GRAYSCALE_COVERS     = count_options
         count_options += 1
-        OPT_DITHERED_COVERS             = count_options
-        count_options += 1
         OPT_KEEP_COVER_ASPECT_RATIO     = count_options
-        count_options += 1
-        OPT_LETTERBOX_FULLSCREEN_COVERS = count_options
-        count_options += 1
-        OPT_PNG_COVERS                  = count_options
         count_options += 1
         OPT_SHOW_ARCHIVED_BOOK_RECORDS  = count_options
         count_options += 1
@@ -3614,9 +3608,6 @@ class KOBOTOUCH(KOBO):
             settings.upload_covers = settings.extra_customization[OPT_UPLOAD_COVERS]
             settings.keep_cover_aspect = settings.extra_customization[OPT_KEEP_COVER_ASPECT_RATIO]
             settings.upload_grayscale = settings.extra_customization[OPT_UPLOAD_GRAYSCALE_COVERS]
-            settings.dithered_covers = settings.extra_customization[OPT_DITHERED_COVERS]
-            settings.letterbox_fs_covers = settings.extra_customization[OPT_LETTERBOX_FULLSCREEN_COVERS]
-            settings.png_covers = settings.extra_customization[OPT_PNG_COVERS]
 
             settings.show_archived_books = settings.extra_customization[OPT_SHOW_ARCHIVED_BOOK_RECORDS]
             settings.show_previews = settings.extra_customization[OPT_SHOW_PREVIEWS]

--- a/src/calibre/devices/kobo/driver.py
+++ b/src/calibre/devices/kobo/driver.py
@@ -139,12 +139,6 @@ class KOBO(USBMS):
             'to perform full read-write functionality - Here be Dragons!! '
             'Enable only if you are comfortable with restoring your kobo '
             'to factory defaults and testing software'),
-        _('Letterbox full-screen covers') + ':::'+_(
-            'Do it on our end, instead of letting Nickel handle it. '
-            'Provides pixel-perfect results on devices where Nickel does not do extra processing. '
-            'Obviously has no effect without "Keep cover aspect ratio". '
-            'This is probably undesirable if you disable the "Show book covers full screen" '
-            'setting on your device.'),
     ]
 
     EXTRA_CUSTOMIZATION_DEFAULT = [
@@ -152,7 +146,6 @@ class KOBO(USBMS):
             True,
             True,
             True,
-            False,
             False,
             False,
             False
@@ -165,7 +158,6 @@ class KOBO(USBMS):
     OPT_SHOW_PREVIEWS = 4
     OPT_SHOW_RECOMMENDATIONS = 5
     OPT_SUPPORT_NEWER_FIRMWARE = 6
-    OPT_LETTERBOX_FULLSCREEN_COVERS = 7
 
     def __init__(self, *args, **kwargs):
         USBMS.__init__(self, *args, **kwargs)
@@ -1006,18 +998,13 @@ class KOBO(USBMS):
         else:
             uploadgrayscale = True
 
-        if not opts.extra_customization[self.OPT_LETTERBOX_FULLSCREEN_COVERS]:
-            letterboxcovers = False
-        else:
-            letterboxcovers = True
-
         debug_print('KOBO: uploading cover')
         try:
-            self._upload_cover(path, filename, metadata, filepath, uploadgrayscale, letterboxcovers)
+            self._upload_cover(path, filename, metadata, filepath, uploadgrayscale)
         except:
             debug_print('FAILED to upload cover', filepath)
 
-    def _upload_cover(self, path, filename, metadata, filepath, uploadgrayscale, letterboxcovers):
+    def _upload_cover(self, path, filename, metadata, filepath, uploadgrayscale):
         from calibre.utils.img import save_cover_data_to
         if metadata.cover:
             cover = self.normalize_path(metadata.cover.replace('/', os.sep))
@@ -1060,16 +1047,13 @@ class KOBO(USBMS):
                         fpath = path + ending
                         fpath = self.normalize_path(fpath.replace('/', os.sep))
 
-                        # Only full-screen covers should be letterboxed
-                        letterbox = letterboxcovers and "N3_FULL" in ending
-
                         if os.path.exists(fpath):
                             with lopen(cover, 'rb') as f:
                                 data = f.read()
 
-                            # Return the data resized and grayscaled/letterboxed if
+                            # Return the data resized and grayscaled if
                             # required
-                            data = save_cover_data_to(data, grayscale=uploadgrayscale, resize_to=resize, minify_to=resize, letterbox=letterbox)
+                            data = save_cover_data_to(data, grayscale=uploadgrayscale, resize_to=resize, minify_to=resize)
 
                             with lopen(fpath, 'wb') as f:
                                 f.write(data)
@@ -1118,7 +1102,6 @@ class KOBO(USBMS):
         OPT_SHOW_PREVIEWS = 4
         OPT_SHOW_RECOMMENDATIONS = 5
         OPT_SUPPORT_NEWER_FIRMWARE = 6
-        OPT_LETTERBOX_FULLSCREEN_COVERS = 7
 
         p = {}
         p['format_map'] = old_settings.format_map
@@ -1132,7 +1115,6 @@ class KOBO(USBMS):
 
         p['upload_covers'] = old_settings.extra_customization[OPT_UPLOAD_COVERS]
         p['upload_grayscale'] = old_settings.extra_customization[OPT_UPLOAD_GRAYSCALE_COVERS]
-        p['letterbox_fs_covers'] = old_settings.extra_customization[OPT_LETTERBOX_FULLSCREEN_COVERS]
 
         p['show_expired_books'] = old_settings.extra_customization[OPT_SHOW_EXPIRED_BOOK_RECORDS]
         p['show_previews'] = old_settings.extra_customization[OPT_SHOW_PREVIEWS]

--- a/src/calibre/devices/kobo/driver.py
+++ b/src/calibre/devices/kobo/driver.py
@@ -139,6 +139,12 @@ class KOBO(USBMS):
             'to perform full read-write functionality - Here be Dragons!! '
             'Enable only if you are comfortable with restoring your kobo '
             'to factory defaults and testing software'),
+        _('Letterbox full-screen covers') + ':::'+_(
+            'Do it on our end, instead of letting Nickel handle it. '
+            'Provides pixel-perfect results on devices where Nickel does not do extra processing. '
+            'Obviously has no effect without "Keep cover aspect ratio". '
+            'This is probably undesirable if you disable the "Show book covers full screen" '
+            'setting on your device.'),
     ]
 
     EXTRA_CUSTOMIZATION_DEFAULT = [
@@ -146,6 +152,7 @@ class KOBO(USBMS):
             True,
             True,
             True,
+            False,
             False,
             False,
             False

--- a/src/calibre/devices/kobo/driver.py
+++ b/src/calibre/devices/kobo/driver.py
@@ -1023,7 +1023,7 @@ class KOBO(USBMS):
             debug_print('FAILED to upload cover', filepath)
 
     def _upload_cover(self, path, filename, metadata, filepath, uploadgrayscale, ditheredcovers, letterboxcovers, pngcovers):
-        from calibre.utils.img import save_cover_data_to
+        from calibre.utils.img import save_cover_data_to, optimize_png
         if metadata.cover:
             cover = self.normalize_path(metadata.cover.replace('/', os.sep))
 
@@ -1076,6 +1076,9 @@ class KOBO(USBMS):
                             with lopen(fpath, 'wb') as f:
                                 f.write(data)
                                 fsync(f)
+
+                            if pngcovers:
+                                optimize_png(fpath)
 
                 else:
                     debug_print("ImageID could not be retreived from the database")
@@ -2697,6 +2700,7 @@ class KOBOTOUCH(KOBO):
 
     def _upload_cover(self, path, filename, metadata, filepath, upload_grayscale, dithered_covers=False, keep_cover_aspect=False, letterbox_fs_covers=False, png_covers=False):
         from calibre.utils.imghdr import identify
+        from calibre.utils.img import optimize_png
         debug_print("KoboTouch:_upload_cover - filename='%s' upload_grayscale='%s' dithered_covers='%s' "%(filename, upload_grayscale, dithered_covers))
 
         if not metadata.cover:
@@ -2780,6 +2784,9 @@ class KOBOTOUCH(KOBO):
                         with lopen(fpath, 'wb') as f:
                             f.write(data)
                             fsync(f)
+
+                        if png_covers:
+                            optimize_png(fpath)
         except Exception as e:
             err = unicode_type(e)
             debug_print("KoboTouch:_upload_cover - Exception string: %s"%err)

--- a/src/calibre/devices/kobo/driver.py
+++ b/src/calibre/devices/kobo/driver.py
@@ -1439,98 +1439,104 @@ class KOBOTOUCH(KOBO):
     # Image file name endings. Made up of: image size, min_dbversion, max_dbversion, isFullSize,
     # Note: "200" has been used just as a much larger number than the current versions. It is just a lazy
     #    way of making it open ended.
+    # NOTE: Values pulled from Nickel by @geek1011,
+    #       c.f., this handy recap: https://github.com/shermp/Kobo-UNCaGED/issues/16#issuecomment-494229994
+    #       Only the N3_FULL values differ, as they should match the screen's effective resolution.
+    #       Note that All Kobo devices share a common AR at roughly 0.75,
+    #       so results should be similar, no matter the exact device.
     COVER_FILE_ENDINGS = {
                           # Used for screensaver, home screen
-                          ' - N3_FULL.parsed':[(600,800),0, 200,True,],            # Used for screensaver, home screen
+                          ' - N3_FULL.parsed':[(600,800),0, 200,True,],
                           # Used for Details screen before FW2.8.1, then for current book tile on home screen
-                          ' - N3_LIBRARY_FULL.parsed':[(355,473),0, 200,False,],
+                          ' - N3_LIBRARY_FULL.parsed':[(355,530),0, 200,False,],
                           # Used for library lists
-                          ' - N3_LIBRARY_GRID.parsed':[(149,198),0, 200,False,],   # Used for library lists
+                          ' - N3_LIBRARY_GRID.parsed':[(149,223),0, 200,False,],
                           # Used for library lists
                           ' - N3_LIBRARY_LIST.parsed':[(60,90),0, 53,False,],
                           # Used for Details screen from FW2.8.1
-                          ' - AndroidBookLoadTablet_Aspect.parsed':[(355,473), 82, 100,False,],
+                          ' - AndroidBookLoadTablet_Aspect.parsed':[(355,530), 82, 100,False,],
                           }
-    # Glo and Aura share resolution, so the image sizes should be the same.
+    # Glo
     GLO_COVER_FILE_ENDINGS = {
                           # Used for screensaver, home screen
                           ' - N3_FULL.parsed':[(758,1024),0, 200,True,],
                           # Used for Details screen before FW2.8.1, then for current book tile on home screen
-                          ' - N3_LIBRARY_FULL.parsed':[(355,479),0, 200,False,],
+                          ' - N3_LIBRARY_FULL.parsed':[(355,530),0, 200,False,],
                           # Used for library lists
-                          ' - N3_LIBRARY_GRID.parsed':[(149,201),0, 200,False,],
+                          ' - N3_LIBRARY_GRID.parsed':[(149,223),0, 200,False,],
                           # Used for Details screen from FW2.8.1
-                          ' - AndroidBookLoadTablet_Aspect.parsed':[(355,479), 88, 100,False,],
+                          ' - AndroidBookLoadTablet_Aspect.parsed':[(355,530), 88, 100,False,],
+                          }
+    # Aura
+    AURA_COVER_FILE_ENDINGS = {
+                          # Used for screensaver, home screen
+                          # NOTE: The Aura's bezel covers 10 pixels at the bottom.
+                          #       Kobo officially advertised the screen resolution with those chopped off.
+                          ' - N3_FULL.parsed':[(758,1014),0, 200,True,],
+                          # Used for Details screen before FW2.8.1, then for current book tile on home screen
+                          ' - N3_LIBRARY_FULL.parsed':[(355,530),0, 200,False,],
+                          # Used for library lists
+                          ' - N3_LIBRARY_GRID.parsed':[(149,223),0, 200,False,],
+                          # Used for Details screen from FW2.8.1
+                          ' - AndroidBookLoadTablet_Aspect.parsed':[(355,530), 88, 100,False,],
                           }
     # Glo HD and Clara HD share resolution, so the image sizes should be the same.
     GLO_HD_COVER_FILE_ENDINGS = {
                           # Used for screensaver, home screen
                           ' - N3_FULL.parsed':        [(1072,1448), 0, 200,True,],
                           # Used for Details screen before FW2.8.1, then for current book tile on home screen
-                          ' - N3_LIBRARY_FULL.parsed':[(355,  479), 0, 200,False,],
+                          ' - N3_LIBRARY_FULL.parsed':[(355,530),0, 200,False,],
                           # Used for library lists
-                          ' - N3_LIBRARY_GRID.parsed':[(149,  201), 0, 200,False,],
+                          ' - N3_LIBRARY_GRID.parsed':[(149,223),0, 200,False,],
                           # Used for Details screen from FW2.8.1
-                          ' - AndroidBookLoadTablet_Aspect.parsed':[(355,  471), 88, 100,False,],
+                          ' - AndroidBookLoadTablet_Aspect.parsed':[(355,530), 88, 100,False,],
                           }
     AURA_HD_COVER_FILE_ENDINGS = {
                           # Used for screensaver, home screen
                           ' - N3_FULL.parsed':        [(1080,1440), 0, 200,True,],
                           # Used for Details screen before FW2.8.1, then for current book tile on home screen
-                          ' - N3_LIBRARY_FULL.parsed':[(355,  471), 0, 200,False,],
+                          ' - N3_LIBRARY_FULL.parsed':[(355,530),0, 200,False,],
                           # Used for library lists
-                          ' - N3_LIBRARY_GRID.parsed':[(149,  198), 0, 200,False,],
+                          ' - N3_LIBRARY_GRID.parsed':[(149,223),0, 200,False,],
                           # Used for Details screen from FW2.8.1
-                          ' - AndroidBookLoadTablet_Aspect.parsed':[(355,  471), 88, 100,False,],
+                          ' - AndroidBookLoadTablet_Aspect.parsed':[(355,530), 88, 100,False,],
                           }
     AURA_H2O_COVER_FILE_ENDINGS = {
                           # Used for screensaver, home screen
-                          # NOTE: Top 11px are dead. Confirmed w/ fbgrab.
+                          # NOTE: The H2O's bezel covers 11 pixels at the top.
+                          #       Unlike on the Aura, Nickel fails to account for this when generating covers.
+                          #       c.f., https://github.com/shermp/Kobo-UNCaGED/pull/17#discussion_r286209827
                           ' - N3_FULL.parsed':        [(1080,1429), 0, 200,True,],
                           # Used for Details screen before FW2.8.1, then for current book tile on home screen
-                          # NOTE: Should probably be 354x472 or 357x476 to keep honoring the 0.75 AR,
-                          #       but that's not what Nickel does...
-                          ' - N3_LIBRARY_FULL.parsed':[(355,  473), 0, 200,False,],
+                          ' - N3_LIBRARY_FULL.parsed':[(355,530),0, 200,False,],
                           # Used for library lists
-                          # NOTE: Again, 147x196 or 150x200 would match the 0.75 AR perfectly...
-                          ' - N3_LIBRARY_GRID.parsed':[(149,  198), 0, 200,False,],
+                          ' - N3_LIBRARY_GRID.parsed':[(149,223),0, 200,False,],
                           # Used for Details screen from FW2.8.1
-                          ' - AndroidBookLoadTablet_Aspect.parsed':[(355,  471), 88, 100,False,],
+                          ' - AndroidBookLoadTablet_Aspect.parsed':[(355,530), 88, 100,False,],
                           }
     AURA_ONE_COVER_FILE_ENDINGS = {
                           # Used for screensaver, home screen
                           ' - N3_FULL.parsed':        [(1404,1872), 0, 200,True,],
                           # Used for Details screen before FW2.8.1, then for current book tile on home screen
-                          ' - N3_LIBRARY_FULL.parsed':[(355,  473), 0, 200,False,],
+                          ' - N3_LIBRARY_FULL.parsed':[(355,530),0, 200,False,],
                           # Used for library lists
-                          ' - N3_LIBRARY_GRID.parsed':[(149,  198), 0, 200,False,],  # Used for library lists
+                          ' - N3_LIBRARY_GRID.parsed':[(149,223),0, 200,False,],
                           }
     FORMA_COVER_FILE_ENDINGS = {
                           # Used for screensaver, home screen
-                          # NOTE: Nickel keeps generating smaller images (1404x1872) for sideloaded content,
-                          #       and will *also* download Aura One sized images for kePubs, which is stupid.
-                          #       What's worse is that it expects that size during the full pipeline,
-                          #       which means sleep covers get mangled by a terrible upscaling pass...
-                          #       Hopefully that's just a teething quirk that'll be fixed in a later FW.
+                          # NOTE: Nickel currently fails to honor the real screen resolution when generating covers,
+                          #       choosing instead to follow the Aura One codepath.
                           ' - N3_FULL.parsed':        [(1440,1920), 0, 200,True,],
                           # Used for Details screen before FW2.8.1, then for current book tile on home screen
-                          # NOTE: Same thing, Nickel generates tiny thumbnails (355x473),
-                          #       but *will* download slightly larger ones for kePubs.
-                          #       That's still probably A1 sized, I'd expect roughly x636 instead...
-                          #       The actual widget itself has space for a 316x421 image...
-                          ' - N3_LIBRARY_FULL.parsed':[(398,  530), 0, 200,False,],
+                          ' - N3_LIBRARY_FULL.parsed':[(355,530),0, 200,False,],
                           # Used for library lists
-                          # NOTE: Same thing, Nickel generates tiny thumbnails (149x198),
-                          #       but downloads larger ones for kePubs.
-                          #       Again, probably still A1 sized, I'd expect roughly x266 instead...
-                          #       The actual widget itself has space for a 155x207 image...
-                          ' - N3_LIBRARY_GRID.parsed':[(167,  223), 0, 200,False,],  # Used for library lists
+                          ' - N3_LIBRARY_GRID.parsed':[(149,223),0, 200,False,],
                           }
     # Following are the sizes used with pre2.1.4 firmware
 #    COVER_FILE_ENDINGS = {
 # ' - N3_LIBRARY_FULL.parsed':[(355,530),0, 99,],   # Used for Details screen
 # ' - N3_LIBRARY_FULL.parsed':[(600,800),0, 99,],
-# ' - N3_LIBRARY_GRID.parsed':[(149,233),0, 99,],   # Used for library lists
+# ' - N3_LIBRARY_GRID.parsed':[(149,223),0, 99,],   # Used for library lists
 #                          ' - N3_LIBRARY_LIST.parsed':[(60,90),0, 53,],
 #                          ' - N3_LIBRARY_SHELF.parsed': [(40,60),0, 52,],
 # ' - N3_FULL.parsed':[(600,800),0, 99,],           # Used for screensaver if "Full screen" is checked.
@@ -3315,7 +3321,7 @@ class KOBOTOUCH(KOBO):
 
     def cover_file_endings(self):
         if self.isAura():
-            _cover_file_endings = self.GLO_COVER_FILE_ENDINGS
+            _cover_file_endings = self.AURA_COVER_FILE_ENDINGS
         elif self.isAuraEdition2():
             _cover_file_endings = self.GLO_COVER_FILE_ENDINGS
         elif self.isAuraHD():

--- a/src/calibre/devices/kobo/driver.py
+++ b/src/calibre/devices/kobo/driver.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 __license__   = 'GPL v3'
-__copyright__ = '2010-2018, Timothy Legge <timlegge@gmail.com>, Kovid Goyal <kovid@kovidgoyal.net> and David Forrester <davidfor@internode.on.net>'
+__copyright__ = '2010-2019, Timothy Legge <timlegge@gmail.com>, Kovid Goyal <kovid@kovidgoyal.net> and David Forrester <davidfor@internode.on.net>'
 __docformat__ = 'restructuredtext en'
 
 '''
@@ -2651,7 +2651,8 @@ class KOBOTOUCH(KOBO):
         # NOTE: Loosely based on Qt's QSize::scaled implementation
         if keep_cover_aspect:
             # NOTE: Py3k wouldn't need explicit casts to return a float
-            # NOTE: Unlike Qt, we round to avoid accumulating errors
+            # NOTE: Unlike Qt, we round to avoid accumulating errors,
+            #       as ImageOps will then floor via fit_image
             aspect_ratio = library_size[0] / float(library_size[1])
             rescaled_width = int(round(kobo_size[1] * aspect_ratio))
 

--- a/src/calibre/devices/kobo/driver.py
+++ b/src/calibre/devices/kobo/driver.py
@@ -154,13 +154,11 @@ class KOBO(USBMS):
     OPT_COLLECTIONS    = 0
     OPT_UPLOAD_COVERS  = 1
     OPT_UPLOAD_GRAYSCALE_COVERS  = 2
-    OPT_DITHERED_COVERS  = 3
-    OPT_LETTERBOX_FULLSCREEN_COVERS = 4
-    OPT_PNG_COVERS = 5
-    OPT_SHOW_EXPIRED_BOOK_RECORDS = 6
-    OPT_SHOW_PREVIEWS = 7
-    OPT_SHOW_RECOMMENDATIONS = 8
-    OPT_SUPPORT_NEWER_FIRMWARE = 9
+    OPT_SHOW_EXPIRED_BOOK_RECORDS = 3
+    OPT_SHOW_PREVIEWS = 4
+    OPT_SHOW_RECOMMENDATIONS = 5
+    OPT_SUPPORT_NEWER_FIRMWARE = 6
+    OPT_LETTERBOX_FULLSCREEN_COVERS = 7
 
     def __init__(self, *args, **kwargs):
         USBMS.__init__(self, *args, **kwargs)
@@ -1001,28 +999,18 @@ class KOBO(USBMS):
         else:
             uploadgrayscale = True
 
-        if not opts.extra_customization[self.OPT_DITHERED_COVERS]:
-            ditheredcovers = False
-        else:
-            ditheredcovers = True
-
         if not opts.extra_customization[self.OPT_LETTERBOX_FULLSCREEN_COVERS]:
             letterboxcovers = False
         else:
             letterboxcovers = True
 
-        if not opts.extra_customization[self.OPT_PNG_COVERS]:
-            pngcovers = False
-        else:
-            pngcovers = True
-
         debug_print('KOBO: uploading cover')
         try:
-            self._upload_cover(path, filename, metadata, filepath, uploadgrayscale, ditheredcovers, letterboxcovers, pngcovers)
+            self._upload_cover(path, filename, metadata, filepath, uploadgrayscale, letterboxcovers)
         except:
             debug_print('FAILED to upload cover', filepath)
 
-    def _upload_cover(self, path, filename, metadata, filepath, uploadgrayscale, ditheredcovers, letterboxcovers, pngcovers):
+    def _upload_cover(self, path, filename, metadata, filepath, uploadgrayscale, letterboxcovers):
         from calibre.utils.img import save_cover_data_to
         if metadata.cover:
             cover = self.normalize_path(metadata.cover.replace('/', os.sep))
@@ -1065,13 +1053,16 @@ class KOBO(USBMS):
                         fpath = path + ending
                         fpath = self.normalize_path(fpath.replace('/', os.sep))
 
+                        # Only full-screen covers should be letterboxed
+                        letterbox = letterboxcovers and "N3_FULL" in ending
+
                         if os.path.exists(fpath):
                             with lopen(cover, 'rb') as f:
                                 data = f.read()
 
-                            # Return the data resized and grayscaled/dithered/letterboxed if
+                            # Return the data resized and grayscaled/letterboxed if
                             # required
-                            data = save_cover_data_to(data, grayscale=uploadgrayscale, eink=ditheredcovers, resize_to=resize, minify_to=resize, letterbox=letterboxcovers, data_fmt="png" if pngcovers else "jpeg")
+                            data = save_cover_data_to(data, grayscale=uploadgrayscale, resize_to=resize, minify_to=resize, letterbox=letterbox)
 
                             with lopen(fpath, 'wb') as f:
                                 f.write(data)
@@ -1116,13 +1107,11 @@ class KOBO(USBMS):
         OPT_COLLECTIONS    = 0
         OPT_UPLOAD_COVERS  = 1
         OPT_UPLOAD_GRAYSCALE_COVERS  = 2
-        OPT_DITHERED_COVERS = 3
-        OPT_LETTERBOX_FULLSCREEN_COVERS = 4
-        OPT_PNG_COVERS = 5
-        OPT_SHOW_EXPIRED_BOOK_RECORDS = 6
-        OPT_SHOW_PREVIEWS = 7
-        OPT_SHOW_RECOMMENDATIONS = 8
-        OPT_SUPPORT_NEWER_FIRMWARE = 9
+        OPT_SHOW_EXPIRED_BOOK_RECORDS = 3
+        OPT_SHOW_PREVIEWS = 4
+        OPT_SHOW_RECOMMENDATIONS = 5
+        OPT_SUPPORT_NEWER_FIRMWARE = 6
+        OPT_LETTERBOX_FULLSCREEN_COVERS = 7
 
         p = {}
         p['format_map'] = old_settings.format_map
@@ -1136,9 +1125,7 @@ class KOBO(USBMS):
 
         p['upload_covers'] = old_settings.extra_customization[OPT_UPLOAD_COVERS]
         p['upload_grayscale'] = old_settings.extra_customization[OPT_UPLOAD_GRAYSCALE_COVERS]
-        p['dithered_covers'] = old_settings.extra_customization[OPT_DITHERED_COVERS]
         p['letterbox_fs_covers'] = old_settings.extra_customization[OPT_LETTERBOX_FULLSCREEN_COVERS]
-        p['png_covers'] = old_settings.extra_customization[OPT_PNG_COVERS]
 
         p['show_expired_books'] = old_settings.extra_customization[OPT_SHOW_EXPIRED_BOOK_RECORDS]
         p['show_previews'] = old_settings.extra_customization[OPT_SHOW_PREVIEWS]

--- a/src/calibre/devices/kobo/driver.py
+++ b/src/calibre/devices/kobo/driver.py
@@ -2769,7 +2769,7 @@ class KOBOTOUCH(KOBO):
                         #       (i.e., QSize's boundedTo() vs. expandedTo(). See also IM's '^' geometry token, for the same "expand" behavior.)
                         #       Note that Nickel itself will generate bounded thumbnails, while it will download expanded thumbnails for store-bought KePubs...
                         #       We chose to emulate the KePub behavior.
-                        resize_to, expand_to = self._calculate_kobo_cover_size(library_cover_size, kobo_size, expand=not is_full_size, keep_cover_aspect, letterbox)
+                        resize_to, expand_to = self._calculate_kobo_cover_size(library_cover_size, kobo_size, not is_full_size, keep_cover_aspect, letterbox)
                         if show_debug:
                              debug_print("KoboTouch:_calculate_kobo_cover_size - expand_to=%s (vs. kobo_size=%s) & resize_to=%s, keep_cover_aspect=%s & letterbox_fs_covers=%s, png_covers=%s" % (
                                  expand_to, kobo_size, resize_to, keep_cover_aspect, letterbox_fs_covers, png_covers))

--- a/src/calibre/devices/kobo/kobotouch_config.py
+++ b/src/calibre/devices/kobo/kobotouch_config.py
@@ -316,9 +316,7 @@ class CoversGroupBox(DeviceOptionsGroupBox):
                              _('Upload dithered covers'),
                              _('Dither cover images to the appropriate 16c grayscale palette for an eInk screen.'
                                ' This usually ensures greater accuracy and avoids banding, making sleep covers look better.'
-                               ' Note that in some cases, you might want to leave this disabled,'
-                               ' as Nickel will do a better job than Calibre, especially on newer FW versions (>= 4.11)!'
-                               ' Unfortunately, this desirable behavior appears to depend on the exact device and FW version combo...'
+                               ' On FW >= 4.11, Nickel itself may sometimes do a decent job of it.'
                                ' Has no effect without "Upload black and white covers"!'),
                              device.get_pref('dithered_covers')
                              )
@@ -337,10 +335,10 @@ class CoversGroupBox(DeviceOptionsGroupBox):
 
         self.letterbox_fs_covers_checkbox = create_checkbox(
                              _('Letterbox full-screen covers'),
-                             _('Do it on our end, instead of letting nickel handle it.'
+                             _('Do it on our end, instead of letting Nickel handle it.'
                                ' Provides pixel-perfect results on devices where Nickel does not do extra processing.'
                                ' Obviously has no effect without "Keep cover aspect ratio".'
-                               ' This is also probably undesirable if you disable the "Show book covers full screen"'
+                               ' This is probably undesirable if you disable the "Show book covers full screen"'
                                ' setting on your device.'),
                              device.get_pref('letterbox_fs_covers'))
         # Make it visually depend on AR being enabled!
@@ -355,7 +353,7 @@ class CoversGroupBox(DeviceOptionsGroupBox):
                                ' Higher quality, especially with "Upload dithered covers" enabled,'
                                ' which will also help generate potentially smaller files.'
                                ' Behavior completely unknown on "old" Kobo firmwares,'
-                               ' last tested on FW 4.9 to 4.12.'
+                               ' known to behave on FW >= 4.9.'
                                ' Has no effect without "Upload black and white covers"!'),
                              device.get_pref('png_covers'))
         # Make it visually depend on B&W being enabled, to avoid storing ridiculously large color PNGs.

--- a/src/calibre/devices/kobo/kobotouch_config.py
+++ b/src/calibre/devices/kobo/kobotouch_config.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 __license__   = 'GPL v3'
-__copyright__ = '2015-2018, Kovid Goyal <kovid at kovidgoyal.net>'
+__copyright__ = '2015-2019, Kovid Goyal <kovid at kovidgoyal.net>'
 __docformat__ = 'restructuredtext en'
 
 import textwrap

--- a/src/calibre/devices/kobo/kobotouch_config.py
+++ b/src/calibre/devices/kobo/kobotouch_config.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 __license__   = 'GPL v3'
-__copyright__ = '2015, Kovid Goyal <kovid at kovidgoyal.net>'
+__copyright__ = '2015-2018, Kovid Goyal <kovid at kovidgoyal.net>'
 __docformat__ = 'restructuredtext en'
 
 import textwrap
@@ -106,6 +106,9 @@ class KOBOTOUCHConfig(TabbedDeviceConfig):
         p['upload_covers'] = self.upload_covers
         p['keep_cover_aspect'] = self.keep_cover_aspect
         p['upload_grayscale'] = self.upload_grayscale
+        p['dithered_covers'] = self.dithered_covers
+        p['letterbox_fs_covers'] = self.letterbox_fs_covers
+        p['png_covers'] = self.png_covers
 
         p['show_recommendations'] = self.show_recommendations
         p['show_previews'] = self.show_previews
@@ -305,9 +308,26 @@ class CoversGroupBox(DeviceOptionsGroupBox):
 
         self.upload_grayscale_checkbox = create_checkbox(
                              _('Upload black and white covers'),
-                             _('Convert covers to black and white when uploading'),
+                             _('Convert covers to grayscale when uploading.'),
                              device.get_pref('upload_grayscale')
                              )
+
+        self.dithered_covers_checkbox = create_checkbox(
+                             _('Upload dithered covers'),
+                             _('Dither cover images to the appropriate 16c grayscale palette for an eInk screen.'
+                               ' This usually ensures greater accuracy and avoids banding, making sleep covers look better.'
+                               ' Note that in some cases, you might want to leave this disabled,'
+                               ' as Nickel will do a better job than Calibre, especially on newer FW versions (>= 4.11)!'
+                               ' Unfortunately, this desirable behavior appears to depend on the exact device and FW version combo...'
+                               ' Has no effect without "Upload black and white covers"!'),
+                             device.get_pref('dithered_covers')
+                             )
+        # Make it visually depend on B&W being enabled!
+        # c.f., https://stackoverflow.com/q/36281103
+        self.dithered_covers_checkbox.setEnabled(device.get_pref('upload_grayscale'))
+        self.upload_grayscale_checkbox.toggled.connect(self.dithered_covers_checkbox.setEnabled)
+        self.upload_grayscale_checkbox.toggled.connect(
+            lambda checked: not checked and self.dithered_covers_checkbox.setChecked(False))
 
         self.keep_cover_aspect_checkbox = create_checkbox(
                              _('Keep cover aspect ratio'),
@@ -315,8 +335,40 @@ class CoversGroupBox(DeviceOptionsGroupBox):
                                ' This is for firmware versions 2.3.1 and later.'),
                              device.get_pref('keep_cover_aspect'))
 
+        self.letterbox_fs_covers_checkbox = create_checkbox(
+                             _('Letterbox full-screen covers'),
+                             _('Do it on our end, instead of letting nickel handle it.'
+                               ' Provides pixel-perfect results on devices where Nickel does not do extra processing.'
+                               ' Obviously has no effect without "Keep cover aspect ratio".'
+                               ' This is also probably undesirable if you disable the "Show book covers full screen"'
+                               ' setting on your device.'),
+                             device.get_pref('letterbox_fs_covers'))
+        # Make it visually depend on AR being enabled!
+        self.letterbox_fs_covers_checkbox.setEnabled(device.get_pref('keep_cover_aspect'))
+        self.keep_cover_aspect_checkbox.toggled.connect(self.letterbox_fs_covers_checkbox.setEnabled)
+        self.keep_cover_aspect_checkbox.toggled.connect(
+            lambda checked: not checked and self.letterbox_fs_covers_checkbox.setChecked(False))
+
+        self.png_covers_checkbox = create_checkbox(
+                             _('Save covers as PNG'),
+                             _('Use the PNG image format instead of JPG.'
+                               ' Higher quality, especially with "Upload dithered covers" enabled,'
+                               ' which will also help generate potentially smaller files.'
+                               ' Behavior completely unknown on "old" Kobo firmwares,'
+                               ' last tested on FW 4.9 to 4.12.'
+                               ' Has no effect without "Upload black and white covers"!'),
+                             device.get_pref('png_covers'))
+        # Make it visually depend on B&W being enabled, to avoid storing ridiculously large color PNGs.
+        self.png_covers_checkbox.setEnabled(device.get_pref('upload_grayscale'))
+        self.upload_grayscale_checkbox.toggled.connect(self.png_covers_checkbox.setEnabled)
+        self.upload_grayscale_checkbox.toggled.connect(
+            lambda checked: not checked and self.png_covers_checkbox.setChecked(False))
+
         self.options_layout.addWidget(self.keep_cover_aspect_checkbox,    0, 0, 1, 1)
         self.options_layout.addWidget(self.upload_grayscale_checkbox,     1, 0, 1, 1)
+        self.options_layout.addWidget(self.dithered_covers_checkbox,      2, 0, 1, 1)
+        self.options_layout.addWidget(self.letterbox_fs_covers_checkbox,  3, 0, 1, 1)
+        self.options_layout.addWidget(self.png_covers_checkbox,           4, 0, 1, 1)
 
     @property
     def upload_covers(self):
@@ -327,8 +379,20 @@ class CoversGroupBox(DeviceOptionsGroupBox):
         return self.upload_grayscale_checkbox.isChecked()
 
     @property
+    def dithered_covers(self):
+        return self.dithered_covers_checkbox.isChecked()
+
+    @property
     def keep_cover_aspect(self):
         return self.keep_cover_aspect_checkbox.isChecked()
+
+    @property
+    def letterbox_fs_covers(self):
+        return self.letterbox_fs_covers_checkbox.isChecked()
+
+    @property
+    def png_covers(self):
+        return self.png_covers_checkbox.isChecked()
 
 
 class DeviceListGroupBox(DeviceOptionsGroupBox):

--- a/src/calibre/devices/kobo/kobotouch_config.py
+++ b/src/calibre/devices/kobo/kobotouch_config.py
@@ -352,8 +352,8 @@ class CoversGroupBox(DeviceOptionsGroupBox):
                              _('Use the PNG image format instead of JPG.'
                                ' Higher quality, especially with "Upload dithered covers" enabled,'
                                ' which will also help generate potentially smaller files.'
-                               ' Behavior completely unknown on "old" Kobo firmwares,'
-                               ' known to behave on FW >= 4.9.'
+                               ' Behavior completely unknown on old (< 3.x) Kobo firmwares,'
+                               ' known to behave on FW >= 4.8.'
                                ' Has no effect without "Upload black and white covers"!'),
                              device.get_pref('png_covers'))
         # Make it visually depend on B&W being enabled, to avoid storing ridiculously large color PNGs.

--- a/src/calibre/devices/kobo/kobotouch_config.py
+++ b/src/calibre/devices/kobo/kobotouch_config.py
@@ -8,7 +8,7 @@ __docformat__ = 'restructuredtext en'
 
 import textwrap
 
-from PyQt5.Qt import (QWidget, QLabel, QGridLayout, QLineEdit, QVBoxLayout,
+from PyQt5.Qt import (Qt, QWidget, QLabel, QGridLayout, QLineEdit, QVBoxLayout,
                       QDialog, QDialogButtonBox, QCheckBox, QPushButton)
 
 from calibre.gui2.device_drivers.tabbed_device_config import TabbedDeviceConfig, DeviceConfigTab, DeviceOptionsGroupBox
@@ -362,11 +362,11 @@ class CoversGroupBox(DeviceOptionsGroupBox):
         self.upload_grayscale_checkbox.toggled.connect(
             lambda checked: not checked and self.png_covers_checkbox.setChecked(False))
 
-        self.options_layout.addWidget(self.keep_cover_aspect_checkbox,    0, 0, 1, 1)
-        self.options_layout.addWidget(self.upload_grayscale_checkbox,     1, 0, 1, 1)
-        self.options_layout.addWidget(self.dithered_covers_checkbox,      2, 0, 1, 1)
-        self.options_layout.addWidget(self.letterbox_fs_covers_checkbox,  3, 0, 1, 1)
-        self.options_layout.addWidget(self.png_covers_checkbox,           4, 0, 1, 1)
+        self.options_layout.addWidget(self.upload_grayscale_checkbox,     0, 0, 1, 1)
+        self.options_layout.addWidget(self.dithered_covers_checkbox,      0, 1, 1, 1)
+        self.options_layout.addWidget(self.keep_cover_aspect_checkbox,    1, 0, 1, 1)
+        self.options_layout.addWidget(self.letterbox_fs_covers_checkbox,  1, 1, 1, 1)
+        self.options_layout.addWidget(self.png_covers_checkbox,           2, 0, 1, 2, Qt.AlignCenter)
 
     @property
     def upload_covers(self):

--- a/src/calibre/utils/imageops/imageops.h
+++ b/src/calibre/utils/imageops/imageops.h
@@ -22,6 +22,7 @@ QImage quantize(const QImage &image, unsigned int maximum_colors, bool dither, c
 bool has_transparent_pixels(const QImage &image);
 QImage set_opacity(const QImage &image, double alpha);
 QImage texture_image(const QImage &image, const QImage &texturei);
+QImage ordered_dither(const QImage &image);
 
 class ScopedGILRelease {
 public:

--- a/src/calibre/utils/imageops/imageops.sip
+++ b/src/calibre/utils/imageops/imageops.sip
@@ -15,7 +15,7 @@
         } catch (std::out_of_range &exc) { PyErr_SetString(PyExc_ValueError, exc.what()); return NULL; \
         } catch (std::bad_alloc &) { PyErr_NoMemory(); return NULL; \
         } catch (std::exception &exc) { PyErr_SetString(PyExc_Exception, exc.what()); return NULL; \
-        } catch (...) { PyErr_SetString(PyExc_RuntimeError, "unknown error"); return NULL;} 
+        } catch (...) { PyErr_SetString(PyExc_RuntimeError, "unknown error"); return NULL;}
 %End
 
 QImage* remove_borders(const QImage &image, double fuzz);
@@ -98,5 +98,12 @@ QImage texture_image(const QImage &image, const QImage &texturei);
 %MethodCode
         IMAGEOPS_PREFIX
 			sipRes = new QImage(texture_image(*a0, *a1));
+        IMAGEOPS_SUFFIX
+%End
+
+QImage ordered_dither(const QImage &image);
+%MethodCode
+        IMAGEOPS_PREFIX
+			sipRes = new QImage(ordered_dither(*a0));
         IMAGEOPS_SUFFIX
 %End

--- a/src/calibre/utils/imageops/ordered_dither.cpp
+++ b/src/calibre/utils/imageops/ordered_dither.cpp
@@ -74,7 +74,7 @@ static uint8_t
     // c = ClampToQuantum((l+(t >= map[(x % mw) + mw * (y % mh)])) * QuantumRange / (L-1));
     uint32_t q = ((l + (t >= threshold_map_o8x8[(x & 7U) + 8U * (y & 7U)])) * 17);
     // NOTE: We're doing unsigned maths, so, clamping is basically MIN(q, UINT8_MAX) ;).
-    //       The only overflow we should ever catch should be for a few black (v = 0xFF) input pixels
+    //       The only overflow we should ever catch should be for a few white (v = 0xFF) input pixels
     //       that get shifted to the next step (i.e., q = 272 (0xFF + 17)).
     return (q > UINT8_MAX ? UINT8_MAX : static_cast<uint8_t>(q));
 }

--- a/src/calibre/utils/imageops/ordered_dither.cpp
+++ b/src/calibre/utils/imageops/ordered_dither.cpp
@@ -24,7 +24,7 @@ typedef unsigned __int8 uint8_t;
 #define UINT8_MAX _UI8_MAX
 typedef unsigned __int32 uint32_t;
 #else
-#include <cstdint>
+#include <stdint.h>
 #endif
 
 // Only needed for the (commented out) Indexed8 codepath

--- a/src/calibre/utils/imageops/ordered_dither.cpp
+++ b/src/calibre/utils/imageops/ordered_dither.cpp
@@ -79,6 +79,7 @@ QImage ordered_dither(const QImage &image) { // {{{
     QImage img = image;
     int y = 0, x = 0, width = img.width(), height = img.height();
     uint8_t gray = 0, dithered = 0;
+    // NOTE: We went with Grayscale8 because QImageWriter was doing some weird things with an Indexed8 input...
     QImage dst(width, height, QImage::Format_Grayscale8);
 
     // We're running behind blend_image, so, we should only ever be fed RGB32 as input...

--- a/src/calibre/utils/imageops/ordered_dither.cpp
+++ b/src/calibre/utils/imageops/ordered_dither.cpp
@@ -1,0 +1,93 @@
+/*
+ *  Copyright 1999-2019 ImageMagick Studio LLC
+ *
+ *  Licensed under the ImageMagick License (the "License"); you may not use
+ *  this file except in compliance with the License.  You may obtain a copy
+ *  of the License at
+ *
+ *    https://imagemagick.org/script/license.php
+
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ */
+
+#include "imageops.h"
+
+// Just in case, as I don't want to deal with MSVC madness...
+#if defined _MSC_VER && _MSC_VER < 1700
+typedef unsigned __int8 uint8_t;
+#define UINT8_MAX _UI8_MAX
+typedef unsigned __int32 uint32_t;
+#else
+#include <cstdint>
+#endif
+
+// Quantize an 8-bit color value down to a palette of 16 evenly spaced colors, using an ordered 8x8 dithering pattern.
+// With a grayscale input, this happens to match the eInk palette perfectly ;).
+// If the input is not grayscale, and the output fb is not grayscale either,
+// this usually still happens to match the eInk palette after the EPDC's own quantization pass.
+// c.f., https://en.wikipedia.org/wiki/Ordered_dithering
+// & https://github.com/ImageMagick/ImageMagick/blob/ecfeac404e75f304004f0566557848c53030bad6/MagickCore/threshold.c#L1627
+// NOTE: As the references imply, this is straight from ImageMagick,
+//       with only minor simplifications to enforce Q8 & avoid fp maths.
+static uint8_t
+    dither_o8x8(int x, int y, uint8_t v)
+{
+	// c.f., https://github.com/ImageMagick/ImageMagick/blob/ecfeac404e75f304004f0566557848c53030bad6/config/thresholds.xml#L107
+	static const uint8_t threshold_map_o8x8[] = { 1,  49, 13, 61, 4,  52, 16, 64, 33, 17, 45, 29, 36, 20, 48, 32,
+						      9,  57, 5,  53, 12, 60, 8,  56, 41, 25, 37, 21, 44, 28, 40, 24,
+						      3,  51, 15, 63, 2,  50, 14, 62, 35, 19, 47, 31, 34, 18, 46, 30,
+						      11, 59, 7,  55, 10, 58, 6,  54, 43, 27, 39, 23, 42, 26, 38, 22 };
+
+	// Constants:
+	// Quantum = 8; Levels = 16; map Divisor = 65
+	// QuantumRange = 0xFF
+	// QuantumScale = 1.0 / QuantumRange
+	//
+	// threshold = QuantumScale * v * ((L-1) * (D-1) + 1)
+	// NOTE: The initial computation of t (specifically, what we pass to DIV255) would overflow an uint8_t.
+	//       With a Q8 input value, we're at no risk of ever underflowing, so, keep to unsigned maths.
+	//       Technically, an uint16_t would be wide enough, but it gains us nothing,
+	//       and requires a few explicit casts to make GCC happy ;).
+	uint32_t t = DIV255(v * ((15U << 6) + 1U));
+	// level = t / (D-1);
+	uint32_t l = (t >> 6);
+	// t -= l * (D-1);
+	t = (t - (l << 6));
+
+	// map width & height = 8
+	// c = ClampToQuantum((l+(t >= map[(x % mw) + mw * (y % mh)])) * QuantumRange / (L-1));
+	uint32_t q = ((l + (t >= threshold_map_o8x8[(x & 7U) + 8U * (y & 7U)])) * 17);
+	// NOTE: We're doing unsigned maths, so, clamping is basically MIN(q, UINT8_MAX) ;).
+	//       The only overflow we should ever catch should be for a few black (v = 0xFF) input pixels
+	//       that get shifted to the next step (i.e., q = 272 (0xFF + 17)).
+	return (q > UINT8_MAX ? UINT8_MAX : reinterpret_cast<uint8_t>(q);
+}
+
+QImage ordered_dither(const QImage &image) { // {{{
+    ScopedGILRelease PyGILRelease;
+    QImage img = image;
+    QRgb *row = NULL, *pixel = NULL;
+    int y = 0, x = 0, width = img.width(), height = img.height();
+    uint8_t gray = 0, dithered = 0;
+
+    // We're running behind blend_image, so, we should only ever be fed RGB32 as input...
+    if (img.format() != QImage::Format_RGB32) {
+        img = img.convertToFormat(QImage::Format_RGB32);
+        if (img.isNull()) throw std::bad_alloc();
+    }
+
+    for (y = 0; y < height; y++) {
+        row = reinterpret_cast<QRgb*>(img.scanLine(y));
+        for (x = 0, pixel = row; x < width; x++, pixel++) {
+            // We're running behind grayscale_image, so R = G = B
+            gray = qRed(*pixel);
+            dithered = dither_o8x8(x, y, gray);
+            *pixel = qRgb(dithered, dithered, dithered);
+        }
+    }
+    return img;
+} // }}}

--- a/src/calibre/utils/imageops/ordered_dither.cpp
+++ b/src/calibre/utils/imageops/ordered_dither.cpp
@@ -1,17 +1,19 @@
 /*
- *  Copyright 1999-2019 ImageMagick Studio LLC
+ * ordered_dither.cpp
+ * Glue code based on quantize.cpp, Copyright (C) 2016 Kovid Goyal <kovid at kovidgoyal.net>
+ * Actual ordered dithering routine (dither_o8x8) is Copyright 1999-2019 ImageMagick Studio LLC,
  *
- *  Licensed under the ImageMagick License (the "License"); you may not use
- *  this file except in compliance with the License.  You may obtain a copy
- *  of the License at
+ * Licensed under the ImageMagick License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy
+ * of the License at
  *
- *    https://imagemagick.org/script/license.php
+ *   https://imagemagick.org/script/license.php
 
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- *  License for the specific language governing permissions and limitations
- *  under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  */
 
 #include "imageops.h"

--- a/src/calibre/utils/imageops/ordered_dither.cpp
+++ b/src/calibre/utils/imageops/ordered_dither.cpp
@@ -72,7 +72,7 @@ QImage ordered_dither(const QImage &image) { // {{{
     QImage img = image;
     int y = 0, x = 0, width = img.width(), height = img.height();
     uint8_t gray = 0, dithered = 0;
-    QImage dst(width, height, QImage::Format_Indexed8);
+    QImage dst(width, height, QImage::Format_Grayscale8);
 
     // We're running behind blend_image, so, we should only ever be fed RGB32 as input...
     if (img.format() != QImage::Format_RGB32) {

--- a/src/calibre/utils/imageops/ordered_dither.cpp
+++ b/src/calibre/utils/imageops/ordered_dither.cpp
@@ -25,8 +25,6 @@ typedef unsigned __int32 uint32_t;
 #include <cstdint>
 #endif
 
-#include <QVector>
-
 // NOTE: *May* not behave any better than a simple / 0xFF on modern x86_64 CPUs...
 //       This was, however, tested on ARM, where it is noticeably faster.
 static uint32_t DIV255(uint32_t v) {
@@ -81,19 +79,7 @@ QImage ordered_dither(const QImage &image) { // {{{
     QImage img = image;
     int y = 0, x = 0, width = img.width(), height = img.height();
     uint8_t gray = 0, dithered = 0;
-    QImage dst(width, height, QImage::Format_Indexed8);
-
-    // Set up the eInk palette
-    // FIXME: Make it const and switch to C++11 list init if MSVC is amenable...
-    QVector<uint8_t> palette(16);
-    QVector<QRgb> color_table(16);
-    int i = 0;
-    for (i = 0; i < 16; i++) {
-        uint8_t color = i * 17;
-        palette << color;
-        color_table << qRgb(color, color, color);
-    }
-    dst.setColorTable(color_table);
+    QImage dst(width, height, QImage::Format_Grayscale8);
 
     // We're running behind blend_image, so, we should only ever be fed RGB32 as input...
     if (img.format() != QImage::Format_RGB32) {
@@ -109,7 +95,7 @@ QImage ordered_dither(const QImage &image) { // {{{
             // We're running behind grayscale_image, so R = G = B
             gray = qRed(pixel);
             dithered = dither_o8x8(x, y, gray);
-            *(dst_row + x) = palette.indexOf(dithered);
+            *(dst_row + x) = dithered;
         }
     }
     return dst;

--- a/src/calibre/utils/imageops/ordered_dither.cpp
+++ b/src/calibre/utils/imageops/ordered_dither.cpp
@@ -48,35 +48,35 @@ static uint32_t DIV255(uint32_t v) {
 static uint8_t
     dither_o8x8(int x, int y, uint8_t v)
 {
-	// c.f., https://github.com/ImageMagick/ImageMagick/blob/ecfeac404e75f304004f0566557848c53030bad6/config/thresholds.xml#L107
-	static const uint8_t threshold_map_o8x8[] = { 1,  49, 13, 61, 4,  52, 16, 64, 33, 17, 45, 29, 36, 20, 48, 32,
-						      9,  57, 5,  53, 12, 60, 8,  56, 41, 25, 37, 21, 44, 28, 40, 24,
-						      3,  51, 15, 63, 2,  50, 14, 62, 35, 19, 47, 31, 34, 18, 46, 30,
-						      11, 59, 7,  55, 10, 58, 6,  54, 43, 27, 39, 23, 42, 26, 38, 22 };
+    // c.f., https://github.com/ImageMagick/ImageMagick/blob/ecfeac404e75f304004f0566557848c53030bad6/config/thresholds.xml#L107
+    static const uint8_t threshold_map_o8x8[] = { 1,  49, 13, 61, 4,  52, 16, 64, 33, 17, 45, 29, 36, 20, 48, 32,
+                                                9,  57, 5,  53, 12, 60, 8,  56, 41, 25, 37, 21, 44, 28, 40, 24,
+                                                3,  51, 15, 63, 2,  50, 14, 62, 35, 19, 47, 31, 34, 18, 46, 30,
+                                                11, 59, 7,  55, 10, 58, 6,  54, 43, 27, 39, 23, 42, 26, 38, 22 };
 
-	// Constants:
-	// Quantum = 8; Levels = 16; map Divisor = 65
-	// QuantumRange = 0xFF
-	// QuantumScale = 1.0 / QuantumRange
-	//
-	// threshold = QuantumScale * v * ((L-1) * (D-1) + 1)
-	// NOTE: The initial computation of t (specifically, what we pass to DIV255) would overflow an uint8_t.
-	//       With a Q8 input value, we're at no risk of ever underflowing, so, keep to unsigned maths.
-	//       Technically, an uint16_t would be wide enough, but it gains us nothing,
-	//       and requires a few explicit casts to make GCC happy ;).
-	uint32_t t = DIV255(v * ((15U << 6) + 1U));
-	// level = t / (D-1);
-	uint32_t l = (t >> 6);
-	// t -= l * (D-1);
-	t = (t - (l << 6));
+    // Constants:
+    // Quantum = 8; Levels = 16; map Divisor = 65
+    // QuantumRange = 0xFF
+    // QuantumScale = 1.0 / QuantumRange
+    //
+    // threshold = QuantumScale * v * ((L-1) * (D-1) + 1)
+    // NOTE: The initial computation of t (specifically, what we pass to DIV255) would overflow an uint8_t.
+    //       With a Q8 input value, we're at no risk of ever underflowing, so, keep to unsigned maths.
+    //       Technically, an uint16_t would be wide enough, but it gains us nothing,
+    //       and requires a few explicit casts to make GCC happy ;).
+    uint32_t t = DIV255(v * ((15U << 6) + 1U));
+    // level = t / (D-1);
+    uint32_t l = (t >> 6);
+    // t -= l * (D-1);
+    t = (t - (l << 6));
 
-	// map width & height = 8
-	// c = ClampToQuantum((l+(t >= map[(x % mw) + mw * (y % mh)])) * QuantumRange / (L-1));
-	uint32_t q = ((l + (t >= threshold_map_o8x8[(x & 7U) + 8U * (y & 7U)])) * 17);
-	// NOTE: We're doing unsigned maths, so, clamping is basically MIN(q, UINT8_MAX) ;).
-	//       The only overflow we should ever catch should be for a few black (v = 0xFF) input pixels
-	//       that get shifted to the next step (i.e., q = 272 (0xFF + 17)).
-	return (q > UINT8_MAX ? UINT8_MAX : static_cast<uint8_t>(q));
+    // map width & height = 8
+    // c = ClampToQuantum((l+(t >= map[(x % mw) + mw * (y % mh)])) * QuantumRange / (L-1));
+    uint32_t q = ((l + (t >= threshold_map_o8x8[(x & 7U) + 8U * (y & 7U)])) * 17);
+    // NOTE: We're doing unsigned maths, so, clamping is basically MIN(q, UINT8_MAX) ;).
+    //       The only overflow we should ever catch should be for a few black (v = 0xFF) input pixels
+    //       that get shifted to the next step (i.e., q = 272 (0xFF + 17)).
+    return (q > UINT8_MAX ? UINT8_MAX : static_cast<uint8_t>(q));
 }
 
 QImage ordered_dither(const QImage &image) { // {{{

--- a/src/calibre/utils/imageops/ordered_dither.cpp
+++ b/src/calibre/utils/imageops/ordered_dither.cpp
@@ -109,13 +109,19 @@ QImage ordered_dither(const QImage &image) { // {{{
         if (img.isNull()) throw std::bad_alloc();
     }
 
+    const bool is_gray = img.isGrayscale();
+
     for (y = 0; y < height; y++) {
         const QRgb *src_row = reinterpret_cast<const QRgb*>(img.constScanLine(y));
         uint8_t *dst_row = dst.scanLine(y);
         for (x = 0; x < width; x++) {
             const QRgb pixel = *(src_row + x);
-            // We're running behind grayscale_image, so R = G = B
-            gray = qRed(pixel);
+            if (is_gray) {
+                // Grayscale and RGB32, so R = G = B
+                gray = qRed(pixel);
+            } else {
+                gray = qGray(pixel);
+            }
             dithered = dither_o8x8(x, y, gray);
             *(dst_row + x) = dithered;  // ... or palette.indexOf(dithered); for Indexed8
         }

--- a/src/calibre/utils/imageops/ordered_dither.cpp
+++ b/src/calibre/utils/imageops/ordered_dither.cpp
@@ -25,6 +25,9 @@ typedef unsigned __int32 uint32_t;
 #include <cstdint>
 #endif
 
+// Only needed for the (commented out) Indexed8 codepath
+//#include <QVector>
+
 // NOTE: *May* not behave any better than a simple / 0xFF on modern x86_64 CPUs...
 //       This was, however, tested on ARM, where it is noticeably faster.
 static uint32_t DIV255(uint32_t v) {
@@ -82,6 +85,22 @@ QImage ordered_dither(const QImage &image) { // {{{
     // NOTE: We went with Grayscale8 because QImageWriter was doing some weird things with an Indexed8 input...
     QImage dst(width, height, QImage::Format_Grayscale8);
 
+    /*
+    QImage dst(width, height, QImage::Format_Indexed8);
+
+    // Set up the eInk palette
+    // FIXME: Make it const and switch to C++11 list init if MSVC is amenable...
+    QVector<uint8_t> palette(16);
+    QVector<QRgb> color_table(16);
+    int i = 0;
+    for (i = 0; i < 16; i++) {
+        uint8_t color = i * 17;
+        palette << color;
+        color_table << qRgb(color, color, color);
+    }
+    dst.setColorTable(color_table);
+    */
+
     // We're running behind blend_image, so, we should only ever be fed RGB32 as input...
     if (img.format() != QImage::Format_RGB32) {
         img = img.convertToFormat(QImage::Format_RGB32);
@@ -96,7 +115,7 @@ QImage ordered_dither(const QImage &image) { // {{{
             // We're running behind grayscale_image, so R = G = B
             gray = qRed(pixel);
             dithered = dither_o8x8(x, y, gray);
-            *(dst_row + x) = dithered;
+            *(dst_row + x) = dithered;  // ... or palette.indexOf(dithered); for Indexed8
         }
     }
     return dst;

--- a/src/calibre/utils/img.py
+++ b/src/calibre/utils/img.py
@@ -463,10 +463,14 @@ def quantize_image(img, max_colors=256, dither=True, palette=''):
 def eink_dither_image(img):
     ''' Dither the source image down to the eInk palette of 16 shades of grey,
     using ImageMagick's OrderedDither algorithm.
+
+    NOTE: Expects input as a grayscale image in RGB32 pixel format (as returned by grayscale_image).
+          Running blend_image if the image has an alpha channel,
+          or grayscale_image if it's not already grayscaled is the caller's responsibility.
+
+    Returns a QImage in Indexed8 pixel format.
     '''
     img = image_from_data(img)
-    if img.hasAlphaChannel():
-        img = blend_image(img)
     return imageops.ordered_dither(img)
 
 # }}}

--- a/src/calibre/utils/img.py
+++ b/src/calibre/utils/img.py
@@ -560,6 +560,12 @@ def optimize_png(file_path):
     cmd = [exe] + '-fix -clobber -strip all -o7 -out'.split() + [False, True]
     return run_optimizer(file_path, cmd)
 
+# Use -o1 to make it much, much faster, when we only care about re-encoding, and not recompression.
+def optimize_png_fast(file_path):
+    exe = get_exe_path('optipng')
+    cmd = [exe] + '-fix -clobber -strip all -o1 -out'.split() + [False, True]
+    return run_optimizer(file_path, cmd)
+
 
 def encode_jpeg(file_path, quality=80):
     from calibre.utils.speedups import ReadOnlyFileBuffer

--- a/src/calibre/utils/img.py
+++ b/src/calibre/utils/img.py
@@ -468,7 +468,7 @@ def eink_dither_image(img):
           Running blend_image if the image has an alpha channel,
           or grayscale_image if it's not already grayscaled is the caller's responsibility.
 
-    Returns a QImage in Grayscale8 pixel format.
+    Returns a QImage in Indexed8 pixel format.
     '''
     img = image_from_data(img)
     return imageops.ordered_dither(img)

--- a/src/calibre/utils/img.py
+++ b/src/calibre/utils/img.py
@@ -237,9 +237,9 @@ def save_cover_data_to(data, path=None, bgcolor='#ffffff', resize_to=None, compr
         img = eink_dither_image(img)
         changed = True
     if path is None:
-        return image_to_data(img, compression_quality, fmt) if changed else data
+        return image_to_data(img, compression_quality, fmt, compression_quality // 10) if changed else data
     with lopen(path, 'wb') as f:
-        f.write(image_to_data(img, compression_quality, fmt) if changed else data)
+        f.write(image_to_data(img, compression_quality, fmt, compression_quality // 10) if changed else data)
 # }}}
 
 # Overlaying images {{{

--- a/src/calibre/utils/img.py
+++ b/src/calibre/utils/img.py
@@ -227,7 +227,7 @@ def save_cover_data_to(data, path=None, bgcolor='#ffffff', resize_to=None, compr
     if img.hasAlphaChannel():
         changed = True
         img = blend_image(img, bgcolor)
-    if grayscale:
+    if grayscale and not eink:
         if not img.allGray():
             changed = True
             img = grayscale_image(img)
@@ -464,13 +464,13 @@ def eink_dither_image(img):
     ''' Dither the source image down to the eInk palette of 16 shades of grey,
     using ImageMagick's OrderedDither algorithm.
 
-    NOTE: Expects input as a grayscale image in RGB32 pixel format (as returned by grayscale_image).
-          Running blend_image if the image has an alpha channel,
-          or grayscale_image if it's not already grayscaled is the caller's responsibility.
+    NOTE: No need to call grayscale_image first, as this will inline a grayscaling pass if need be.
 
     Returns a QImage in Grayscale8 pixel format.
     '''
     img = image_from_data(img)
+    if img.hasAlphaChannel():
+        img = blend_image(img)
     return imageops.ordered_dither(img)
 
 # }}}

--- a/src/calibre/utils/img.py
+++ b/src/calibre/utils/img.py
@@ -468,7 +468,7 @@ def eink_dither_image(img):
           Running blend_image if the image has an alpha channel,
           or grayscale_image if it's not already grayscaled is the caller's responsibility.
 
-    Returns a QImage in Indexed8 pixel format.
+    Returns a QImage in Grayscale8 pixel format.
     '''
     img = image_from_data(img)
     return imageops.ordered_dither(img)

--- a/src/calibre/utils/img.py
+++ b/src/calibre/utils/img.py
@@ -233,7 +233,7 @@ def save_cover_data_to(data, path=None, bgcolor='#ffffff', resize_to=None, compr
             img = grayscale_image(img)
     if eink:
         # NOTE: Keep in mind that JPG does NOT actually support indexed colors, so the JPG algorithm will then smush everything back into a 256c mess...
-        #       Thankfully, Nickel handles PNG just fine, and we generate smaller files to boot, because they're properly color indexed ;).
+        #       Thankfully, Nickel handles PNG just fine, and we potentially generate smaller files to boot, because they can be properly color indexed ;).
         img = eink_dither_image(img)
         changed = True
     if path is None:


### PR DESCRIPTION
* Optional dithering down to the exact eInk color palette.

  Recent FW versions got better at this than they used to,
  but it's still not perfect.
  Note that Mk. 7 devices can and *will* enforce HW dithering,
  at the very least on sleep screens, using an ordered dither pattern,
  like we do.

  Speaking of, said ordered dithering pattern has been ported from ImageMagick.

  This has the added bonus of generating much smaller PNG files.

  Depends on B&W covers to avoid nonsensical results.

* Optional letterboxing of full-screen covers to avoid extra Nickel
  processing.

  Depends on Keep AR to avoid nonsensical results.

* Optional storage as PNG to avoid JPG wrecking the dithering

  Depends on B&W covers to avoid storing stupidly large color PNGs.

* Revamp thumbnail dimension calculations to match what's done with
  store-bought KePubs, fixing a few AR rounding issues in the process.

* Speaking of thumbnails, the target sizes have been unified,
  and the sleep cover dimensions have been updated for a few
  specific models (Aura, H2O, Forma) to match their effective screen resolution,
  instead of something less accurate.
