### PR TITLE
Open With: don't raise KeyError if cache exists and there are new dirs

### DIFF
--- a/src/calibre/utils/open_with/linux.py
+++ b/src/calibre/utils/open_with/linux.py
@@ -116,7 +116,7 @@ def find_icons():
         with open(cache_file, 'rb') as f:
             cache = f.read()
         cache = msgpack_loads(cache)
-        mtimes, cache = cache['mtimes'], cache['data']
+        mtimes, cache = defaultdict(int, cache['mtimes']), defaultdict(dict, cache['data'])
     except Exception:
         mtimes, cache = defaultdict(int), defaultdict(dict)
 


### PR DESCRIPTION
If the cache failed to load, it is initialized as a defaultdict and all mtimes compare as 0. If the cache did load, however, then an ordinary dict was used, and if new icon directories appeared on the system since the cache creation, they would raise a KeyError and Open With would not load data.

Fix by using a defaultdict in all cases, but initializing with the contents of the cache if possible.

Discovered when crazy applications added crazy subdirectories in /usr/share/pixmaps (???) and suddenly calibre failed to do the right thing, but the same should apply if the system adds a new icon theme.