### PR TITLE
Fix Czech local time handling in Denik N recipe

### DIFF
--- a/recipes/denikn.cz.recipe
+++ b/recipes/denikn.cz.recipe
@@ -12,15 +12,31 @@ def cz_title_time():
     """
 
     orig_locale = locale.getlocale(locale.LC_TIME)
+
+    # Try to switch time locale to Czech and return the formatted current date
     try:
         locale.setlocale(locale.LC_TIME, 'cs_CZ')
+        # In Python 2 time.stftime returns czech chars in ISO 8859-2 encoding
+        # e.g. the character Ú is returned as the bytes 'da'
+        # if using the default calibre.strftime function it tries to decode it
+        # with the 'preferred_encoding' which is likely 'utf-8' however that
+        # results in the char u'\ufffd' (�) instead of u'\xda' or u'\u00da'
+        # Passing 'iso-8859-2' to decode fixes this.
+        return strftime('%a, %d %b %Y', enc='iso-8859-2')
     except Exception:
-        return ''
-    try:
-        timestr = strftime('%a, %d %b %Y')
+        # Ignore failure, try to fall back to default locale
+        pass
     finally:
         locale.setlocale(locale.LC_TIME, orig_locale)
-    return timestr
+
+    # We failed to return the czech locale above, falling back to default
+    try:
+        return strftime('%a, %d %b %Y')
+    except Exception:
+        pass
+
+    # Failed again...giving up
+    return ''
 
 
 class DenikNRecipe(BasicNewsRecipe):

--- a/src/calibre/__init__.py
+++ b/src/calibre/__init__.py
@@ -482,7 +482,7 @@ def walk(dir):
             yield os.path.join(record[0], f)
 
 
-def strftime(fmt, t=None):
+def strftime(fmt, t=None, enc=preferred_encoding):
     ''' A version of strftime that returns unicode strings and tries to handle dates
     before 1900 '''
     if not fmt:
@@ -508,7 +508,7 @@ def strftime(fmt, t=None):
     else:
         ans = time.strftime(fmt, t)
         if isinstance(ans, bytes):
-            ans = ans.decode(preferred_encoding, 'replace')
+            ans = ans.decode(enc, 'replace')
     if early_year:
         ans = ans.replace('_early year hack##', unicode_type(orig_year))
     return ans


### PR DESCRIPTION
This is a follow up patch for https://bugs.launchpad.net/calibre/+bug/1853788 
I realized on Tuesday (Úterý) that there is an encoding issue with the title string that is using `calibre.strftime` which tries to decode the `time.strftime` output (python2) with a detected preferred encoding in my case `utf-8`. In the Deník N recipe there is a locale switch to include Czech date in the title string which is not `utf-8` and results in invalid chars (�) in the title string.

So I could just revert back to using `time.strftime().decode('iso-8859-2')` or change `calibre.strftime` to accept a character set for decoding. I chose the latter here, but don't have strong feelings if you prefer to keep the change in the recipe.

Tested on Linux and sent to Kindle, show today's date correctly as "Deník N - Út, 26 lis 2019" instead of the previous "Deník N - �t, 26 lis 2019".

I wanted to add a test case for the `calibre.strftime` function for this and to avoid regression etc., but I am not familiar with the codebase and the testing approach and couldn't find the right place for it. Please advise if you would like to me to add some tests too.
