### PR TITLE
py3: When changing a dict, iterate over a copy of its items

### DIFF
--- a/src/calibre/ebooks/oeb/base.py
+++ b/src/calibre/ebooks/oeb/base.py
@@ -702,7 +702,7 @@ class Metadata(object):
                 term = CALIBRE(local)
             self.term = term
             self.value = value
-            for attr, value in attrib.items():
+            for attr, value in list(attrib.items()):
                 if isprefixname(value):
                     attrib[attr] = qname(value, nsmap)
                 nsattr = Metadata.OPF_ATTRS.get(attr, attr)


### PR DESCRIPTION
Changing dict keys while iterating over the dict was always undefined behavior in Python, but in 3.8 our tests started failing on this case.