### PR TITLE
Restore cover download for la_jornada.recipe

### DIFF
--- a/recipes/la_jornada.recipe
+++ b/recipes/la_jornada.recipe
@@ -13,6 +13,7 @@ try:
     from urllib.parse import urlparse, urlunparse, parse_qs
 except ImportError:
     from urlparse import urlparse, urlunparse, parse_qs
+from calibre import strftime
 from calibre.web.feeds.news import BasicNewsRecipe
 
 
@@ -29,6 +30,7 @@ class LaJornada_mx(BasicNewsRecipe):
     use_embedded_content = False
     language = 'es_MX'
     remove_empty_feeds = True
+    cover_url = strftime("http://www.jornada.unam.mx/%Y/%m/%d/portada.pdf")
     masthead_url = 'http://www.jornada.com.mx/v7.0/imagenes/la-jornada-trans.png'
     publication_type = 'newspaper'
     extra_css             = """


### PR DESCRIPTION
This was removed in commit 735da787caf6a80272e3dcc0c21ef4946d9fd867, but I'm not sure why. It works perfectly here.