### PR TITLE
Fix Czech local time handling in Denik N recipe

### DIFF
--- a/recipes/denikn.cz.recipe
+++ b/recipes/denikn.cz.recipe
@@ -2,25 +2,26 @@
 # vim:fileencoding=UTF-8:ts=4:sw=4:sta:et:sts=4:ai
 from __future__ import unicode_literals, division, absolute_import, print_function
 from calibre.web.feeds.news import BasicNewsRecipe
-from calibre import strftime
-import locale
+from datetime import datetime
+
+
+CZ_DAYS = ['Po', 'Út', 'St', 'Čt', 'Pá', 'So', 'Ne']
+CZ_MONTHS = ['led', 'úno', 'bře', 'dub', 'kvě', 'čen', 'čec', 'srp', 'zář', 'říj', 'lis', 'pro']
 
 
 def cz_title_time():
     """
     Helper function to return date with czech locale.
+    Uses hardcoded lookup table of day and month names as strftime requires
+    locale change that is not thread safe.
     """
-
-    orig_locale = locale.getlocale(locale.LC_TIME)
-    try:
-        locale.setlocale(locale.LC_TIME, 'cs_CZ')
-    except Exception:
-        return ''
-    try:
-        timestr = strftime('%a, %d %b %Y')
-    finally:
-        locale.setlocale(locale.LC_TIME, orig_locale)
-    return timestr
+    today = datetime.today()
+    weekday = CZ_DAYS[today.weekday()]
+    month = CZ_MONTHS[today.month-1]
+    return '{weekday}, {day} {month} {year}'.format(weekday=weekday,
+                                                    day=today.day,
+                                                    month=month,
+                                                    year=today.year)
 
 
 class DenikNRecipe(BasicNewsRecipe):


### PR DESCRIPTION
This is a follow up patch for https://bugs.launchpad.net/calibre/+bug/1853788
I realized on Tuesday (Úterý) that there is an encoding issue with the title string that is using calibre.strftime which tries to decode the time.strftime output (python2) with a detected preferred encoding in my case utf-8. In the Deník N recipe there is a locale switch to include Czech date in the title string which is not utf-8 and results in invalid chars (�) in the title string.

This is a fix for the above based on the suggestion in https://github.com/kovidgoyal/calibre/pull/1071

Using strftime requires locale change which is not thread safe.
Keeping it simple and using a hardcoded list of day and month names,
this should work the same way on python 2 and 3 as well.