### PR TITLE
[metadata]fix amazon japan for referrer

### DIFF
--- a/src/calibre/ebooks/metadata/sources/amazon.py
+++ b/src/calibre/ebooks/metadata/sources/amazon.py
@@ -1010,6 +1010,7 @@ class Amazon(Source):
             'uk':  'https://www.amazon.co.uk/',
             'au':  'https://www.amazon.com.au/',
             'br':  'https://www.amazon.com.br/',
+            'jp':  'https://www.amazon.co.jp/',
         }.get(domain, 'https://www.amazon.%s/' % domain)
 
     def _get_book_url(self, identifiers):  # {{{


### PR DESCRIPTION
try to fix
```
Making google query: https://www.google.com/search?q=%28hidden_isbn+or+hidden_isbn%29+site%3Awww.amazon.jp
Failed to find any results on results page, with title: (hidden_isbn or hidden_isbn) site:www.amazon.jp - Google Search
No search engine results for terms: (hidden_isbn OR hidden_isbn)
```
should be ```site: www.amazon.co.jp```

confirm from my local with `calibre-debug -g`

it seems  site:www.amazon.jp does not work, site:www.amazon.co.jp works fine. 

I assume amazon japan changes their spider policy...etc 