### PR TITLE
Use canonical ID for AppStream ID

### DIFF
--- a/src/calibre/linux.py
+++ b/src/calibre/linux.py
@@ -1133,7 +1133,8 @@ def get_appdata():
 def write_appdata(key, entry, base, translators):
     from lxml.etree import tostring
     from lxml.builder import E
-    fpath = os.path.join(base, '%s.appdata.xml' % key)
+    appstream_id = ('com.calibre-ebook.Calibre.' + key).replace('-', '_')
+    fpath = os.path.join(base, '%s.appdata.xml' % appstream_id)
     screenshots = E.screenshots()
     for w, h, url in entry['screenshots']:
         s = E.screenshot(E.image(url, width=unicode_type(w), height=unicode_type(h)))
@@ -1149,7 +1150,7 @@ def write_appdata(key, entry, base, translators):
                 description[-1].set('{http://www.w3.org/XML/1998/namespace}lang', lang)
 
     root = E.component(
-        E.id(key + '.desktop'),
+        E.id(appstream_id),
         E.name(entry['name']),
         E.metadata_license('CC0-1.0'),
         E.project_license('GPL-3.0'),

--- a/src/calibre/linux.py
+++ b/src/calibre/linux.py
@@ -877,8 +877,10 @@ class PostInstall:
                 with open('com.calibre_ebook.Calibre.calibre_gui.desktop', 'wb') as f:
                     f.write(GUI.encode('utf-8'))
                     write_mimetypes(f)
-                des = ('com.calibre_ebook.Calibre.calibre_gui.desktop', 'com.calibre_ebook.Calibre.calibre_lrfviewer.desktop',
-                        'com.calibre_ebook.Calibre.calibre_ebook_viewer.desktop', 'com.calibre_ebook.Calibre.calibre_ebook_edit.desktop')
+                des = ('com.calibre_ebook.Calibre.calibre_gui.desktop',
+                       'com.calibre_ebook.Calibre.calibre_lrfviewer.desktop',
+                       'com.calibre_ebook.Calibre.calibre_ebook_viewer.desktop',
+                       'com.calibre_ebook.Calibre.calibre_ebook_edit.desktop')
                 appdata = os.path.join(os.path.dirname(self.opts.staging_sharedir), 'metainfo')
                 if not os.path.exists(appdata):
                     try:

--- a/src/calibre/linux.py
+++ b/src/calibre/linux.py
@@ -898,7 +898,7 @@ class PostInstall:
                     cmd = ['xdg-desktop-menu', 'install', '--noupdate', './'+x]
                     cc(' '.join(cmd), shell=True)
                     self.menu_resources.append(x)
-                    ak = x.partition('.')[0]
+                    ak = x.partition('.desktop')[0]
                     if ak in APPDATA and os.access(appdata, os.W_OK):
                         self.appdata_resources.append(write_appdata(ak, APPDATA[ak], appdata, translators))
                 MIME_BASE = 'calibre-mimetypes.xml'
@@ -1089,7 +1089,7 @@ X-GNOME-UsesNotifications=true
 def get_appdata():
     _ = lambda x: x  # Make sure the text below is not translated, but is marked for translation
     return {
-        'calibre-gui': {
+        'com.calibre_ebook.Calibre.calibre_gui': {
             'name':'calibre',
             'summary':_('The one stop solution to all your e-book needs'),
             'description':(
@@ -1103,7 +1103,7 @@ def get_appdata():
             ),
         },
 
-        'calibre-ebook-edit': {
+        'com.calibre_ebook.Calibre.calibre_ebook_edit': {
             'name':'calibre - E-book Editor',
             'summary':_('Edit the text and styles inside e-books'),
             'description':(
@@ -1117,7 +1117,7 @@ def get_appdata():
             ),
         },
 
-        'calibre-ebook-viewer': {
+        'com.calibre_ebook.Calibre.calibre_ebook_viewer': {
             'name':'calibre - E-book Viewer',
             'summary':_('Read e-books in over a dozen different formats'),
             'description': (
@@ -1135,8 +1135,7 @@ def get_appdata():
 def write_appdata(key, entry, base, translators):
     from lxml.etree import tostring
     from lxml.builder import E
-    appstream_id = ('com.calibre-ebook.Calibre.' + key).replace('-', '_')
-    fpath = os.path.join(base, '%s.appdata.xml' % appstream_id)
+    fpath = os.path.join(base, '%s.appdata.xml' % key)
     screenshots = E.screenshots()
     for w, h, url in entry['screenshots']:
         s = E.screenshot(E.image(url, width=unicode_type(w), height=unicode_type(h)))
@@ -1152,7 +1151,7 @@ def write_appdata(key, entry, base, translators):
                 description[-1].set('{http://www.w3.org/XML/1998/namespace}lang', lang)
 
     root = E.component(
-        E.id(appstream_id),
+        E.id(key),
         E.name(entry['name']),
         E.metadata_license('CC0-1.0'),
         E.project_license('GPL-3.0'),

--- a/src/calibre/linux.py
+++ b/src/calibre/linux.py
@@ -865,20 +865,20 @@ class PostInstall:
 
                 from calibre.ebooks.oeb.polish.main import SUPPORTED
                 from calibre.ebooks.oeb.polish.import_book import IMPORTABLE
-                with open('calibre-lrfviewer.desktop', 'wb') as f:
+                with open('com.calibre_ebook.Calibre.calibre_lrfviewer.desktop', 'wb') as f:
                     f.write(VIEWER.encode('utf-8'))
-                with open('calibre-ebook-viewer.desktop', 'wb') as f:
+                with open('com.calibre_ebook.Calibre.calibre_ebook_viewer.desktop', 'wb') as f:
                     f.write(EVIEWER.encode('utf-8'))
                     write_mimetypes(f)
-                with open('calibre-ebook-edit.desktop', 'wb') as f:
+                with open('com.calibre_ebook.Calibre.calibre_ebook_edit.desktop', 'wb') as f:
                     f.write(ETWEAK.encode('utf-8'))
                     mt = {guess_type('a.' + x.lower())[0] for x in (SUPPORTED|IMPORTABLE)} - {None, 'application/octet-stream'}
                     f.write(('MimeType=%s;\n'%';'.join(mt)).encode('utf-8'))
-                with open('calibre-gui.desktop', 'wb') as f:
+                with open('com.calibre_ebook.Calibre.calibre_gui.desktop', 'wb') as f:
                     f.write(GUI.encode('utf-8'))
                     write_mimetypes(f)
-                des = ('calibre-gui.desktop', 'calibre-lrfviewer.desktop',
-                        'calibre-ebook-viewer.desktop', 'calibre-ebook-edit.desktop')
+                des = ('com.calibre_ebook.Calibre.calibre_gui.desktop', 'com.calibre_ebook.Calibre.calibre_lrfviewer.desktop',
+                        'com.calibre_ebook.Calibre.calibre_ebook_viewer.desktop', 'com.calibre_ebook.Calibre.calibre_ebook_edit.desktop')
                 appdata = os.path.join(os.path.dirname(self.opts.staging_sharedir), 'metainfo')
                 if not os.path.exists(appdata):
                     try:

--- a/src/calibre/linux.py
+++ b/src/calibre/linux.py
@@ -865,22 +865,22 @@ class PostInstall:
 
                 from calibre.ebooks.oeb.polish.main import SUPPORTED
                 from calibre.ebooks.oeb.polish.import_book import IMPORTABLE
-                with open('com.calibre_ebook.Calibre.calibre_lrfviewer.desktop', 'wb') as f:
+                with open('com.calibre_ebook.Calibre.lrfviewer.desktop', 'wb') as f:
                     f.write(VIEWER.encode('utf-8'))
-                with open('com.calibre_ebook.Calibre.calibre_ebook_viewer.desktop', 'wb') as f:
+                with open('com.calibre_ebook.Calibre.ebook_viewer.desktop', 'wb') as f:
                     f.write(EVIEWER.encode('utf-8'))
                     write_mimetypes(f)
-                with open('com.calibre_ebook.Calibre.calibre_ebook_edit.desktop', 'wb') as f:
+                with open('com.calibre_ebook.Calibre.ebook_edit.desktop', 'wb') as f:
                     f.write(ETWEAK.encode('utf-8'))
                     mt = {guess_type('a.' + x.lower())[0] for x in (SUPPORTED|IMPORTABLE)} - {None, 'application/octet-stream'}
                     f.write(('MimeType=%s;\n'%';'.join(mt)).encode('utf-8'))
-                with open('com.calibre_ebook.Calibre.calibre_gui.desktop', 'wb') as f:
+                with open('com.calibre_ebook.Calibre.gui.desktop', 'wb') as f:
                     f.write(GUI.encode('utf-8'))
                     write_mimetypes(f)
-                des = ('com.calibre_ebook.Calibre.calibre_gui.desktop',
-                       'com.calibre_ebook.Calibre.calibre_lrfviewer.desktop',
-                       'com.calibre_ebook.Calibre.calibre_ebook_viewer.desktop',
-                       'com.calibre_ebook.Calibre.calibre_ebook_edit.desktop')
+                des = ('com.calibre_ebook.Calibre.gui.desktop',
+                       'com.calibre_ebook.Calibre.lrfviewer.desktop',
+                       'com.calibre_ebook.Calibre.ebook_viewer.desktop',
+                       'com.calibre_ebook.Calibre.ebook_edit.desktop')
                 appdata = os.path.join(os.path.dirname(self.opts.staging_sharedir), 'metainfo')
                 if not os.path.exists(appdata):
                     try:
@@ -1089,7 +1089,7 @@ X-GNOME-UsesNotifications=true
 def get_appdata():
     _ = lambda x: x  # Make sure the text below is not translated, but is marked for translation
     return {
-        'com.calibre_ebook.Calibre.calibre_gui': {
+        'com.calibre_ebook.Calibre.gui': {
             'name':'calibre',
             'summary':_('The one stop solution to all your e-book needs'),
             'description':(
@@ -1103,7 +1103,7 @@ def get_appdata():
             ),
         },
 
-        'com.calibre_ebook.Calibre.calibre_ebook_edit': {
+        'com.calibre_ebook.Calibre.ebook_edit': {
             'name':'calibre - E-book Editor',
             'summary':_('Edit the text and styles inside e-books'),
             'description':(
@@ -1117,7 +1117,7 @@ def get_appdata():
             ),
         },
 
-        'com.calibre_ebook.Calibre.calibre_ebook_viewer': {
+        'com.calibre_ebook.Calibre.ebook_viewer': {
             'name':'calibre - E-book Viewer',
             'summary':_('Read e-books in over a dozen different formats'),
             'description': (


### PR DESCRIPTION
AppStream specification recommends to use reverse-DNS scheme as AppStream ID.

This PR changes AppStream ID and its related file name.

See https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-id-generic for
specificatio detail.