### PR TITLE
Nested loop continue logic fix

### DIFF
--- a/src/calibre/devices/usbms/device.py
+++ b/src/calibre/devices/usbms/device.py
@@ -466,7 +466,9 @@ class Device(DeviceConfig, DevicePlugin):
                 for y in ('idProduct', 'idVendor', 'bcdDevice'):
                     if not os.access(j(usb_dir, y), os.R_OK):
                         usb_dir = None
-                        continue
+                        break
+                if usb_dir is None:
+                    continue
                 e = lambda q : raw2num(open(j(usb_dir, q), 'rb').read().decode('utf-8'))
                 ven, prod, bcd = map(e, ('idVendor', 'idProduct', 'bcdDevice'))
                 if not (test(ven, 'idVendor') and test(prod, 'idProduct') and


### PR DESCRIPTION
Continue the outer loop, break of the inner loop.

Else you get a `usb_dir` `NoneType` exception in `os.path.join` if there's a device without idProduct, idVendor, bcdDevice sysfs files.

```
Traceback (most recent call last):
  File "/usr/lib/calibre/calibre/gui2/device.py", line 201, in do_connect
    dev.open(detected_device, self.current_library_uuid)
  File "/usr/lib/calibre/calibre/devices/usbms/device.py", line 809, in open
    self.open_linux()
  File "/usr/lib/calibre/calibre/devices/usbms/device.py", line 560, in open_linux
    main, carda, cardb = self.find_device_nodes()
  File "/usr/lib/calibre/calibre/devices/usbms/device.py", line 471, in find_device_nodes
    ven, prod, bcd = map(e, ('idVendor', 'idProduct', 'bcdDevice'))
  File "/usr/lib/calibre/calibre/devices/usbms/device.py", line 470, in <lambda>
    e = lambda q : raw2num(open(j(usb_dir, q), 'rb').read().decode('utf-8'))
  File "/usr/lib/python2.7/posixpath.py", line 70, in join
    elif path == '' or path.endswith('/'):
AttributeError: 'NoneType' object has no attribute 'endswith'
```