### PR TITLE
Add options to exclude test modules and individual tests from test run

### DIFF
--- a/src/calibre/utils/run_tests.py
+++ b/src/calibre/utils/run_tests.py
@@ -113,6 +113,14 @@ def filter_tests_by_name(suite, *names):
     return filter_tests(suite, q)
 
 
+def remove_tests_by_name(suite, *names):
+    names = {x if x.startswith('test_') else 'test_' + x for x in names}
+
+    def q(test):
+        return test._testMethodName not in names
+    return filter_tests(suite, q)
+
+
 def filter_tests_by_module(suite, *names):
     names = frozenset(names)
 


### PR DESCRIPTION
The Calibre test suite currently allows to specify individual or groups of tests to be executed. What is missing are options to exclude individual or groups of tests from the set of all available tests. This would especially be helpful when packaging Calibre for Linux distributions, e.g., when certain dependencies (like libunrar) can not be made available or some tests are known to be flaky on the build server. It is much easier to maintain a short list of tests to be excluded than a long list of tests to be executed.