### PR TITLE
Replace obsolete alias tostring() with tobytes()

### DIFF
--- a/src/calibre/utils/fonts/sfnt/loca.py
+++ b/src/calibre/utils/fonts/sfnt/loca.py
@@ -79,7 +79,7 @@ class LocaTable(UnknownTable):
 
         if sys.byteorder != "big":
             vals.byteswap()
-        self.raw = vals.tostring()
+        self.raw = vals.tobytes()
     subset = update
 
     def dump_glyphs(self, sfnt):


### PR DESCRIPTION
The tostring() method was renamed to tobytes() in Python 3.2 and has since been deprecated and removed in Python 3.9.