### PR TITLE
Bump dbversion in KoboTouch driver

### DIFF
--- a/src/calibre/devices/kobo/driver.py
+++ b/src/calibre/devices/kobo/driver.py
@@ -83,7 +83,7 @@ class KOBO(USBMS):
 
     dbversion = 0
     fwversion = (0,0,0)
-    supported_dbversion = 155
+    supported_dbversion = 156
     has_kepubs = False
 
     supported_platforms = ['windows', 'osx', 'linux']
@@ -1349,7 +1349,7 @@ class KOBOTOUCH(KOBO):
         ' Based on the existing Kobo driver by %s.') % KOBO.author
 #    icon        = I('devices/kobotouch.jpg')
 
-    supported_dbversion             = 155
+    supported_dbversion             = 156
     min_supported_dbversion         = 53
     min_dbversion_series            = 65
     min_dbversion_externalid        = 65
@@ -1361,7 +1361,7 @@ class KOBOTOUCH(KOBO):
     # Starting with firmware version 3.19.x, the last number appears to be is a
     # build number. A number will be recorded here but it can be safely ignored
     # when testing the firmware version.
-    max_supported_fwversion         = (4, 17, 13579)
+    max_supported_fwversion         = (4, 17, 13651)
     # The following document firwmare versions where new function or devices were added.
     # Not all are used, but this feels a good place to record it.
     min_fwversion_shelves           = (2, 0, 0)
@@ -1375,6 +1375,7 @@ class KOBOTOUCH(KOBO):
     min_clarahd_fwversion           = (4,  8, 11090)
     min_forma_fwversion             = (4, 11, 11879)
     min_librah20_fwversion          = (4, 16, 13337)  # "Reviewers" release.
+    min_fwversion_epub_location     = (4, 17, 13651)  # ePub reading location without full contentid.
 
     has_kepubs = True
 


### PR DESCRIPTION
A last minute change from Kobo bumped the database version in the release for the Libra H2O.