### PR TITLE
Speed-up of the FB2 writer and other fixes

### DIFF
--- a/src/calibre/ebooks/fb2/fb2ml.py
+++ b/src/calibre/ebooks/fb2/fb2ml.py
@@ -103,6 +103,10 @@ class FB2MLizer(object):
         if self.opts.insert_blank_line:
             text = re.sub(r'(?miu)</p>', '</p><empty-line/>', text)
 
+        # Put line breaks between paragraphs on a separate line.
+        text = re.sub(r'(?miu)</(p|title)>\s*<empty-line/>', r'</\1>\n<empty-line/>', text)
+        text = re.sub(r'(?miu)<empty-line/>\s*<p>', '<empty-line/>\n<p>', text)
+
         return text
 
     def fb2_header(self):

--- a/src/calibre/ebooks/fb2/fb2ml.py
+++ b/src/calibre/ebooks/fb2/fb2ml.py
@@ -19,7 +19,7 @@ from calibre.constants import __appname__, __version__
 from calibre.utils.localization import lang_as_iso639_1
 from calibre.utils.img import save_cover_data_to
 from calibre.ebooks.oeb.base import urlnormalize
-from polyglot.builtins import unicode_type, string_or_bytes
+from polyglot.builtins import unicode_type, string_or_bytes, range
 from polyglot.binary import as_base64_unicode
 
 
@@ -315,14 +315,8 @@ class FB2MLizer(object):
                         raw_data = as_base64_unicode(item.data)
                         content_type = item.media_type
                     # Don't put the encoded image on a single line.
-                    data = ''
-                    col = 1
-                    for char in raw_data:
-                        if col == 72:
-                            data += '\n'
-                            col = 1
-                        col += 1
-                        data += char
+                    step = 72
+                    data = '\n'.join(raw_data[i:i+step] for i in range(0, len(raw_data), step))
                     images.append('<binary id="%s" content-type="%s">%s\n</binary>' % (self.image_hrefs[item.href], content_type, data))
                 except Exception as e:
                     self.log.error('Error: Could not include file %s because '

--- a/src/calibre/ebooks/fb2/fb2ml.py
+++ b/src/calibre/ebooks/fb2/fb2ml.py
@@ -73,6 +73,8 @@ class FB2MLizer(object):
         return '<?xml version="1.0" encoding="UTF-8"?>\n' + output
 
     def clean_text(self, text):
+        # Remove empty tags.
+        text = re.sub(r'(?miu)<(strong|emphasis|strikethrough|sub|sup)>\s*</\1>', '', text)
         # Condense empty paragraphs into a line break.
         text = re.sub(r'(?miu)(<p>\s*</p>\s*){3,}', '<empty-line/>', text)
         # Remove empty paragraphs.

--- a/src/calibre/ebooks/fb2/fb2ml.py
+++ b/src/calibre/ebooks/fb2/fb2ml.py
@@ -253,9 +253,8 @@ class FB2MLizer(object):
 
         if cover_href:
             # Only write the image tag if it is in the manifest.
-            if cover_href in self.oeb_book.manifest.hrefs.keys():
-                if cover_href not in self.image_hrefs.keys():
-                    self.image_hrefs[cover_href] = '_%s.jpg' % len(self.image_hrefs.keys())
+            if cover_href in self.oeb_book.manifest.hrefs and cover_href not in self.image_hrefs:
+                self.image_hrefs[cover_href] = 'img_%s' % len(self.image_hrefs)
             return '<coverpage><image xlink:href="#%s" /></coverpage>' % self.image_hrefs[cover_href]
 
         return ''
@@ -462,7 +461,7 @@ class FB2MLizer(object):
                 ihref = urlnormalize(page.abshref(elem_tree.attrib['src']))
                 if ihref in self.oeb_book.manifest.hrefs:
                     if ihref not in self.image_hrefs:
-                        self.image_hrefs[ihref] = '_%s.jpg' % len(self.image_hrefs)
+                        self.image_hrefs[ihref] = 'img_%s' % len(self.image_hrefs)
                     p_txt, p_tag = self.ensure_p()
                     fb2_out += p_txt
                     tags += p_tag

--- a/src/calibre/ebooks/fb2/fb2ml.py
+++ b/src/calibre/ebooks/fb2/fb2ml.py
@@ -72,7 +72,7 @@ class FB2MLizer(object):
 
     def clean_text(self, text):
         # Condense empty paragraphs into a line break.
-        text = re.sub(r'(?miu)(<p>\s*</p>\s*){3,}', '<empty-line />', text)
+        text = re.sub(r'(?miu)(<p>\s*</p>\s*){3,}', '<empty-line/>', text)
         # Remove empty paragraphs.
         text = re.sub(r'(?miu)<p>\s*</p>', '', text)
         # Clean up pargraph endings.
@@ -95,7 +95,7 @@ class FB2MLizer(object):
         text = re.sub(r'(?miu)</section>\s*<section>', '</section>\n<section>', text)
 
         if self.opts.insert_blank_line:
-            text = re.sub(r'(?miu)</p>', '</p><empty-line />', text)
+            text = re.sub(r'(?miu)</p>', '</p><empty-line/>', text)
 
         return text
 
@@ -152,7 +152,7 @@ class FB2MLizer(object):
             index = '1'
             if self.oeb_book.metadata.series_index:
                 index = self.oeb_book.metadata.series_index[0]
-            metadata['sequence'] = '<sequence name="%s" number="%s" />' % (prepare_string_for_xml('%s' % self.oeb_book.metadata.series[0]), index)
+            metadata['sequence'] = '<sequence name="%s" number="%s"/>' % (prepare_string_for_xml('%s' % self.oeb_book.metadata.series[0]), index)
 
         year = publisher = isbn = ''
         identifiers = self.oeb_book.metadata['identifier']
@@ -255,7 +255,7 @@ class FB2MLizer(object):
             # Only write the image tag if it is in the manifest.
             if cover_href in self.oeb_book.manifest.hrefs and cover_href not in self.image_hrefs:
                 self.image_hrefs[cover_href] = 'img_%s' % len(self.image_hrefs)
-            return '<coverpage><image l:href="#%s" /></coverpage>' % self.image_hrefs[cover_href]
+            return '<coverpage><image l:href="#%s"/></coverpage>' % self.image_hrefs[cover_href]
 
         return ''
 
@@ -466,7 +466,7 @@ class FB2MLizer(object):
                     p_txt, p_tag = self.ensure_p()
                     fb2_out += p_txt
                     tags += p_tag
-                    fb2_out.append('<image l:href="#%s" />' % self.image_hrefs[ihref])
+                    fb2_out.append('<image l:href="#%s"/>' % self.image_hrefs[ihref])
                 else:
                     self.log.warn(u'Ignoring image not in manifest: %s'%ihref)
         if tag in ('br', 'hr') or ems >= 1:
@@ -483,12 +483,12 @@ class FB2MLizer(object):
                     closed_tags.append(t)
                     if t == 'p':
                         break
-                fb2_out.append('<empty-line />' * multiplier)
+                fb2_out.append('<empty-line/>' * multiplier)
                 closed_tags.reverse()
                 for t in closed_tags:
                     fb2_out.append('<%s>' % t)
             else:
-                fb2_out.append('<empty-line />' * multiplier)
+                fb2_out.append('<empty-line/>' * multiplier)
         if tag in ('div', 'li', 'p'):
             p_text, added_p = self.close_open_p(tag_stack+tags)
             fb2_out += p_text

--- a/src/calibre/ebooks/fb2/fb2ml.py
+++ b/src/calibre/ebooks/fb2/fb2ml.py
@@ -73,8 +73,9 @@ class FB2MLizer(object):
         return '<?xml version="1.0" encoding="UTF-8"?>\n' + output
 
     def clean_text(self, text):
-        # Remove empty tags.
-        text = re.sub(r'(?miu)<(strong|emphasis|strikethrough|sub|sup)>\s*</\1>', '', text)
+        # Remove pointless tags, but keep their contents.
+        text = re.sub(r'(?miu)<(strong|emphasis|strikethrough|sub|sup)>(\s*)</\1>', r'\2', text)
+
         # Condense empty paragraphs into a line break.
         text = re.sub(r'(?miu)(<p>\s*</p>\s*){3,}', '<empty-line/>', text)
         # Remove empty paragraphs.

--- a/src/calibre/ebooks/fb2/fb2ml.py
+++ b/src/calibre/ebooks/fb2/fb2ml.py
@@ -81,22 +81,24 @@ class FB2MLizer(object):
         # Condense empty paragraphs into a line break.
         text = re.sub(r'(?mu)(?:<p></p>\s*){3,}', '<empty-line/>', text)
         # Remove empty paragraphs.
-        text = re.sub(r'(?mu)<p></p>', '', text)
+        text = re.sub(r'(?mu)<p></p>\s*', '', text)
         # Put the paragraph following a paragraph on a separate line.
         text = re.sub(r'(?mu)</p>\s*<p>', '</p>\n<p>', text)
 
         # Clean up title endings.
         text = re.sub(r'(?mu)\s+</title>', '</title>', text)
         # Remove empty title elements.
-        text = re.sub(r'(?mu)<title></title>', '', text)
+        text = re.sub(r'(?mu)<title></title>\s*', '', text)
         # Put the paragraph following a title on a separate line.
         text = re.sub(r'(?mu)</title>\s*<p>', '</title>\n<p>', text)
 
         # Remove empty sections.
         text = re.sub(r'(?mu)<section>\s*</section>', '', text)
         # Clean up sections starts and ends.
-        text = re.sub(r'(?mu)\s*<section>\s*', '\n<section>\n', text)
-        text = re.sub(r'(?mu)\s*</section>\s*', '\n</section>\n', text)
+        text = re.sub(r'(?mu)\s*<section>', '\n<section>', text)
+        text = re.sub(r'(?mu)<section>\s*', '<section>\n', text)
+        text = re.sub(r'(?mu)\s*</section>', '\n</section>', text)
+        text = re.sub(r'(?mu)</section>\s*', '</section>\n', text)
         # Put the section following a section on a separate line.
         text = re.sub(r'(?mu)</section>\s*<section>', '</section>\n<section>', text)
 

--- a/src/calibre/ebooks/fb2/fb2ml.py
+++ b/src/calibre/ebooks/fb2/fb2ml.py
@@ -196,7 +196,7 @@ class FB2MLizer(object):
             metadata['comments'] = '<annotation>{}</annotation>'.format(prepare_string_for_xml(html2text(comments.value.strip())))
 
         return textwrap.dedent('''
-            <FictionBook xmlns="http://www.gribuser.ru/xml/fictionbook/2.0" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <FictionBook xmlns="http://www.gribuser.ru/xml/fictionbook/2.0" xmlns:l="http://www.w3.org/1999/xlink">
                 <description>
                     <title-info>
                         <genre>%(genre)s</genre>
@@ -255,7 +255,7 @@ class FB2MLizer(object):
             # Only write the image tag if it is in the manifest.
             if cover_href in self.oeb_book.manifest.hrefs and cover_href not in self.image_hrefs:
                 self.image_hrefs[cover_href] = 'img_%s' % len(self.image_hrefs)
-            return '<coverpage><image xlink:href="#%s" /></coverpage>' % self.image_hrefs[cover_href]
+            return '<coverpage><image l:href="#%s" /></coverpage>' % self.image_hrefs[cover_href]
 
         return ''
 
@@ -466,7 +466,7 @@ class FB2MLizer(object):
                     p_txt, p_tag = self.ensure_p()
                     fb2_out += p_txt
                     tags += p_tag
-                    fb2_out.append('<image xlink:href="#%s" />' % self.image_hrefs[ihref])
+                    fb2_out.append('<image l:href="#%s" />' % self.image_hrefs[ihref])
                 else:
                     self.log.warn(u'Ignoring image not in manifest: %s'%ihref)
         if tag in ('br', 'hr') or ems >= 1:

--- a/src/calibre/ebooks/fb2/fb2ml.py
+++ b/src/calibre/ebooks/fb2/fb2ml.py
@@ -78,7 +78,7 @@ class FB2MLizer(object):
         # Clean up pargraph endings.
         text = re.sub(r'(?miu)\s*</p>', '</p>', text)
         # Put paragraphs following a paragraph on a separate line.
-        text = re.sub(r'(?miu)</p>\s*<p>', '</p>\n\n<p>', text)
+        text = re.sub(r'(?miu)</p>\s*<p>', '</p>\n<p>', text)
 
         # Remove empty title elements.
         text = re.sub(r'(?miu)<title>\s*</title>', '', text)
@@ -88,11 +88,11 @@ class FB2MLizer(object):
         text = re.sub(r'(?miu)<section>\s*</section>', '', text)
         # Clean up sections start and ends.
         text = re.sub(r'(?miu)\s*</section>', '\n</section>', text)
-        text = re.sub(r'(?miu)</section>\s*', '</section>\n\n', text)
+        text = re.sub(r'(?miu)</section>\s*', '</section>\n', text)
         text = re.sub(r'(?miu)\s*<section>', '\n<section>', text)
         text = re.sub(r'(?miu)<section>\s*', '<section>\n', text)
         # Put sectnions followed by sections on a separate line.
-        text = re.sub(r'(?miu)</section>\s*<section>', '</section>\n\n<section>', text)
+        text = re.sub(r'(?miu)</section>\s*<section>', '</section>\n<section>', text)
 
         if self.opts.insert_blank_line:
             text = re.sub(r'(?miu)</p>', '</p><empty-line />', text)
@@ -223,7 +223,7 @@ class FB2MLizer(object):
                 </description>\n''') % metadata
 
     def fb2_footer(self):
-        return '\n</FictionBook>'
+        return '</FictionBook>'
 
     def get_cover(self):
         from calibre.ebooks.oeb.base import OEB_RASTER_IMAGES
@@ -291,7 +291,8 @@ class FB2MLizer(object):
             text.append('</section>')
             self.section_level -= 1
 
-        return ''.join(text) + '</body>'
+        text.append('</body>')
+        return ''.join(text) + '\n'
 
     def fb2mlize_images(self):
         '''
@@ -316,11 +317,11 @@ class FB2MLizer(object):
                     # Don't put the encoded image on a single line.
                     step = 72
                     data = '\n'.join(raw_data[i:i+step] for i in range(0, len(raw_data), step))
-                    images.append('<binary id="%s" content-type="%s">%s\n</binary>' % (self.image_hrefs[item.href], content_type, data))
+                    images.append('<binary id="%s" content-type="%s">%s</binary>' % (self.image_hrefs[item.href], content_type, data))
                 except Exception as e:
                     self.log.error('Error: Could not include file %s because '
                         '%s.' % (item.href, e))
-        return ''.join(images)
+        return '\n'.join(images) + '\n'
 
     def create_flat_toc(self, nodes, level):
         for item in nodes:

--- a/src/calibre/ebooks/fb2/fb2ml.py
+++ b/src/calibre/ebooks/fb2/fb2ml.py
@@ -200,32 +200,33 @@ class FB2MLizer(object):
             from calibre.utils.html2text import html2text
             metadata['comments'] = '<annotation><p>{}</p></annotation>'.format(prepare_string_for_xml(html2text(comments.value).strip()))
 
+        # Keep the indentation level of the description the same as the body.
         header = textwrap.dedent('''\
             <FictionBook xmlns="http://www.gribuser.ru/xml/fictionbook/2.0" xmlns:l="http://www.w3.org/1999/xlink">
-                <description>
-                    <title-info>
-                        <genre>%(genre)s</genre>
-                        %(author)s
-                        <book-title>%(title)s</book-title>
-                        %(cover)s
-                        <lang>%(lang)s</lang>
-                        %(keywords)s
-                        %(sequence)s
-                        %(comments)s
-                    </title-info>
-                    <document-info>
-                        %(author)s
-                        <program-used>%(appname)s %(version)s</program-used>
-                        <date>%(date)s</date>
-                        <id>%(id)s</id>
-                        <version>1.0</version>
-                    </document-info>
-                    <publish-info>
-                        %(publisher)s
-                        %(year)s
-                        %(isbn)s
-                    </publish-info>
-                </description>''') % metadata
+            <description>
+                <title-info>
+                    <genre>%(genre)s</genre>
+                    %(author)s
+                    <book-title>%(title)s</book-title>
+                    %(cover)s
+                    <lang>%(lang)s</lang>
+                    %(keywords)s
+                    %(sequence)s
+                    %(comments)s
+                </title-info>
+                <document-info>
+                    %(author)s
+                    <program-used>%(appname)s %(version)s</program-used>
+                    <date>%(date)s</date>
+                    <id>%(id)s</id>
+                    <version>1.0</version>
+                </document-info>
+                <publish-info>
+                    %(publisher)s
+                    %(year)s
+                    %(isbn)s
+                </publish-info>
+            </description>''') % metadata
 
         # Remove empty lines.
         return '\n'.join(filter(unicode_type.strip, header.splitlines()))

--- a/src/calibre/ebooks/fb2/fb2ml.py
+++ b/src/calibre/ebooks/fb2/fb2ml.py
@@ -21,12 +21,13 @@ from calibre.utils.img import save_cover_data_to
 from calibre.ebooks.oeb.base import urlnormalize
 from polyglot.builtins import unicode_type, string_or_bytes, range, filter
 from polyglot.binary import as_base64_unicode
+from polyglot.urllib import urlparse
 
 
 class FB2MLizer(object):
     '''
     Todo: * Include more FB2 specific tags in the conversion.
-          * Handle a tags.
+          * Handle notes and anchor links.
     '''
 
     def __init__(self, log):
@@ -508,6 +509,14 @@ class FB2MLizer(object):
             fb2_out += p_text
             if added_p:
                 tags.append('p')
+        if tag == 'a' and elem_tree.attrib.get('href', None):
+            # Handle only external links for now
+            if urlparse(elem_tree.attrib['href']).netloc:
+                p_txt, p_tag = self.ensure_p()
+                fb2_out += p_txt
+                tags += p_tag
+                fb2_out.append('<a l:href="%s">' % urlnormalize(elem_tree.attrib['href']))
+                tags.append('a')
         if tag == 'b' or style['font-weight'] in ('bold', 'bolder'):
             s_out, s_tags = self.handle_simple_tag('strong', tag_stack+tags)
             fb2_out += s_out

--- a/src/calibre/ebooks/fb2/fb2ml.py
+++ b/src/calibre/ebooks/fb2/fb2ml.py
@@ -19,7 +19,7 @@ from calibre.constants import __appname__, __version__
 from calibre.utils.localization import lang_as_iso639_1
 from calibre.utils.img import save_cover_data_to
 from calibre.ebooks.oeb.base import urlnormalize
-from polyglot.builtins import unicode_type, string_or_bytes, range
+from polyglot.builtins import unicode_type, string_or_bytes, range, filter
 from polyglot.binary import as_base64_unicode
 
 
@@ -195,12 +195,12 @@ class FB2MLizer(object):
             from calibre.utils.html2text import html2text
             metadata['comments'] = '<annotation>{}</annotation>'.format(prepare_string_for_xml(html2text(comments.value.strip())))
 
-        return textwrap.dedent('''
+        header = textwrap.dedent('''\
             <FictionBook xmlns="http://www.gribuser.ru/xml/fictionbook/2.0" xmlns:l="http://www.w3.org/1999/xlink">
                 <description>
                     <title-info>
                         <genre>%(genre)s</genre>
-                            %(author)s
+                        %(author)s
                         <book-title>%(title)s</book-title>
                         %(cover)s
                         <lang>%(lang)s</lang>
@@ -220,7 +220,10 @@ class FB2MLizer(object):
                         %(year)s
                         %(isbn)s
                     </publish-info>
-                </description>\n''') % metadata
+                </description>''') % metadata
+
+        # Remove empty lines.
+        return '\n'.join(filter(unicode_type.strip, header.splitlines())) + '\n'
 
     def fb2_footer(self):
         return '</FictionBook>'

--- a/src/calibre/ebooks/fb2/fb2ml.py
+++ b/src/calibre/ebooks/fb2/fb2ml.py
@@ -471,19 +471,18 @@ class FB2MLizer(object):
         # Process the XHTML tag and styles. Converted to an FB2 tag.
         # Use individual if statement not if else. There can be
         # only one XHTML tag but it can have multiple styles.
-        if tag == 'img':
-            if elem_tree.attrib.get('src', None):
-                # Only write the image tag if it is in the manifest.
-                ihref = urlnormalize(page.abshref(elem_tree.attrib['src']))
-                if ihref in self.oeb_book.manifest.hrefs:
-                    if ihref not in self.image_hrefs:
-                        self.image_hrefs[ihref] = 'img_%s' % len(self.image_hrefs)
-                    p_txt, p_tag = self.ensure_p()
-                    fb2_out += p_txt
-                    tags += p_tag
-                    fb2_out.append('<image l:href="#%s"/>' % self.image_hrefs[ihref])
-                else:
-                    self.log.warn(u'Ignoring image not in manifest: %s'%ihref)
+        if tag == 'img' and elem_tree.attrib.get('src', None):
+            # Only write the image tag if it is in the manifest.
+            ihref = urlnormalize(page.abshref(elem_tree.attrib['src']))
+            if ihref in self.oeb_book.manifest.hrefs:
+                if ihref not in self.image_hrefs:
+                    self.image_hrefs[ihref] = 'img_%s' % len(self.image_hrefs)
+                p_txt, p_tag = self.ensure_p()
+                fb2_out += p_txt
+                tags += p_tag
+                fb2_out.append('<image l:href="#%s"/>' % self.image_hrefs[ihref])
+            else:
+                self.log.warn(u'Ignoring image not in manifest: %s' % ihref)
         if tag in ('br', 'hr') or ems >= 1:
             if ems < 1:
                 multiplier = 1

--- a/src/calibre/ebooks/fb2/fb2ml.py
+++ b/src/calibre/ebooks/fb2/fb2ml.py
@@ -74,38 +74,38 @@ class FB2MLizer(object):
 
     def clean_text(self, text):
         # Remove pointless tags, but keep their contents.
-        text = re.sub(r'(?miu)<(strong|emphasis|strikethrough|sub|sup)>(\s*)</\1>', r'\2', text)
+        text = re.sub(r'(?mu)<(strong|emphasis|strikethrough|sub|sup)>(\s*)</\1>', r'\2', text)
 
         # Clean up paragraphs endings.
-        text = re.sub(r'(?miu)\s+</p>', '</p>', text)
+        text = re.sub(r'(?mu)\s+</p>', '</p>', text)
         # Condense empty paragraphs into a line break.
-        text = re.sub(r'(?miu)(?:<p></p>\s*){3,}', '<empty-line/>', text)
+        text = re.sub(r'(?mu)(?:<p></p>\s*){3,}', '<empty-line/>', text)
         # Remove empty paragraphs.
-        text = re.sub(r'(?miu)<p></p>', '', text)
+        text = re.sub(r'(?mu)<p></p>', '', text)
         # Put the paragraph following a paragraph on a separate line.
-        text = re.sub(r'(?miu)</p>\s*<p>', '</p>\n<p>', text)
+        text = re.sub(r'(?mu)</p>\s*<p>', '</p>\n<p>', text)
 
         # Clean up title endings.
-        text = re.sub(r'(?miu)\s+</title>', '</title>', text)
+        text = re.sub(r'(?mu)\s+</title>', '</title>', text)
         # Remove empty title elements.
-        text = re.sub(r'(?miu)<title></title>', '', text)
+        text = re.sub(r'(?mu)<title></title>', '', text)
         # Put the paragraph following a title on a separate line.
-        text = re.sub(r'(?miu)</title>\s*<p>', '</title>\n<p>', text)
+        text = re.sub(r'(?mu)</title>\s*<p>', '</title>\n<p>', text)
 
         # Remove empty sections.
-        text = re.sub(r'(?miu)<section>\s*</section>', '', text)
+        text = re.sub(r'(?mu)<section>\s*</section>', '', text)
         # Clean up sections starts and ends.
-        text = re.sub(r'(?miu)\s*<section>\s*', '\n<section>\n', text)
-        text = re.sub(r'(?miu)\s*</section>\s*', '\n</section>\n', text)
+        text = re.sub(r'(?mu)\s*<section>\s*', '\n<section>\n', text)
+        text = re.sub(r'(?mu)\s*</section>\s*', '\n</section>\n', text)
         # Put the section following a section on a separate line.
-        text = re.sub(r'(?miu)</section>\s*<section>', '</section>\n<section>', text)
+        text = re.sub(r'(?mu)</section>\s*<section>', '</section>\n<section>', text)
 
         if self.opts.insert_blank_line:
-            text = re.sub(r'(?miu)</p>', '</p><empty-line/>', text)
+            text = re.sub(r'(?mu)</p>', '</p><empty-line/>', text)
 
         # Put line breaks between paragraphs on a separate line.
-        text = re.sub(r'(?miu)</(p|title)>\s*<empty-line/>', r'</\1>\n<empty-line/>', text)
-        text = re.sub(r'(?miu)<empty-line/>\s*<p>', '<empty-line/>\n<p>', text)
+        text = re.sub(r'(?mu)</(p|title)>\s*<empty-line/>', r'</\1>\n<empty-line/>', text)
+        text = re.sub(r'(?mu)<empty-line/>\s*<p>', '<empty-line/>\n<p>', text)
 
         return text
 

--- a/src/calibre/ebooks/fb2/fb2ml.py
+++ b/src/calibre/ebooks/fb2/fb2ml.py
@@ -59,16 +59,18 @@ class FB2MLizer(object):
         return self.fb2mlize_spine()
 
     def fb2mlize_spine(self):
-        output = [self.fb2_header()]
-        output.append(self.get_text())
-        output.append(self.fb2mlize_images())
-        output.append(self.fb2_footer())
-        output = self.clean_text(''.join(output))
+        output = (
+            self.fb2_header(),
+            self.get_text(),
+            self.fb2mlize_images(),
+            self.fb2_footer(),
+        )
+        output = self.clean_text('\n'.join(output))
 
         if self.opts.pretty_print:
-            return '<?xml version="1.0" encoding="UTF-8"?>\n%s' % etree.tostring(etree.fromstring(output), encoding='unicode', pretty_print=True)
-        else:
-            return '<?xml version="1.0" encoding="UTF-8"?>' + output
+            output = etree.tostring(etree.fromstring(output), encoding='unicode', pretty_print=True)
+
+        return '<?xml version="1.0" encoding="UTF-8"?>\n' + output
 
     def clean_text(self, text):
         # Condense empty paragraphs into a line break.
@@ -223,7 +225,7 @@ class FB2MLizer(object):
                 </description>''') % metadata
 
         # Remove empty lines.
-        return '\n'.join(filter(unicode_type.strip, header.splitlines())) + '\n'
+        return '\n'.join(filter(unicode_type.strip, header.splitlines()))
 
     def fb2_footer(self):
         return '</FictionBook>'
@@ -295,7 +297,7 @@ class FB2MLizer(object):
             self.section_level -= 1
 
         text.append('</body>')
-        return ''.join(text) + '\n'
+        return ''.join(text)
 
     def fb2mlize_images(self):
         '''
@@ -324,7 +326,7 @@ class FB2MLizer(object):
                 except Exception as e:
                     self.log.error('Error: Could not include file %s because '
                         '%s.' % (item.href, e))
-        return '\n'.join(images) + '\n'
+        return '\n'.join(images)
 
     def create_flat_toc(self, nodes, level):
         for item in nodes:

--- a/src/calibre/ebooks/fb2/fb2ml.py
+++ b/src/calibre/ebooks/fb2/fb2ml.py
@@ -85,12 +85,19 @@ class FB2MLizer(object):
         # Put the paragraph following a paragraph on a separate line.
         text = re.sub(r'(?mu)</p>\s*<p>', '</p>\n<p>', text)
 
+        if self.opts.insert_blank_line:
+            text = re.sub(r'(?mu)</p>', '</p><empty-line/>', text)
+
         # Clean up title endings.
         text = re.sub(r'(?mu)\s+</title>', '</title>', text)
         # Remove empty title elements.
         text = re.sub(r'(?mu)<title></title>\s*', '', text)
         # Put the paragraph following a title on a separate line.
         text = re.sub(r'(?mu)</title>\s*<p>', '</title>\n<p>', text)
+
+        # Put line breaks between paragraphs on a separate line.
+        text = re.sub(r'(?mu)</(p|title)>\s*<empty-line/>', r'</\1>\n<empty-line/>', text)
+        text = re.sub(r'(?mu)<empty-line/>\s*<p>', '<empty-line/>\n<p>', text)
 
         # Remove empty sections.
         text = re.sub(r'(?mu)<section>\s*</section>', '', text)
@@ -99,15 +106,6 @@ class FB2MLizer(object):
         text = re.sub(r'(?mu)<section>\s*', '<section>\n', text)
         text = re.sub(r'(?mu)\s*</section>', '\n</section>', text)
         text = re.sub(r'(?mu)</section>\s*', '</section>\n', text)
-        # Put the section following a section on a separate line.
-        text = re.sub(r'(?mu)</section>\s*<section>', '</section>\n<section>', text)
-
-        if self.opts.insert_blank_line:
-            text = re.sub(r'(?mu)</p>', '</p><empty-line/>', text)
-
-        # Put line breaks between paragraphs on a separate line.
-        text = re.sub(r'(?mu)</(p|title)>\s*<empty-line/>', r'</\1>\n<empty-line/>', text)
-        text = re.sub(r'(?mu)<empty-line/>\s*<p>', '<empty-line/>\n<p>', text)
 
         return text
 

--- a/src/calibre/ebooks/fb2/fb2ml.py
+++ b/src/calibre/ebooks/fb2/fb2ml.py
@@ -197,7 +197,7 @@ class FB2MLizer(object):
             metadata['comments'] = ''
         else:
             from calibre.utils.html2text import html2text
-            metadata['comments'] = '<annotation>{}</annotation>'.format(prepare_string_for_xml(html2text(comments.value.strip())))
+            metadata['comments'] = '<annotation><p>{}</p></annotation>'.format(prepare_string_for_xml(html2text(comments.value).strip()))
 
         header = textwrap.dedent('''\
             <FictionBook xmlns="http://www.gribuser.ru/xml/fictionbook/2.0" xmlns:l="http://www.w3.org/1999/xlink">

--- a/src/calibre/ebooks/fb2/fb2ml.py
+++ b/src/calibre/ebooks/fb2/fb2ml.py
@@ -76,27 +76,28 @@ class FB2MLizer(object):
         # Remove pointless tags, but keep their contents.
         text = re.sub(r'(?miu)<(strong|emphasis|strikethrough|sub|sup)>(\s*)</\1>', r'\2', text)
 
+        # Clean up paragraphs endings.
+        text = re.sub(r'(?miu)\s+</p>', '</p>', text)
         # Condense empty paragraphs into a line break.
-        text = re.sub(r'(?miu)(<p>\s*</p>\s*){3,}', '<empty-line/>', text)
+        text = re.sub(r'(?miu)(?:<p></p>\s*){3,}', '<empty-line/>', text)
         # Remove empty paragraphs.
-        text = re.sub(r'(?miu)<p>\s*</p>', '', text)
-        # Clean up pargraph endings.
-        text = re.sub(r'(?miu)\s*</p>', '</p>', text)
-        # Put paragraphs following a paragraph on a separate line.
+        text = re.sub(r'(?miu)<p></p>', '', text)
+        # Put the paragraph following a paragraph on a separate line.
         text = re.sub(r'(?miu)</p>\s*<p>', '</p>\n<p>', text)
 
-        # Remove empty title elements.
-        text = re.sub(r'(?miu)<title>\s*</title>', '', text)
+        # Clean up title endings.
         text = re.sub(r'(?miu)\s+</title>', '</title>', text)
+        # Remove empty title elements.
+        text = re.sub(r'(?miu)<title></title>', '', text)
+        # Put the paragraph following a title on a separate line.
+        text = re.sub(r'(?miu)</title>\s*<p>', '</title>\n<p>', text)
 
         # Remove empty sections.
         text = re.sub(r'(?miu)<section>\s*</section>', '', text)
-        # Clean up sections start and ends.
-        text = re.sub(r'(?miu)\s*</section>', '\n</section>', text)
-        text = re.sub(r'(?miu)</section>\s*', '</section>\n', text)
-        text = re.sub(r'(?miu)\s*<section>', '\n<section>', text)
-        text = re.sub(r'(?miu)<section>\s*', '<section>\n', text)
-        # Put sectnions followed by sections on a separate line.
+        # Clean up sections starts and ends.
+        text = re.sub(r'(?miu)\s*<section>\s*', '\n<section>\n', text)
+        text = re.sub(r'(?miu)\s*</section>\s*', '\n</section>\n', text)
+        # Put the section following a section on a separate line.
         text = re.sub(r'(?miu)</section>\s*<section>', '</section>\n<section>', text)
 
         if self.opts.insert_blank_line:


### PR DESCRIPTION
Hi,

Thank you for adding the [support for PNG images](https://bugs.launchpad.net/calibre/+bug/1844911), it speeds up the conversion.

But even after these changes the conversion of one average book takes roughly one hour. I looked into the code and found that most of the time spent on splitting of the base64 string. Python strings are immutable and appending just one char to a string leads to copying the whole string on each iteration. The better way to use the slice method.
The old code converts one image with size of 820 Kb more than 11 minutes, the new one – faster than one second of time.

Code | Seconds
--- | ---
old | 680.590
new | 0.014

[split_test.zip](https://github.com/kovidgoyal/calibre/files/3696952/split_test.zip)

So now the conversion of one book takes only several seconds.
We can observe this terrible slowdown only on Python 2, the Python 3 concatenate strings much faster, but it’s still not the best way to solve this problem.
I should note, that the [FB2 documentation](http://www.fictionbook.org/index.php/Элемент_binary) says, that the base64 string should be splitted by 72 chars, but Calibre splits it at 72th char (i.e. splits by 71 chars). I fixed this too.
This is the first commit.

Let’s get going further. After adding the PNG support there appeared an issue, when the ID of PNG image contained ".jpg" extension.
`<binary id="_0.jpg" content-type="image/png">`
I did not find a way to get the correct extension, because the link to the cover image adds up before the images was converted, so we cannot know if the cover image was converted to another format or not. So I just removed extension from ID, because it’s just a identifier, and file extension there is not required. I have these kind of books in my library and they work just fine. This is the second commit for.

The next commits are just prettify the document as well as making the file smaller. I strive to adjust document to the same way, as the official FictionBook Editor does.

Last three commits fix the issues with empty tags in the body (sometimes writer generates something like `<p><strong></strong></p>`) and annotation tag, which should contain paragraph tag.

In the end, I have a question: can I reduce the indentation level of the header to position it on the same level as the body?

Best regards,
Andrey.