### PR TITLE
build: detect mathjax directory with or without es5/ subdir

### DIFF
--- a/setup/mathjax.py
+++ b/setup/mathjax.py
@@ -43,11 +43,13 @@ class MathJax(ReVendor):
         os.mkdir(self.vendored_dir)
         with self.temp_dir(suffix='-calibre-mathjax-build') as tdir:
             src = opts.path_to_mathjax or self.download_vendor_release(tdir, opts.mathjax_url)
+            if os.path.isdir(os.path.join(src, 'es5')):
+                src = os.path.join(src, 'es5')
             self.info('Adding MathJax...')
             for x in 'core loader startup input/tex-full input/asciimath input/mml input/mml/entities output/chtml'.split():
-                self.add_file(self.j(src, 'es5', x + '.js'), x + '.js')
+                self.add_file(self.j(src, x + '.js'), x + '.js')
             self.add_tree(
-                self.j(src, 'es5', 'output', 'chtml'), 'output/chtml')
+                self.j(src, 'output', 'chtml'), 'output/chtml')
             etag = self.h.hexdigest()
             with open(self.j(self.RESOURCES, 'mathjax', 'manifest.json'), 'wb') as f:
                 f.write(json.dumps({'etag': etag, 'files': self.mathjax_files, 'version': self.VERSION}, indent=2).encode('utf-8'))


### PR DESCRIPTION
The release tarballs contain an es5/ directory with the actual mathjax code. However, when building against a system mathjax it is likely the es5/ directory is skipped and the directory name is just /usr/share/mathjax/

Detect this by moving the es5/ component to the definition of the mathjax source root, but only appending it if the --path-to-mathjax actually contains such a directory.