### PR TITLE
py3: fix creation of empty record with .txt format

### DIFF
--- a/src/calibre/ebooks/oeb/polish/create.py
+++ b/src/calibre/ebooks/oeb/polish/create.py
@@ -42,7 +42,7 @@ def create_book(mi, path, fmt='epub', opf_name='metadata.opf', html_name='start.
     if fmt == 'txt':
         with open(path, 'wb') as f:
             if not mi.is_null('title'):
-                f.write(mi.title)
+                f.write(mi.title.encode('utf-8'))
         return
     if fmt == 'docx':
         from calibre.ebooks.conversion.plumber import Plumber


### PR DESCRIPTION
Metadata objects are unicode strings, but we tried to write the content directly to a .txt file opened in binary mode.