### PR TITLE
 Fix podofo convert pystring to PdfString bug 

### DIFF
--- a/src/calibre/utils/podofo/utils.cpp
+++ b/src/calibre/utils/podofo/utils.cpp
@@ -32,7 +32,6 @@ const PdfString
 pdf::podofo_convert_pystring(PyObject *val) {
 #if PY_MAJOR_VERSION > 2
     return *(new PdfString(reinterpret_cast<const pdf_utf8*>(PyUnicode_AsUTF8(val))));
-
 #else
     PyObject *temp = PyUnicode_AsUTF8String(val);
     if (!temp) throw std::bad_alloc();

--- a/src/calibre/utils/podofo/utils.cpp
+++ b/src/calibre/utils/podofo/utils.cpp
@@ -31,11 +31,12 @@ pdf::podofo_convert_pdfstring(const PdfString &s) {
 const PdfString
 pdf::podofo_convert_pystring(PyObject *val) {
 #if PY_MAJOR_VERSION > 2
-    return s(reinterpret_cast<const pdf_utf8*>(PyUnicode_AsUTF8(val)));
+    return *(new PdfString(reinterpret_cast<const pdf_utf8*>(PyUnicode_AsUTF8(val))));
+
 #else
     PyObject *temp = PyUnicode_AsUTF8String(val);
     if (!temp) throw std::bad_alloc();
-    PdfString s(reinterpret_cast<const pdf_utf8*>(PyBytes_AS_STRING(temp)));
+    const PdfString s = *(new PdfString(reinterpret_cast<const pdf_utf8*>(PyBytes_AS_STRING(temp))));
     Py_DECREF(temp);
     return s;
 #endif


### PR DESCRIPTION
I cannot build because of bug: s is not declared in the scope of pdf::podofo_convert_pystring(PyObject *val).
I can build successfully with this patch applied. 