### PR TITLE
Fix test_workers timeout response check with Python 3.5+

### DIFF
--- a/src/calibre/srv/tests/loop.py
+++ b/src/calibre/srv/tests/loop.py
@@ -93,7 +93,7 @@ class LoopTest(BaseTest):
             conn.request('GET', '/')
             with self.assertRaises(socket.timeout):
                 res = conn.getresponse()
-                if unicode_type(res.status) == unicode_type(http_client.REQUEST_TIMEOUT):
+                if int(res.status) == int(http_client.REQUEST_TIMEOUT):
                     raise socket.timeout('Timeout')
                 raise Exception('Got unexpected response: code: %s %s headers: %r data: %r' % (
                     res.status, res.reason, res.getheaders(), res.read()))


### PR DESCRIPTION
This check broke with Python 3.5, because REQUEST_TIMEOUT changed
from being simply an integer constant to being an instance of the
new HTTPStatus enum:
https://docs.python.org/3/library/http.html#http.HTTPStatus
on Python 3.5+, `str(http.client.REQUEST_TIMEOUT)` gives
`"HTTPStatus.REQUEST_TIMEOUT"`, not `"408"`.

Simply comparing as `int` not `unicode_type` should work with all
Pythons (2, 3 before 3.5, and 3.5+). `int(REQUEST_TIMEOUT)` gives
you `408` in all cases.

This may not have been noticed till now because this check seems
to be a kind of safety valve: it seems that usually, the
`res = conn.getresponse()` call should raise `socket.timeout`
itself, and this is some sort of backstop in case it doesn't. I
caught this in Fedora Rawhide package builds: it seems that on
most arches, we don't hit the bug because `conn.getresponse()`
raises `socket.timeout` directly, but on 32-bit ARM for some
reason we almost always hit this backstop, and that was causing
the test to fail because of this problem.

Signed-off-by: Adam Williamson <awilliam@redhat.com>