### PR TITLE
Fix bug #1869515: right-clicking in empty space in Quickview raises …

### DIFF
--- a/src/calibre/gui2/dialogs/quickview.py
+++ b/src/calibre/gui2/dialogs/quickview.py
@@ -273,6 +273,8 @@ class Quickview(QDialog, Ui_Quickview):
     def show_context_menu(self, point):
         index = self.books_table.indexAt(point)
         item = self.books_table.item(index.row(), 0)
+        if item is None:
+            return False;
         book_id = int(item.data(Qt.UserRole))
         self.context_menu = QMenu(self)
         self.context_menu.addAction(self.view_icon, _('View'),


### PR DESCRIPTION
…an exception.