### PR TITLE
enlarge cover img resolution by change the url

### DIFF
--- a/recipes/nature.recipe
+++ b/recipes/nature.recipe
@@ -50,6 +50,13 @@ class Nature(BasicNewsRecipe):
         self.cover_url = 'https:' + soup.find(
             'img', attrs={'data-test': check_words('issue-cover-image')}
         )['src']
+        try:
+            self.cover_url = self.cover_url.replace("w200","w500") # enlarge cover size resolution
+        except:
+            """
+            failed, img src might have changed, use default width 200
+            """
+            pass
         section_tags = soup.find(
             'div', {'data-container-type': check_words('issue-section-list')}
         )


### PR DESCRIPTION
kindle app on larger tablets does not show cover
if the cover img resolution is too low.
(same as my previous PR)

sorry i'm just doing this for the periodicals that I read..