### PR TITLE
check: cleanup file exclusions

### DIFF
--- a/setup/check.py
+++ b/setup/check.py
@@ -30,11 +30,9 @@ class Check(Command):
             for x in os.walk(self.j(self.SRC, dname)):
                 for f in x[-1]:
                     y = self.j(x[0], f)
-                    if x[0].endswith('calibre/ebooks/markdown'):
-                        continue
                     if (f.endswith('.py') and f not in (
-                            'feedparser.py', 'markdown.py', 'BeautifulSoup.py', 'dict_data.py',
-                            'unicodepoints.py', 'krcodepoints.py', 'jacodepoints.py', 'vncodepoints.py', 'zhcodepoints.py') and
+                            'dict_data.py', 'unicodepoints.py', 'krcodepoints.py',
+                            'jacodepoints.py', 'vncodepoints.py', 'zhcodepoints.py') and
                             'prs500/driver.py' not in y) and not f.endswith('_ui.py'):
                         yield y
 


### PR DESCRIPTION
Some of these files no longer exist due to being devendored. BeautifulSoup.py is now something else entirely which is calibre-specific code and deserves the right to be linted.