### PR TITLE
wsj.recipe: update the if condition to check successful login

### DIFF
--- a/recipes/wsj.recipe
+++ b/recipes/wsj.recipe
@@ -148,7 +148,7 @@ class WSJ(BasicNewsRecipe):
             self.log('Performing login callback...')
             res = br.submit()
             self.wsj_itp_page = raw = res.read()
-            if b'>Sign Out<' not in raw:
+            if b'logout' not in raw:
                 raise ValueError(
                     'Failed to login (callback URL failed), check username and password')
             return br


### PR DESCRIPTION
due to i18n, the text "Sign Out" might not appear in the returned html. Therefore for people sending the requests from non english speaking country, the if condition would incorrectly raise an exception despite a successful login. I am changing the if condition to check the a tag href instead.

The <i>a<i> tag for logging out is : 
```
<a href="https://accounts.wsj.com/logout?target=">登出</a>
```