### PR TITLE
Encode internet search URLs with spaces as %20 rather than +

### DIFF
--- a/src/calibre/ebooks/metadata/search_internet.py
+++ b/src/calibre/ebooks/metadata/search_internet.py
@@ -5,7 +5,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from polyglot.builtins import iteritems
-from polyglot.urllib import quote_plus
+from polyglot.urllib import quote
 
 AUTHOR_SEARCHES = {
     'goodreads':
@@ -51,7 +51,7 @@ all_author_searches = AUTHOR_SEARCHES.__iter__
 def qquote(val):
     if not isinstance(val, bytes):
         val = val.encode('utf-8')
-    ans = quote_plus(val)
+    ans = quote(val)
     if isinstance(ans, bytes):
         ans = ans.decode('utf-8')
     return ans


### PR DESCRIPTION
According to [RFC3986](https://tools.ietf.org/html/rfc3986) spaces should be encoded as %20 not +.

In particular, author lookups on goodreads work better with this encoding e.g. lookup of "Trista Ann Michaels" works with https://www.goodreads.com/book/author/Trista%20Ann%20Michaels but not with https://www.goodreads.com/book/author/Trista+Ann+Michaels