### PR TITLE
setup: add option to use offline hyphenation dicts

### DIFF
--- a/setup/mathjax.py
+++ b/setup/mathjax.py
@@ -6,73 +6,33 @@ __license__   = 'GPL v3'
 __copyright__ = '2012, Kovid Goyal <kovid at kovidgoyal.net>'
 __docformat__ = 'restructuredtext en'
 
-import os, shutil, json
+import os, json
 from io import BytesIO
-from zipfile import ZipFile
 from hashlib import sha1
-from tempfile import mkdtemp
 
 
-from setup import Command, download_securely
+from setup.revendor import ReVendor
 
 
-class MathJax(Command):
+class MathJax(ReVendor):
 
     description = 'Create the MathJax bundle'
-    MATH_JAX_VERSION = '2.7.6'
-    MATH_JAX_URL = 'https://github.com/mathjax/MathJax/archive/%s.zip' % MATH_JAX_VERSION
+    NAME = 'mathjax'
+    TAR_NAME = 'MathJax'
+    VERSION = '2.7.6'
+    DOWNLOAD_URL = 'https://github.com/mathjax/MathJax/archive/%s.tar.gz' % VERSION
     FONT_FAMILY = 'TeX'
 
-    def add_options(self, parser):
-        parser.add_option('--path-to-mathjax', help='Path to the MathJax source code')
-        parser.add_option('--mathjax-url', default=self.MATH_JAX_URL, help='URL to MathJax source archive in zip format')
-        parser.add_option('--system-mathjax', default=False, action='store_true',
-                help='Treat MathJax as system copy and symlink instead of copy')
-
-    def download_mathjax_release(self, tdir, url):
-        self.info('Downloading MathJax:', url)
-        raw = download_securely(url)
-        with ZipFile(BytesIO(raw)) as zf:
-            zf.extractall(tdir)
-            return os.path.join(tdir, 'MathJax-' + self.MATH_JAX_VERSION)
-
-    def add_file(self, path, name):
-        with open(path, 'rb') as f:
-            raw = f.read()
+    def add_file_pre(self, name, raw):
         self.h.update(raw)
         self.mathjax_files[name] = len(raw)
-        dest = self.j(self.mathjax_dir, *name.split('/'))
-        base = os.path.dirname(dest)
-        if not os.path.exists(base):
-            os.makedirs(base)
-        if self.use_symlinks:
-            os.symlink(path, dest)
-        else:
-            with open(dest, 'wb') as f:
-                f.write(raw)
-
-    def add_tree(self, base, prefix, ignore=lambda n:False):
-        for dirpath, dirnames, filenames in os.walk(base):
-            for fname in filenames:
-                f = os.path.join(dirpath, fname)
-                name = prefix + '/' + os.path.relpath(f, base).replace(os.sep, '/')
-                if not ignore(name):
-                    self.add_file(f, name)
-
-    @property
-    def mathjax_dir(self):
-        return self.j(self.RESOURCES, 'mathjax')
 
     def already_present(self):
-        manifest = self.j(self.mathjax_dir, 'manifest.json')
+        manifest = self.j(self.vendored_dir, 'manifest.json')
         if os.path.exists(manifest):
             with open(manifest, 'rb') as f:
-                return json.load(f).get('version') == self.MATH_JAX_VERSION
+                return json.load(f).get('version') == self.VERSION
         return False
-
-    def clean(self):
-        if os.path.exists(self.mathjax_dir):
-            shutil.rmtree(self.mathjax_dir)
 
     def run(self, opts):
         if not opts.system_mathjax and self.already_present():
@@ -82,10 +42,9 @@ class MathJax(Command):
         self.h = sha1()
         self.mathjax_files = {}
         self.clean()
-        os.mkdir(self.mathjax_dir)
-        tdir = mkdtemp('calibre-mathjax-build')
-        try:
-            src = opts.path_to_mathjax or self.download_mathjax_release(tdir, opts.mathjax_url)
+        os.mkdir(self.vendored_dir)
+        with self.temp_dir(suffix='-calibre-mathjax-build') as tdir:
+            src = opts.path_to_mathjax or self.download_vendor_release(tdir, opts.mathjax_url)
             self.info('Adding MathJax...')
             unpacked = 'unpacked' if self.e(self.j(src, 'unpacked')) else ''
             self.add_file(self.j(src, unpacked, 'MathJax.js'), 'MathJax.js')
@@ -97,6 +56,4 @@ class MathJax(Command):
                 self.add_tree(self.j(src, unpacked, *d.split('/')), d)
             etag = self.h.hexdigest()
             with open(self.j(self.RESOURCES, 'mathjax', 'manifest.json'), 'wb') as f:
-                f.write(json.dumps({'etag': etag, 'files': self.mathjax_files, 'version': self.MATH_JAX_VERSION}, indent=2).encode('utf-8'))
-        finally:
-            shutil.rmtree(tdir)
+                f.write(json.dumps({'etag': etag, 'files': self.mathjax_files, 'version': self.VERSION}, indent=2).encode('utf-8'))

--- a/setup/revendor.py
+++ b/setup/revendor.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python2
+# vim:fileencoding=utf-8
+# License: GPL v3 Copyright: 2019, Eli Schwartz <eschwartz@archlinux.org>
+
+import os, shutil
+from io import BytesIO
+import tarfile
+
+
+from setup import Command, download_securely
+
+
+class ReVendor(Command):
+
+    # NAME = TAR_NAME = VERSION = DOWNLOAD_URL = ''
+
+    def add_options(self, parser):
+        parser.add_option('--path-to-%s' % self.NAME, help='Path to the extracted %s source' % self.TAR_NAME)
+        parser.add_option('--%s-url' % self.NAME, default=self.DOWNLOAD_URL,
+                help='URL to %s source archive in tar.gz format' % self.TAR_NAME)
+        parser.add_option('--system-%s' % self.NAME, default=False, action='store_true',
+                help='Treat %s as system copy and symlink instead of copy' % self.TAR_NAME)
+
+    def download_vendor_release(self, tdir, url):
+        self.info('Downloading %s:' % self.TAR_NAME, url)
+        raw = download_securely(url)
+        with tarfile.open(fileobj=BytesIO(raw)) as tf:
+            tf.extractall(tdir)
+            if len(os.listdir(tdir)) == 1:
+                return self.j(tdir, os.listdir(tdir)[0])
+            else:
+                return tdir
+
+    def add_file_pre(self, name, raw):
+        pass
+
+    def add_file(self, path, name):
+        with open(path, 'rb') as f:
+            raw = f.read()
+        self.add_file_pre(name, raw)
+        dest = self.j(self.vendored_dir, *name.split('/'))
+        base = os.path.dirname(dest)
+        if not os.path.exists(base):
+            os.makedirs(base)
+        if self.use_symlinks:
+            os.symlink(path, dest)
+        else:
+            with open(dest, 'wb') as f:
+                f.write(raw)
+
+    def add_tree(self, base, prefix, ignore=lambda n:False):
+        for dirpath, dirnames, filenames in os.walk(base):
+            for fname in filenames:
+                f = os.path.join(dirpath, fname)
+                name = prefix + '/' + os.path.relpath(f, base).replace(os.sep, '/')
+                if not ignore(name):
+                    self.add_file(f, name)
+
+    @property
+    def vendored_dir(self):
+        return self.j(self.RESOURCES, self.NAME)
+
+    def clean(self):
+        if os.path.exists(self.vendored_dir):
+            shutil.rmtree(self.vendored_dir)


### PR DESCRIPTION
Motivation: I'd like to be able to point the hyphenation dicts at a cached tarball for non-network builds. So I figured I could reuse the mathjax code, and I'd previously attempted to refactor this so I had a bit of handy progress.

I've also taken a stab at making the download code not clean and retry it if it already exists: https://github.com/eli-schwartz/calibre/commit/627955f7d2224059bab192837f64a397fa1b1315
But I'm not sure about this since the similar mathjax code checks the version in the mathjax manifest. I think it would be quite nice to do this somehow, though, because currently every execution of setup.py resources will redownload this tarball. (But with this PR, you can make it use --path-to-hyphenation instead.)

P.S. Why do these need to be stored compressed, and then extracted into the cachedir? Why not just store them directly unpacked, and use them from resources/ ?

P.P.S. Have you considered the possibility of using the ones which distributions install to /usr/share/hyphen/ ?