### PR TITLE
douban.py: download hi-res cover

### DIFF
--- a/src/calibre/ebooks/metadata/sources/douban.py
+++ b/src/calibre/ebooks/metadata/sources/douban.py
@@ -48,8 +48,8 @@ def get_details(browser, url, timeout):  # {{{
 class Douban(Source):
 
     name = 'Douban Books'
-    author = 'Li Fanxi, xcffl'
-    version = (3, 0, 0)
+    author = 'Li Fanxi, xcffl, jnozsc'
+    version = (3, 1, 0)
     minimum_calibre_version = (2, 80, 0)
 
     description = _(
@@ -90,7 +90,7 @@ class Douban(Source):
         authors = entry_.get('author')
         book_tags = entry_.get('tags')
         rating = entry_.get('rating')
-        cover_url = entry_.get('image')
+        cover_url = entry_.get('images', {}).get('large')
         series = entry_.get('series')
 
         if not authors:


### PR DESCRIPTION
the API response is
```
{
   "rating":{
      "max":10,
      "numRaters":6223,
      "average":"9.4",
      "min":0
   },
   "subtitle":"",
   "author":[
      "George Orwell"
   ],
   "pubdate":"1961-1-1",
   "tags":[
      {
         "count":1426,
         "name":"乔治·奥威尔",
         "title":"乔治·奥威尔"
      },
      {
         "count":1229,
         "name":"反乌托邦",
         "title":"反乌托邦"
      },
      {
         "count":837,
         "name":"1984",
         "title":"1984"
      },
      {
         "count":778,
         "name":"小说",
         "title":"小说"
      },
      {
         "count":767,
         "name":"政治",
         "title":"政治"
      },
      {
         "count":524,
         "name":"极权",
         "title":"极权"
      },
      {
         "count":441,
         "name":"外国文学",
         "title":"外国文学"
      },
      {
         "count":412,
         "name":"社会",
         "title":"社会"
      }
   ],
   "origin_title":"",
   "image":"https://img9.doubanio.com\/view\/subject\/m\/public\/s1435696.jpg",
   "binding":"Mass Market Paperback",
   "translator":[

   ],
   "catalog":"",
   "pages":"268",
   "images":{
      "small":"https://img9.doubanio.com\/view\/subject\/s\/public\/s1435696.jpg",
      "large":"https://img9.doubanio.com\/view\/subject\/l\/public\/s1435696.jpg",
      "medium":"https://img9.doubanio.com\/view\/subject\/m\/public\/s1435696.jpg"
   },
   "alt":"https:\/\/book.douban.com\/subject\/1424314\/",
   "id":"1424314",
   "publisher":"New American Library",
   "isbn10":"0451524934",
   "isbn13":"9780451524935",
   "title":"1984",
   "url":"https:\/\/api.douban.com\/v2\/book\/1424314",
   "alt_title":"一九八四",
   "author_intro":"",
   "summary":"The year 1984 has come and gone, but George Orwell's prophetic, nightmarish vision in 1949 of the world we were becoming is timelier than ever. 1984 ...more [close] The year 1984 has come and gone, but George Orwell's prophetic, nightmarish vision in 1949 of the world we were becoming is timelier than ever. 1984 is still the great modern classic of \"negative utopia\"--a startlingly original and haunting novel that creates an imaginary world that is completely convincing, from the first sentence to the last four words. No one can deny the novel's hold on the imaginations of the whole generations, or the power of its admonitions--a power that seem to grow, not lessen, with the passage of time.",
   "series":{
      "id":"31445",
      "title":"Signet  Classics"
   },
   "price":"USD 9.99"
}
```

the `data['image']` is medium size image, which is the same as `data['images']['medium']`

in this PR, I change the download_url to `data['images']['large']`
