### PR TITLE
remove '!' from filename for kobo

### DIFF
--- a/src/calibre/srv/content.py
+++ b/src/calibre/srv/content.py
@@ -229,7 +229,6 @@ def static(ctx, rd, what):
     except EnvironmentError:
         raise HTTPNotFound()
 
-kepub
 @endpoint('/favicon.png', auth_required=False, cache_control=24)
 def favicon(ctx, rd):
     return share_open(I('lt.png'), 'rb')

--- a/src/calibre/srv/content.py
+++ b/src/calibre/srv/content.py
@@ -160,8 +160,6 @@ def book_filename(rd, book_id, mi, fmt, as_encoded_unicode=False):
     au = authors_to_string(mi.authors or [_('Unknown')])
     title = mi.title or _('Unknown')
     ext = (fmt or '').lower()
-    if ext == 'kepub' and 'Kobo Touch' in rd.inheaders.get('User-Agent', ''):
-        ext = 'kepub.epub'
     fname = '%s - %s_%s.%s' % (title[:30], au[:30], book_id, ext)
     if as_encoded_unicode:
         # See https://tools.ietf.org/html/rfc6266
@@ -169,6 +167,9 @@ def book_filename(rd, book_id, mi, fmt, as_encoded_unicode=False):
         fname = unicode_type(quote(fname))
     else:
         fname = ascii_filename(fname).replace('"', '_')
+    if ext == 'kepub' and 'Kobo Touch' in rd.inheaders.get('User-Agent', ''):
+        fname = fname.replace('!', '')
+        fname += '.epub'
     return fname
 
 
@@ -228,7 +229,7 @@ def static(ctx, rd, what):
     except EnvironmentError:
         raise HTTPNotFound()
 
-
+kepub
 @endpoint('/favicon.png', auth_required=False, cache_control=24)
 def favicon(ctx, rd):
     return share_open(I('lt.png'), 'rb')


### PR DESCRIPTION
remove the '!' character from file name for downloading a kepub file from kobo browser
since kepub file with a '!' in name doesn't work on a kobo device(at least on my kobo forma)