### PR TITLE
viewer: handle recently opened list when started without a book

### DIFF
--- a/src/calibre/gui2/viewer/toolbars.py
+++ b/src/calibre/gui2/viewer/toolbars.py
@@ -250,7 +250,7 @@ class ActionsToolBar(ToolBar):
                     path = os.path.abspath(entry['pathtoebook'])
                 except Exception:
                     continue
-                if path == os.path.abspath(set_book_path.pathtoebook):
+                if hasattr(set_book_path, 'pathtoebook') and path == os.path.abspath(set_book_path.pathtoebook):
                     continue
                 m.addAction('{}\t {}'.format(
                     elided_text(entry['title'], pos='right', width=250),


### PR DESCRIPTION
When starting ebook-viewer standalone without a book, set_book_path has never been called and there is no pathtoebook attribute yet. In this case, we certainly don't need to compare it to the current book.