### PR TITLE
mit_technology_review: add keep_only_tags and remove_tags

### DIFF
--- a/recipes/mit_technology_review.recipe
+++ b/recipes/mit_technology_review.recipe
@@ -39,10 +39,11 @@ class MitTechnologyReview(BasicNewsRecipe):
 
     keep_only_tags = [
         classes(
-            'article-topper__topic article-topper__title article-topper__media-wrap article-body__content'),
+            'article-topper__topic article-topper__title article-topper__media-wrap article-body__content storyContent'),
     ]
     remove_tags = [
-        classes('l-article-list'),
+        classes('l-article-list signup-wrapper'),
+        dict(name="svg")
     ]
 
     def parse_index(self):


### PR DESCRIPTION
this is re this bug [report](https://bugs.launchpad.net/calibre/+bug/1869553)

adding storyContent class because it is the upper div of most p tags in the articles. 
Only the headline article does not wrap the p tags under storyContent class. that's why the previous recipe only downloads the headline article and all the rest failed to download
