### PR TITLE
resources: bump mathjax version to 2.7.6

### DIFF
--- a/setup/mathjax.py
+++ b/setup/mathjax.py
@@ -19,7 +19,7 @@ from setup import Command, download_securely
 class MathJax(Command):
 
     description = 'Create the MathJax bundle'
-    MATH_JAX_VERSION = '2.7.5'
+    MATH_JAX_VERSION = '2.7.6'
     MATH_JAX_URL = 'https://github.com/mathjax/MathJax/archive/%s.zip' % MATH_JAX_VERSION
     FONT_FAMILY = 'TeX'
 


### PR DESCRIPTION
There is actually no real consequential change here, because the update is a trivial bugfix that doesn't affect calibre's use, but let's do it anyway because it is both simple and harmless.