### PR TITLE
polyglot: don't try to import plistlib.Data

### DIFF
--- a/src/polyglot/plistlib.py
+++ b/src/polyglot/plistlib.py
@@ -2,5 +2,5 @@
 # vim:fileencoding=utf-8
 # License: GPL v3 Copyright: 2019, Kovid Goyal <kovid at kovidgoyal.net>
 
-from plistlib import loads, dumps, Data  # noqa
+from plistlib import loads, dumps  # noqa
 loads_binary_or_xml = loads


### PR DESCRIPTION
plistlib.Data is deprecated from Python 3.4 and fully removed in Python
3.9.

Skimming over the code, it's look like nothing uses this data structure.

Let's remove it.