### PR TITLE
py3: use correct sort key for forcing an element to sort first

### DIFF
--- a/src/calibre/gui2/dialogs/template_dialog.py
+++ b/src/calibre/gui2/dialogs/template_dialog.py
@@ -222,7 +222,7 @@ class TemplateDialog(QDialog, Ui_TemplateDialog):
         cols = []
         if fm is not None:
             for key in sorted(displayable_columns(fm),
-                              key=lambda k: sort_key(fm[k]['name']) if k != color_row_key else 0):
+                              key=lambda k: sort_key(fm[k]['name'] if k != color_row_key else 0)):
                 if key == color_row_key and not self.coloring:
                     continue
                 from calibre.gui2.preferences.coloring import all_columns_string


### PR DESCRIPTION
0 isn't a valid comparison for ICU sort_key() output and returns tracebacks instead, but sort_key(0) is.

