### PR TITLE
Change cover url to new domain www.jornada.com.mx

### DIFF
--- a/recipes/la_jornada.recipe
+++ b/recipes/la_jornada.recipe
@@ -30,7 +30,7 @@ class LaJornada_mx(BasicNewsRecipe):
     use_embedded_content = False
     language = 'es_MX'
     remove_empty_feeds = True
-    cover_url = strftime("http://www.jornada.unam.mx/%Y/%m/%d/portada.pdf")
+    cover_url = strftime("http://www.jornada.com.mx/%Y/%m/%d/portada.pdf")
     masthead_url = 'http://www.jornada.com.mx/v7.0/imagenes/la-jornada-trans.png'
     publication_type = 'newspaper'
     extra_css             = """


### PR DESCRIPTION
old domain still works but it will probably stop working any day, so better to use the new one