### PR TITLE
Fix for bug #1873106: when bools are not tristate, undefined values …

### DIFF
--- a/src/calibre/gui2/custom_column_widgets.py
+++ b/src/calibre/gui2/custom_column_widgets.py
@@ -164,12 +164,13 @@ class Bool(Base):
         l.addWidget(c)
         c.clicked.connect(self.set_to_no)
 
-        t = _('Clear')
-        c = QPushButton(t, parent)
-        width = c.fontMetrics().boundingRect(t).width() + 7
-        c.setMaximumWidth(width)
-        l.addWidget(c)
-        c.clicked.connect(self.set_to_cleared)
+        if self.db.prefs.get('bools_are_tristate'):
+            t = _('Clear')
+            c = QPushButton(t, parent)
+            width = c.fontMetrics().boundingRect(t).width() + 7
+            c.setMaximumWidth(width)
+            l.addWidget(c)
+            c.clicked.connect(self.set_to_cleared)
 
         c = QLabel('', parent)
         c.setMaximumWidth(1)

--- a/src/calibre/gui2/preferences/coloring.py
+++ b/src/calibre/gui2/preferences/coloring.py
@@ -38,6 +38,10 @@ icon_rule_kinds = [(_('icon with text'), 'icon'),
 class ConditionEditor(QWidget):  # {{{
 
     ACTION_MAP = {
+            'bool2' : (
+                    (_('is true'), 'is true',),
+                    (_('is false'), 'is false'),
+            ),
             'bool' : (
                     (_('is true'), 'is true',),
                     (_('is false'), 'is false'),
@@ -200,6 +204,10 @@ class ConditionEditor(QWidget):  # {{{
         if col:
             m = self.fm[col]
             dt = m['datatype']
+            if dt == 'bool':
+                from calibre.gui2.ui import get_gui
+                if not get_gui().current_db.prefs.get('bools_are_tristate'):
+                        dt = 'bool2'
             if dt in self.action_map:
                 actions = self.action_map[dt]
             else:

--- a/src/calibre/library/coloring.py
+++ b/src/calibre/library/coloring.py
@@ -112,10 +112,16 @@ class Rule(object):  # {{{
             return "test(ondevice(), '', '1')"
 
     def bool_condition(self, col, action, val):
-        test = {'is true': 'True',
-                'is false': 'False',
-                'is undefined': 'None'}[action]
-        return "strcmp('%s', raw_field('%s'), '', '1', '')"%(test, col)
+        from calibre.gui2.ui import get_gui
+        if get_gui().current_db.prefs.get('bools_are_tristate'):
+            test = {'is true': 'True',
+                    'is false': 'False',
+                    'is undefined': 'None'}[action]
+            return "strcmp('%s', raw_field('%s'), '', '1', '')"%(test, col)
+        else:
+            if action == 'is true':
+                return "strcmp('True', raw_field('%s'), '', '1', '')"%(col)
+            return "strcmp('True', raw_field('%s'), '1', '', '1')"%(col)
 
     def number_condition(self, col, action, val):
         lt, eq, gt = {


### PR DESCRIPTION
…don't show emblems/icons as if the value is false. This fix requires the user to edit and save the rule.