### PR TITLE
linux installer: fix python3 re.sub with mismatched str/bytes

### DIFF
--- a/setup/linux-installer.py
+++ b/setup/linux-installer.py
@@ -163,7 +163,7 @@ class TerminalController:  # {{{
         if isinstance(cap_name, bytes):
             cap_name = cap_name.decode('utf-8')
         cap = self._escape_code(curses.tigetstr(cap_name))
-        return re.sub(r'\$<\d+>[/*]?', b'', cap)
+        return re.sub(r'\$<\d+>[/*]?', '', cap)
 
     def render(self, template):
         return re.sub(r'\$\$|\${\w+}', self._render_sub, template)

--- a/setup/linux-installer.sh
+++ b/setup/linux-installer.sh
@@ -212,7 +212,7 @@ class TerminalController:  # {{{
         if isinstance(cap_name, bytes):
             cap_name = cap_name.decode('utf-8')
         cap = self._escape_code(curses.tigetstr(cap_name))
-        return re.sub(r'\$<\d+>[/*]?', b'', cap)
+        return re.sub(r'\$<\d+>[/*]?', '', cap)
 
     def render(self, template):
         return re.sub(r'\$\$|\${\w+}', self._render_sub, template)


### PR DESCRIPTION
This does not seem to have been a very commonly hit case, since it's been broken for python3 since before 2014, but a user has just hit it for the first time.

Fixes #1851873