### PR TITLE
Fix string encoding

### DIFF
--- a/src/calibre/devices/smart_device_app/driver.py
+++ b/src/calibre/devices/smart_device_app/driver.py
@@ -636,7 +636,7 @@ class SMART_DEVICE_APP(DeviceConfig, DevicePlugin):
             s = self._json_encode(self.opcodes[op], arg)
             if print_debug_info and extra_debug:
                 self._debug('send string', s)
-            self._send_byte_string(self.device_socket, (b'%d' % len(s)) + s)
+            self._send_byte_string(self.device_socket, (b'%d' % len(s)) + s.encode())
             if not wait_for_response:
                 return None, None
             return self._receive_from_client(print_debug_info=print_debug_info)


### PR DESCRIPTION
Should be a byte string, rather than a character string. Fixes error when connecting from Calibre Companion.