### PR TITLE
Fix python 3 compatibility: template formatter: when no key is used in a template an …

### DIFF
--- a/src/calibre/ebooks/metadata/book/formatter.py
+++ b/src/calibre/ebooks/metadata/book/formatter.py
@@ -16,7 +16,7 @@ class SafeFormat(TemplateFormatter):
         TemplateFormatter.__init__(self)
 
     def get_value(self, orig_key, args, kwargs):
-        if not orig_key:
+        if not orig_key or isinstance(orig_key, int):
             return ''
         key = orig_key = orig_key.lower()
         if (key != 'title_sort' and key not in TOP_LEVEL_IDENTIFIERS and


### PR DESCRIPTION
…integer is passed instead of an empty string. This caused a failure if the keyless template was not the first. Example that failed: "{:'formats_sizes()'} {:'booksize()'}"