### PR TITLE
py3: correctly print results from fetch-ebook-metadata

### DIFF
--- a/src/calibre/ebooks/metadata/sources/cli.py
+++ b/src/calibre/ebooks/metadata/sources/cli.py
@@ -81,7 +81,7 @@ def main(args=sys.argv):
             allowed_plugins=allowed_plugins or None)
 
     if not results:
-        print(log, file=sys.stderr)
+        prints(log, file=sys.stderr)
         prints('No results found', file=sys.stderr)
         raise SystemExit(1)
     result = results[0]
@@ -102,9 +102,9 @@ def main(args=sys.argv):
                     unicode_type(result).encode('utf-8'))
 
     if opts.verbose:
-        print(log, file=sys.stderr)
+        prints(log, file=sys.stderr)
 
-    print(result)
+    prints(result)
     if not opts.opf and opts.cover:
         prints('Cover               :', cf)
 


### PR DESCRIPTION
Identify results are always bytes, as is an opf, as are the log contents (literally a BytesIO buffer).

Therefore decode them when printing to the console by using the prints() function which correctly handles this, and which we already used for some of the logging here.