### PR TITLE
Enhancement #1884343: Add action to show a tag in the Tag browser …

### DIFF
--- a/src/calibre/ebooks/metadata/book/render.py
+++ b/src/calibre/ebooks/metadata/book/render.py
@@ -242,7 +242,7 @@ def mi_to_html(
             if not mi.languages:
                 continue
             names = filter(None, map(calibre_langcode_to_name, mi.languages))
-            names = ['<a href="%s" title="%s">%s</a>' % (search_action('languages', n), _(
+            names = ['<a href="%s" title="%s">%s</a>' % (search_action_with_data('languages', n, book_id), _(
                 'Search calibre for books with the language: {}').format(n), n) for n in names]
             ans.append((field, row % (name, u', '.join(names))))
         elif field == 'publisher':

--- a/src/calibre/gui2/init.py
+++ b/src/calibre/gui2/init.py
@@ -677,6 +677,7 @@ class LayoutMixin(object):  # {{{
         self.book_details.view_device_book.connect(
                 self.iactions['View'].view_device_book)
         self.book_details.manage_category.connect(self.manage_category_triggerred)
+        self.book_details.find_in_tag_browser.connect(self.find_in_tag_browser_triggered)
         self.book_details.edit_identifiers.connect(self.edit_identifiers_triggerred)
         self.book_details.compare_specific_format.connect(self.compare_format)
 
@@ -705,6 +706,13 @@ class LayoutMixin(object):  # {{{
                                          select_link=False, lookup_author=True)
             elif field:
                 self.do_tags_list_edit(value, field)
+
+    def find_in_tag_browser_triggered(self, field, value):
+        if field and value:
+            tb = self.stack.tb_widget
+            tb.set_focus_to_find_box()
+            tb.item_search.lineEdit().setText(field + ':=' + value)
+            tb.do_find()
 
     def toggle_grid_view(self, show):
         self.library_view.alternate_views.show_view('grid' if show else None)


### PR DESCRIPTION
…when right clicking on a tag in the Book details panel.

Works for is_multiple editable fields (not composites). Also made it possible to remove languages from the book details context menu.