### PR TITLE
if the cover img resolution is too low, kindle wouldn't show it.

### DIFF
--- a/recipes/new_yorker.recipe
+++ b/recipes/new_yorker.recipe
@@ -77,6 +77,14 @@ class NewYorker(BasicNewsRecipe):
             cover_img = cover_img.find('img')
             if cover_img is not None:
                 self.cover_url = cover_img.get('src')
+                try:
+                    # the src original resolution w_280 was too low, replace w_280 with w_560
+                    cover_url_width_index = self.cover_url.find("w_")
+                    old_width = self.cover_url[cover_url_width_index:cover_url_width_index+5]
+                    self.cover_url = self.cover_url.replace(old_width, "w_560")
+                except Exception as e:
+                    self.log('Failed enlarging cover img, using the original one')
+              
                 self.log('Found cover:', self.cover_url)
         stories = defaultdict(list)
         last_section = 'Unknown'


### PR DESCRIPTION
not a significant one here...

In Kindle app or Kindle devices, if the resolution of a book's cover is too low, the device would only show a generic (blank) cover. It makes the screen looks ugly if your whole library displays the cover nicely except for one or two.

replacing the original src img size with a bigger size solves this issue

this is discuessed in
https://www.mobileread.com/forums/showthread.php?t=293114