### PR TITLE
py3: fix 'in' operation

### DIFF
--- a/src/calibre/ebooks/__init__.py
+++ b/src/calibre/ebooks/__init__.py
@@ -129,7 +129,7 @@ def render_html_svg_workaround(path_to_html, log, width=590, height=750):
     from calibre.ebooks.oeb.base import SVG_NS
     raw = open(path_to_html, 'rb').read()
     data = None
-    if SVG_NS in raw:
+    if SVG_NS.encode('utf-8') in raw:
         try:
             data = extract_cover_from_embedded_svg(raw,
                    os.path.dirname(path_to_html), log)


### PR DESCRIPTION
SVG_NS is pure ASCII, so it doesn't matter much what encoding is used.

Traceback (most recent call last):
  File "/home/zbyszek/python/calibre/calibre/src/calibre/ebooks/metadata/epub.py", line 264, in get_metadata
    cdata = get_cover(raster_cover, first_spine_item, reader)
  File "/home/zbyszek/python/calibre/calibre/src/calibre/ebooks/metadata/epub.py", line 248, in get_cover
    return render_cover(first_spine_item, zf, reader=reader)
  File "/home/zbyszek/python/calibre/calibre/src/calibre/ebooks/metadata/epub.py", line 234, in render_cover
    return render_html_svg_workaround(cpage, default_log)
  File "/home/zbyszek/python/calibre/calibre/src/calibre/ebooks/__init__.py", line 132, in render_html_svg_workaround
    if SVG_NS in raw:
TypeError: a bytes-like object is required, not 'str'