### PR TITLE
Update opds cover and thumb rel to match OPDS 1.0 and higher

### DIFF
--- a/src/calibre/srv/opds.py
+++ b/src/calibre/srv/opds.py
@@ -233,8 +233,8 @@ def ACQUISITION_ENTRY(book_id, updated, request_context):
                     link.set('length', unicode_type(ffm['size']))
                     link.set('mtime', ffm['mtime'].isoformat())
                 ans.append(link)
-    ans.append(E.link(type='image/jpeg', href=get(what='cover'), rel="http://opds-spec.org/cover"))
-    ans.append(E.link(type='image/jpeg', href=get(what='thumb'), rel="http://opds-spec.org/thumbnail"))
+    ans.append(E.link(type='image/jpeg', href=get(what='cover'), rel="http://opds-spec.org/image"))
+    ans.append(E.link(type='image/jpeg', href=get(what='thumb'), rel="http://opds-spec.org/image/thumbnail"))
 
     return ans
 


### PR DESCRIPTION
OPDS 0.9 used /cover and /thumbnail as link rel for covers and thumbnails but this was changed with ODPS 1.0
See: https://specs.opds.io/opds-1.0.html#Artwork_Relations