### PR TITLE
debug: return the fully qualified path to calibre-debug

### DIFF
--- a/src/calibre/debug.py
+++ b/src/calibre/debug.py
@@ -22,7 +22,7 @@ def get_debug_executable():
         return os.path.join(base, 'MacOS', 'calibre-debug')
     if getattr(sys, 'frozen', False):
         return os.path.join(os.path.dirname(os.path.abspath(sys.executable)), 'calibre-debug' + ('.exe' if iswindows else ''))
-    return 'calibre-debug'
+    return os.path.join(sys.executables_location, 'calibre-debug')
 
 
 def run_calibre_debug(*args, **kw):


### PR DESCRIPTION
We need to use sys.executables_location, because there may be multiple calibre-debug programs in the path or we may simply not be in the path at all. I ran into this due to testing multiple installations of calibre for python2/python3, and discovering that run_calibre_debug used the wrong python version.