### PR TITLE
Fix (I think) for exception:

### DIFF
--- a/src/calibre/utils/mdns.py
+++ b/src/calibre/utils/mdns.py
@@ -148,7 +148,7 @@ def create_service(desc, service_type, port, properties, add_hostname, use_ip_ad
 
     return ServiceInfo(
         service_type, service_name,
-        address=socket.inet_aton(local_ip),
+        addresses=[socket.inet_aton(local_ip),],
         port=port,
         properties=properties,
         server=server_name)


### PR DESCRIPTION
SMART_DEV (   0.24:  0.015) _startup_on_demand registration with bonjour failed
Traceback (most recent call last):
  File "C:\CBH_Data\calibre.git\calibre_dev\src\calibre\devices\smart_device_app\driver.py", line 1957, in _startup_on_demand
  File "C:\CBH_Data\calibre.git\calibre_dev\src\calibre\utils\mdns.py", line 168, in publish
  File "C:\CBH_Data\calibre.git\calibre_dev\src\calibre\utils\mdns.py", line 149, in create_service
TypeError: __init__() got an unexpected keyword argument 'address'