### PR TITLE
tests: remove last reference to sgmllib

### DIFF
--- a/src/calibre/test_build.py
+++ b/src/calibre/test_build.py
@@ -297,11 +297,6 @@ class BuildTest(unittest.TestCase):
 
     def test_feedparser(self):
         from calibre.web.feeds.feedparser import parse
-        # sgmllib is needed for feedparser parsing malformed feeds
-        # on python3 you can get it by taking it from python2 stdlib and
-        # running 2to3 on it
-        import sgmllib
-        sgmllib, parse
 
     def test_openssl(self):
         import ssl


### PR DESCRIPTION
Uses of sgmllib were removed in 692230147c79a1072e37005f91e5664835d53967.