### PR TITLE
Replace unused legacy KDENotifier with XDPNotifier for sandboxed Linux application contexts

### DIFF
--- a/src/calibre/gui2/notify.py
+++ b/src/calibre/gui2/notify.py
@@ -49,24 +49,6 @@ class DBUSNotifier(Notifier):
             prints(server, 'found' if self.ok else 'not found', 'in', '%.1f' % (time.time() - start), 'seconds')
 
 
-class KDENotifier(DBUSNotifier):
-
-    SERVICE = 'org.kde.VisualNotifications', '/VisualNotifications', 'org.kde.VisualNotifications'
-
-    def __call__(self, body, summary=None, replaces_id=None, timeout=0):
-        if replaces_id is None:
-            replaces_id = self.dbus.UInt32()
-        event_id = ''
-        timeout, body, summary = self.get_msg_parms(timeout, body, summary)
-        try:
-            self._notify.Notify('calibre', replaces_id, event_id, self.ICON, summary, body,
-                self.dbus.Array(signature='s'), self.dbus.Dictionary(signature='sv'),
-                timeout)
-        except:
-            import traceback
-            traceback.print_exc()
-
-
 class FDONotifier(DBUSNotifier):
 
     SERVICE = 'org.freedesktop.Notifications', '/org/freedesktop/Notifications', 'org.freedesktop.Notifications'
@@ -88,7 +70,7 @@ def get_dbus_notifier():
     import dbus
     session_bus = dbus.SessionBus()
     names = frozenset(session_bus.list_names())
-    for srv in KDENotifier, FDONotifier:
+    for srv in (FDONotifier,):
         if srv.SERVICE[0] in names:
             ans = srv(session_bus)
             if ans.ok:

--- a/src/calibre/gui2/notify.py
+++ b/src/calibre/gui2/notify.py
@@ -30,7 +30,13 @@ class Notifier(object):
 
 class DBUSNotifier(Notifier):
 
+    #XXX: Really, this should instead just send the themable icon name
+    #
+    # Doing that however, requires Calibre to first be converted to use
+    # its AppID everywhere and then we still need a fallback for portable
+    # installations.
     ICON = I('lt.png')
+    ICON_DATA = I('lt.png', data=True)
 
     def __init__(self, session_bus):
         self.ok, self.err = True, None
@@ -66,11 +72,38 @@ class FDONotifier(DBUSNotifier):
             traceback.print_exc()
 
 
+class XDPNotifier(DBUSNotifier):
+
+    SERVICE = 'org.freedesktop.portal.Desktop', '/org/freedesktop/portal/desktop', 'org.freedesktop.portal.Notification'
+
+    def __call__(self, body, summary=None, replaces_id=None, timeout=0):
+        if replaces_id is None:
+            replaces_id = self.dbus.UInt32()
+        _, body, summary = self.get_msg_parms(timeout, body, summary)
+        # Note: This backend does not natively support the notion of timeouts
+        #
+        # While the effect may be emulated by manually withdrawing the notifi-
+        # cation from the Calibre side, this resulted in a less than optimal
+        # User Experience. Based on this, KG decided it to be better to not
+        # support timeouts at all for this backend.
+        #
+        # See discussion at https://github.com/kovidgoyal/calibre/pull/1268.
+        try:
+            self._notify.AddNotification(str(replaces_id), self.dbus.Dictionary({
+                "title": self.dbus.String(summary),
+                "body": self.dbus.String(body),
+                "icon": self.dbus.Struct(("bytes", self.dbus.ByteArray(self.ICON_DATA, variant_level=1)), signature='sv'),
+            }, signature='sv'))
+        except:
+            import traceback
+            traceback.print_exc()
+
+
 def get_dbus_notifier():
     import dbus
     session_bus = dbus.SessionBus()
     names = frozenset(session_bus.list_names())
-    for srv in (FDONotifier,):
+    for srv in (FDONotifier, XDPNotifier):
         if srv.SERVICE[0] in names:
             ans = srv(session_bus)
             if ans.ok:


### PR DESCRIPTION
This is part of my ongoing work at reducing the number of permissions required for the Calibre Flatpak package (likely useful for Snap too).

The new notification code is programmed to conform to the interface described at https://docs.flatpak.org/en/latest/portal-api-reference.html#gdbus-org.freedesktop.portal.Notification.

As can be seen in the code, that interface does not expose the ability to set a timeout. To remedy this I set a timeout on the Calibre side and manually cancel the notification after the given number of milliseconds. **However**, practical experimentation in KDE shows that notifications submitted via this API have a default timeout of 10 seconds and display a visual cue how long it will take until they expire. Additionally, interacting with the popup (mouse-over) will reset the timer and with Calibre cancelling the notification after the default 5 seconds the popup will appear to  disappear for no apparent reason and contrary to the other cues given by the UI.
Based on this, I'd be inclined to remove the timeout handling altogether and just let the DE decide for how long it wishes to display the notification. Let me know whatever you prefer.

None of this affects unconfined builds of Calibre (website download) as these continue to prefer the older FreeDesktop Notification API.

OT: Is there any plan to eventually switch away from *dbus-python* for DBus interaction to something maintained? Would you accept patches for such a thing? If yes, to which API should the switch be (QDBus, PyDBus, Jeepney)?