### PR TITLE
plistlib.Data is going to be dropped in python 3.9

### DIFF
--- a/src/calibre/utils/config.py
+++ b/src/calibre/utils/config.py
@@ -363,29 +363,26 @@ class XMLConfig(dict):
         self.update(d)
 
     def __getitem__(self, key):
-        from polyglot.plistlib import Data
         try:
             ans = dict.__getitem__(self, key)
-            if isinstance(ans, Data):
+            if isinstance(ans, bytes):
                 ans = ans.data
             return ans
         except KeyError:
             return self.defaults.get(key, None)
 
     def get(self, key, default=None):
-        from polyglot.plistlib import Data
         try:
             ans = dict.__getitem__(self, key)
-            if isinstance(ans, Data):
+            if isinstance(ans, bytes):
                 ans = ans.data
             return ans
         except KeyError:
             return self.defaults.get(key, default)
 
     def __setitem__(self, key, val):
-        from polyglot.plistlib import Data
         if isinstance(val, bytes):
-            val = Data(val)
+            val = bytes(val)
         dict.__setitem__(self, key, val)
         self.commit()
 

--- a/src/polyglot/plistlib.py
+++ b/src/polyglot/plistlib.py
@@ -7,6 +7,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from polyglot.builtins import is_py3
 
 if is_py3:
-    from plistlib import loads, dumps, Data  # noqa
+    from plistlib import loads, dumps  # noqa
 else:
-    from plistlib import readPlistFromString as loads, writePlistToString as dumps, Data  # noqa
+    from plistlib import readPlistFromString as loads, writePlistToString as dumps  # noqa


### PR DESCRIPTION
Here is a rough cut at removing any plistlib.Data imports and switching
to just using bytes for the objects. No idea how close to correct it is,
but without this calibre using python 3.9 doesn't finish it's startup,
and with it it seems to run fine.

Signed-off-by: Kevin Fenzi <kevin@scrye.com>