### PR TITLE
Add render page tweak settings.

### DIFF
--- a/resources/default_tweaks.py
+++ b/resources/default_tweaks.py
@@ -566,3 +566,14 @@ exclude_fields_on_paste = []
 # Useful if for some reason your operating systems network checking
 # facilities are not reliable (for example NetworkManager on Linux).
 skip_network_check = False
+
+#: Render Page Settings
+# Default page size and margins to use when rendering an HTML page.
+# Affects size of cover rendered from ebook file.
+# Examples:
+#   render_page_size = 'A4'
+#   render_page_size = 'A6'
+#   render_page_size = 'Letter'
+#   render_page_margins = (left, top, right, bottom)
+render_page_size = 'A4'
+render_page_margins = (0, 0, 0, 0)

--- a/src/calibre/ebooks/render_html.py
+++ b/src/calibre/ebooks/render_html.py
@@ -17,6 +17,7 @@ from calibre.gui2 import must_use_qt
 from calibre.gui2.webengine import secure_webengine
 from calibre.utils.monotonic import monotonic
 from calibre.utils.filenames import atomic_rename
+from calibre.utils.config import tweaks
 
 LOAD_TIMEOUT = 20
 PRINT_TIMEOUT = 10
@@ -57,8 +58,16 @@ class Render(QWebEnginePage):
                 QApplication.instance().exit(3)
 
     def start_print(self):
-        margins = QMarginsF(0, 0, 0, 0)
-        page_layout = QPageLayout(QPageSize(QPageSize.A4), QPageLayout.Portrait, margins)
+        try:
+            mgs = tweaks.get('render_page_margins', (0, 0, 0, 0))
+            margins = QMarginsF(*mgs)
+        except:
+            margins = QMarginsF(0, 0, 0, 0)
+        try:
+            render_page_size = getattr(QPageSize, tweaks.get('render_page_size', 'A4').capitalize())
+        except:
+            render_page_size='A4'
+        page_layout = QPageLayout(QPageSize(render_page_size), QPageLayout.Portrait, margins)
         self.printToPdf('rendered.pdf', page_layout)
         self.printing_started = True
         self.start_time = monotonic()


### PR DESCRIPTION
A couple tweak settings to allow customization of page size and margins for page renders of ebooks.  This arose from [this discussion](https://www.mobileread.com/forums/showthread.php?p=3909276&postcount=3780).

I will admit that I don't know where else this render code might be called from and may have named and described the settings poorly.