### PR TITLE
Fix series sort after using clear_series

### DIFF
--- a/src/calibre/gui2/dialogs/metadata_bulk.py
+++ b/src/calibre/gui2/dialogs/metadata_bulk.py
@@ -369,6 +369,7 @@ class MyBlockingBusy(QDialog):  # {{{
         if args.clear_series:
             self.progress_next_step_range.emit(0)
             cache.set_field('series', {bid: '' for bid in self.ids})
+            cache.set_field('series_index', {bid:1.0 for bid in self.ids})
             self.progress_finished_cur_step.emit()
 
         if args.pubdate is not None:


### PR DESCRIPTION
If you have books with series and series_index > 1, and use bulk metadata to clear_series, then sort by series puts these at the bottom of the list because the series_index has not been reset to 1.