### PR TITLE
Nexto store: remove use of type('') with better xpath

### DIFF
--- a/src/calibre/gui2/store/stores/nexto_plugin.py
+++ b/src/calibre/gui2/store/stores/nexto_plugin.py
@@ -76,7 +76,7 @@ class NextoStore(BasicStoreConfig, StorePlugin):
                     title = re.sub(r' – ebook', '', title)
                     author = ', '.join(data.xpath('.//div[@class="col-7"]//h4//a/text()'))
                     formats = ', '.join(data.xpath('.//ul[@class="formats"]/li//b/text()'))
-                    DrmFree = re.search(r'znak', type('')(data.xpath('.//ul[@class="formats"]/li//b/@title')))
+                    DrmFree = data.xpath('.//ul[@class="formats"]/li//b[contains(@title, "znak")]')
 
                     counter -= 1
 


### PR DESCRIPTION
There's no need to run regular expressions on a str(list()) of lxml element results, to see if anything contains a string -- simply use the XPath grammar contains() and check if any results were returned.

...

Turns out we don't need to care whether this gets ported to unicode_type or not, since it's totally unneeded. :D