### PR TITLE
Change domain to www.jornada.com.mx

### DIFF
--- a/recipes/la_jornada.recipe
+++ b/recipes/la_jornada.recipe
@@ -1,7 +1,7 @@
 __license__ = 'GPL v3'
 __copyright__ = '2010-2012, Darko Miletic <darko.miletic at gmail.com>, Rogelio Domínguez <rogelio.dominguez@gmail.com>'
 '''
-www.jornada.unam.mx
+www.jornada.com.mx
 '''
 
 import re
@@ -29,7 +29,7 @@ class LaJornada_mx(BasicNewsRecipe):
     use_embedded_content = False
     language = 'es_MX'
     remove_empty_feeds = True
-    masthead_url = 'http://www.jornada.unam.mx/v7.0/imagenes/la-jornada-trans.png'
+    masthead_url = 'http://www.jornada.com.mx/v7.0/imagenes/la-jornada-trans.png'
     publication_type = 'newspaper'
     extra_css             = """
                                 body{font-family: "Times New Roman",serif }
@@ -69,20 +69,20 @@ class LaJornada_mx(BasicNewsRecipe):
 
     feeds = [
 
-    (u'Opinion', u'http://www.jornada.unam.mx/rss/opinion.xml'),
-    (u'Cartones', u'http://www.jornada.unam.mx/rss/cartones.xml'),
-    (u'Politica', u'http://www.jornada.unam.mx/rss/politica.xml'),
-    (u'Economia', u'http://www.jornada.unam.mx/rss/economia.xml'),
-    (u'Mundo', u'http://www.jornada.unam.mx/rss/mundo.xml'),
-    (u'Estados', u'http://www.jornada.unam.mx/rss/estados.xml'),
-    (u'Capital', u'http://www.jornada.unam.mx/rss/capital.xml'),
-    (u'Sociedad y justicia', u'http://www.jornada.unam.mx/rss/sociedad.xml'),
-    (u'Ciencias', u'http://www.jornada.unam.mx/rss/ciencias.xml'),
-    (u'Cultura', u'http://www.jornada.unam.mx/rss/cultura.xml'),
-    (u'Gastronomia', u'http://www.jornada.unam.mx/rss/gastronomia.xml'),
-    (u'Espectaculos', u'http://www.jornada.unam.mx/rss/espectaculos.xml'),
-    (u'Deportes', u'http://www.jornada.unam.mx/rss/deportes.xml'),
-    (u'Ultimas noticias', u'http://www.jornada.unam.mx/ultimas/news/RSS')
+    (u'Opinion', u'http://www.jornada.com.mx/rss/opinion.xml'),
+    (u'Cartones', u'http://www.jornada.com.mx/rss/cartones.xml'),
+    (u'Politica', u'http://www.jornada.com.mx/rss/politica.xml'),
+    (u'Economia', u'http://www.jornada.com.mx/rss/economia.xml'),
+    (u'Mundo', u'http://www.jornada.com.mx/rss/mundo.xml'),
+    (u'Estados', u'http://www.jornada.com.mx/rss/estados.xml'),
+    (u'Capital', u'http://www.jornada.com.mx/rss/capital.xml'),
+    (u'Sociedad y justicia', u'http://www.jornada.com.mx/rss/sociedad.xml'),
+    (u'Ciencias', u'http://www.jornada.com.mx/rss/ciencias.xml'),
+    (u'Cultura', u'http://www.jornada.com.mx/rss/cultura.xml'),
+    (u'Gastronomia', u'http://www.jornada.com.mx/rss/gastronomia.xml'),
+    (u'Espectaculos', u'http://www.jornada.com.mx/rss/espectaculos.xml'),
+    (u'Deportes', u'http://www.jornada.com.mx/rss/deportes.xml'),
+    (u'Ultimas noticias', u'http://www.jornada.com.mx/ultimas/news/RSS')
     ]
 
     def preprocess_html(self, soup):


### PR DESCRIPTION
Old domain (www.jornada.unam.mx) has started to trigger HTTPS errors, so switch completely to the new domain