### PR TITLE
Sort input file list

### DIFF
--- a/setup/build.py
+++ b/setup/build.py
@@ -88,7 +88,7 @@ def expand_file_list(items, is_paths=True):
             ans.extend(expand_file_list(item, is_paths=is_paths))
         else:
             if '*' in item:
-                ans.extend(expand_file_list(glob.glob(os.path.join(SRC, item)), is_paths=is_paths))
+                ans.extend(expand_file_list(sorted(glob.glob(os.path.join(SRC, item))), is_paths=is_paths))
             else:
                 item = [item]
                 if is_paths:


### PR DESCRIPTION
Sort input file list
so that `calibre/plugins/lzma_binding.so` builds in a reproducible way
in spite of indeterministic filesystem readdir order
and http://bugs.python.org/issue30461

See https://reproducible-builds.org/ for why this is good.