### PR TITLE
fetch the economist cover from archive page

### DIFF
--- a/recipes/economist.recipe
+++ b/recipes/economist.recipe
@@ -249,7 +249,8 @@ class Economist(BasicNewsRecipe):
         return ans
 
     def economist_parse_index(self, soup):
-        div = soup.find(attrs={'class': 'weekly-edition-header__image'})
+        archive = self.index_to_soup("https://www.economist.com/weeklyedition/archive")
+        div = archive.find(attrs={'class': 'edition-teaser__image'})
         if div is not None:
             img = div.find('img', srcset=True)
             self.cover_url = img['srcset'].split(',')[-1].split()[0]


### PR DESCRIPTION
The [current edition page](https://www.economist.com/weeklyedition) doesn't contain the cover anymore. I change it to download from [the archive page](https://www.economist.com/weeklyedition/archive).