### PR TITLE
Preserve cover aspect ratio in the download preview

### DIFF
--- a/src/calibre/gui2/metadata/single_download.py
+++ b/src/calibre/gui2/metadata/single_download.py
@@ -653,7 +653,7 @@ class CoversModel(QAbstractListModel):  # {{{
         text = (src + '\n' + sz)
         scaled = pmap.scaled(
             int(CoverDelegate.ICON_SIZE[0] * pmap.devicePixelRatio()), int(CoverDelegate.ICON_SIZE[1] * pmap.devicePixelRatio()),
-            Qt.IgnoreAspectRatio, Qt.SmoothTransformation)
+            Qt.KeepAspectRatio, Qt.SmoothTransformation)
         scaled.setDevicePixelRatio(pmap.devicePixelRatio())
         return (text, (scaled), pmap, waiting)
 


### PR DESCRIPTION
When using the Download Cover feature, the thumbnail view of the downloaded covers would show covers stretched into a fixed aspect ratio. Images that are not in that standard aspect ratio are distorted, potentially making it more difficult to select one that looks good. This pull request changes it to preserve the aspect ratio of the downloaded image so that it appears as intended, accurate to how it will appear in the cover grid.

## Before
![image](https://user-images.githubusercontent.com/755453/90320452-367abd00-df07-11ea-9f53-1610ebc2423a.png)

## After
![image](https://user-images.githubusercontent.com/755453/90320503-8b1e3800-df07-11ea-9909-0b34ec3742e8.png)
