### PR TITLE
Fix bug when scrolling up to the previous chapter

### DIFF
--- a/src/pyj/read_book/view.pyj
+++ b/src/pyj/read_book/view.pyj
@@ -1018,7 +1018,6 @@ class View:
             self.iframe_wrapper.init()
 
     def show_spine_item_stage2(self, resource_data):
-        self.currently_showing.loading = False
         # We cannot encrypt this message because the resource data contains
         # Blob objects which do not survive encryption
         self.processing_spine_item_display = True
@@ -1032,6 +1031,7 @@ class View:
 
     def on_content_loaded(self, data):
         self.processing_spine_item_display = False
+        self.currently_showing.loading = False
         self.hide_loading()
         self.set_progress_frac(data.progress_frac, data.file_progress_frac)
         self.update_header_footer()


### PR DESCRIPTION
In flow mode, at the beginning of a chapter X, when scrolling up with a touch screen to go to the chapter X-1, sometimes, we go to the chapter X-2 instead. 

This is because the flag to indicate that a loading is in process is set to false too early. When it is set, the scrolling to the end of the chapter X-1 is not yet done. When the next touch move event happen (the finger is still moving on the screen), the _check_for_scroll_end will then detect that we are at the beginning of the chapter X-1 and requests another change of chapter. Because the loading flag was already set to false, this change of chapter is accepted and we are at the chapter X-2.

The code is quite dense and I do not have experience on it. I hope the fix is appropriate.