### PR TITLE
Bypass decoding errors during html detection

### DIFF
--- a/src/calibre/ebooks/html/input.py
+++ b/src/calibre/ebooks/html/input.py
@@ -115,7 +115,7 @@ class HTMLFile(object):
                 encoding = detect_xml_encoding(src)[1]
                 if encoding:
                     try:
-                        header = header.decode(encoding)
+                        header = header.decode(encoding, errors='ignore')
                     except ValueError:
                         pass
                 self.is_binary = level > 0 and not bool(self.HTML_PAT.search(header))


### PR DESCRIPTION
Decoding may fail on the header chunk if the file is utf-8 encoded and the chunk ends on a continuation byte.

Not sure if this is the best solution, but it worked for me when I encountered the issue today.
Without it calibre fails with:
```
  File "/usr/lib64/calibre/calibre/ebooks/html/input.py", line 120, in __init__
    self.is_binary = level > 0 and not bool(self.HTML_PAT.search(header))
TypeError: cannot use a string pattern on a bytes-like object
```

for utf-8 encoded input, for which the 4096th byte happens to be a continuation byte (part of a German Umlaut in my case).