### PR TITLE
Avoid error on python3 about str and bytes

### DIFF
--- a/src/calibre/devices/mtp/driver.py
+++ b/src/calibre/devices/mtp/driver.py
@@ -176,6 +176,7 @@ class MTP_DEVICE(BASE):
         dinfo['date_last_connected'] = isoformat(now())
         dinfo['mtp_prefix'] = storage.storage_prefix
         raw = json.dumps(dinfo, default=to_json)
+        raw = bytes(raw,encoding='utf8') if isinstance(raw, str) else raw
         self.put_calibre_file(storage, 'driveinfo', BytesIO(raw), len(raw))
         self.driveinfo[location_code] = dinfo
 


### PR DESCRIPTION
When I launch the calibre application build for python3 I get two errors about expecting bytes not str and the other way around.
in src/calibre/devices/mtp/driver.py and src/calibre/devices/mtp/unix/driver.py
I found that theses edits remove the error.