### PR TITLE
Fix touch lag when changing chapter in flow mode

### DIFF
--- a/resources/content-server/reset.css
+++ b/resources/content-server/reset.css
@@ -34,6 +34,7 @@ time, mark, audio, video {
 
 body {
     line-height:1.2;
+    touch-action:none;
 }
 
 article,aside,details,figcaption,figure,

--- a/src/pyj/read_book/iframe.pyj
+++ b/src/pyj/read_book/iframe.pyj
@@ -44,7 +44,8 @@ from read_book.shortcuts import (
     create_shortcut_map, keyevent_as_shortcut, shortcut_for_key_event
 )
 from read_book.toc import update_visible_toc_anchors
-from read_book.touch import create_handlers as create_touch_handlers
+from read_book.touch import (create_handlers as create_touch_handlers,
+                             reset_handlers as reset_touch_handlers)
 from read_book.viewport import scroll_viewport
 from utils import (
     apply_cloned_selection, clone_selection, debounce, html_escape, is_ios
@@ -334,6 +335,8 @@ class IframeBoss:
         self.send_message('content_loaded', progress_frac=self.calculate_progress_frac(), file_progress_frac=progress_frac())
         self.last_cfi = None
         self.auto_scroll_action('resume')
+        reset_touch_handlers() # Needed to mitigate issue https://bugs.chromium.org/p/chromium/issues/detail?id=464579
+
         window.setTimeout(self.update_cfi, 0)
         window.setTimeout(self.update_toc_position, 0)
 

--- a/src/pyj/read_book/touch.pyj
+++ b/src/pyj/read_book/touch.pyj
@@ -140,6 +140,12 @@ class TouchHandler:
                 return True
         return False
 
+    def reset_handlers(self):
+        self.stop_hold_timer()
+        self.ongoing_touches = {}
+        self.gesture_id = None
+        self.handled_tap_hold = False
+
     def start_hold_timer(self):
         self.stop_hold_timer()
         self.hold_timer = window.setTimeout(self.check_for_hold, 100)
@@ -199,9 +205,7 @@ class TouchHandler:
         self.prune_expired_touches()
         if not self.has_active_touches:
             self.dispatch_gesture()
-            self.ongoing_touches = {}
-            self.gesture_id = None
-            self.handled_tap_hold = False
+            self.reset_handlers()
 
     def handle_touchcancel(self, ev):
         ev.preventDefault(), ev.stopPropagation()
@@ -278,6 +282,9 @@ def create_handlers():
     # Safari does not work if we register the handler
     # on window instead of document
     install_handlers(document, main_touch_handler)
+
+def reset_handlers():
+    main_touch_handler.reset_handlers()
 
 def set_left_margin_handler(elem):
     install_handlers(elem, left_margin_handler)


### PR DESCRIPTION
Hi,

With this branch I fix the lag when scrolling with a touch screen in flow mode at the beginning of a chapter:

-  After changing of chapter by scrolling, the following start events are not cancelable and trigger the error "**Ignored attempt to cancel a touchstart event with cancelable=false, for example because scrolling is in progress and cannot be interrupted.**". I guess there is a bug in Chromium with the scrollTo fonction called just before the touch. It somehow creates lags. To fix it, the only solution I found is to add the **touch-action:none** to the style of the body. It does not seem to break any touch interaction in the viewer. 
- I also found that the touch end event is not triggered when changing of chapter. This is probably the bug [https://bugs.chromium.org/p/chromium/issues/detail?id=464579](https://bugs.chromium.org/p/chromium/issues/detail?id=464579). This is exacerbating the previous issue (seem to generate more not cancelable event). Another consequence is that the timer loop to detect the hold gesture is then never stop (up to the next touch event). I add a function to reset it from the iframe.js. I am not a big fan of that change but did not found a more elegant fix. And I prefer to address it instead of waiting for a fix in Chromium which is not coming since 5 years.

Simon



