### PR TITLE
Possible fix for #1850764.

### DIFF
--- a/src/calibre/gui2/actions/polish.py
+++ b/src/calibre/gui2/actions/polish.py
@@ -530,6 +530,7 @@ class PolishAction(InterfaceAction):
             pass
         self.gui.tags_view.recount()
         if self.gui.current_view() is self.gui.library_view:
+            self.gui.library_view.model().refresh_ids((book_id,))
             current = self.gui.library_view.currentIndex()
             if current.isValid():
                 self.gui.library_view.model().current_changed(current, QModelIndex())


### PR DESCRIPTION
Assuming I guessed right on the column icon rule, the problem is that Polish doesn't clear the icon caches (or any other cache). I fixed this by adding a call to refresh_ids
after line 532. My problem is that I don't know what to do with the resulting lines 534-536. Do they need to stay? They are updating the book details pane. As far as I can tell, refresh_ids does not do that update, so the lines should stay. Do you agree?