### PR TITLE
py3: add missing try/except in metadata sources (ozon.ru)

### DIFF
--- a/src/calibre/ebooks/metadata/sources/ozon.py
+++ b/src/calibre/ebooks/metadata/sources/ozon.py
@@ -71,7 +71,10 @@ class Ozon(Source):
     # }}}
 
     def create_query(self, log, title=None, authors=None, identifiers={}):  # {{{
-        from urllib import quote_plus
+        try:
+            from urllib.parse import quote_plus
+        except:
+            from urllib import quote_plus
 
         # div_book -> search only books, ebooks and audio books
         search_url = self.ozon_url + '/?context=search&group=div_book&text='
@@ -119,9 +122,12 @@ class Ozon(Source):
     def identify(self, log, result_queue, abort, title=None, authors=None,
                  identifiers={}, timeout=90):  # {{{
         from calibre.ebooks.chardet import xml_to_unicode
-        from HTMLParser import HTMLParser
         from lxml import etree, html
         import json
+        try:
+            from html.parser import HTMLParser
+        except:
+            from HTMLParser import HTMLParser
 
         if not self.is_configured():
             return


### PR DESCRIPTION
urllib.quote_plus was missed in this file during commit e0205790b943227ad86a00ca975f078b624b164a and HTMLParser never got checked since this is the only use.

Fixes #1894751 [In Python 3.0, the HTMLParser module has been renamed to html.parser](https://bugs.launchpad.net/bugs/1894751)

...

I could not properly test this, since the ozon.ru test_identify_plugin runner fails early due to no results found and I don't have suitable replacement data to search for with it. But it gets far enough to notice that at least, rather than failing with import errors.