### PR TITLE
Avoid error on python3 about str and bytes

### DIFF
--- a/src/calibre/devices/mtp/unix/driver.py
+++ b/src/calibre/devices/mtp/unix/driver.py
@@ -396,12 +396,11 @@ class MTP_DEVICE(MTPDeviceBase):
                 raise ValueError('Cannot upload file %s, it already exists'%(
                     e.full_path,))
             self.delete_file_or_folder(e)
-        ename = name.encode('utf-8') if isinstance(name, unicode_type) else name
         sid, pid = parent.storage_id, parent.object_id
         if pid == sid:
             pid = 0xFFFFFFFF
 
-        ans, errs = self.dev.put_file(sid, pid, ename, stream, size, callback)
+        ans, errs = self.dev.put_file(sid, pid, name, stream, size, callback)
         if ans is None:
             raise DeviceError('Failed to upload file named: %s to %s: %s'
                     %(name, parent.full_path, self.format_errorstack(errs)))


### PR DESCRIPTION
When I launch the calibre application build for python3 I get two errors about expecting bytes not str and the other way around.
in src/calibre/devices/mtp/driver.py and src/calibre/devices/mtp/unix/driver.py
I found that theses edits remove the error.