### PR TITLE
fix qt 5.13 compatibility

### DIFF
--- a/src/calibre/headless/headless_integration.cpp
+++ b/src/calibre/headless/headless_integration.cpp
@@ -64,7 +64,12 @@ HeadlessIntegration::HeadlessIntegration(const QStringList &parameters)
     mPrimaryScreen->mDepth = 32;
     mPrimaryScreen->mFormat = QImage::Format_ARGB32_Premultiplied;
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 13, 0))
+    QWindowSystemInterface::handleScreenAdded(mPrimaryScreen);
+#else
     screenAdded(mPrimaryScreen);
+#endif
+
 #ifdef __APPLE__
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 12, 0))
     m_fontDatabase.reset(new QCoreTextFontDatabaseEngineFactory<QCoreTextFontEngine>());


### PR DESCRIPTION
In https://github.com/qt/qtbase/commit/01e1df90a7debd333314720fdd5cf6cd9964d796, screenAdded was deprecated, and as of qt 5.13 it is fully removed. Adapt to this change by using the new API in QWindowSystemInterface.