### PR TITLE
Tag browser focus changes discussed in other PR.

### DIFF
--- a/src/calibre/gui2/preferences/look_feel.py
+++ b/src/calibre/gui2/preferences/look_feel.py
@@ -414,7 +414,7 @@ class ConfigWidget(ConfigWidgetBase, Ui_Form):
         r('tag_browser_hide_empty_categories', gprefs)
         r('tag_browser_always_autocollapse', gprefs)
         r('tag_browser_show_tooltips', gprefs)
-        r('tag_browser_allow_keyboard_focus', gprefs, restart_required=True)
+        r('tag_browser_allow_keyboard_focus', gprefs)
         r('bd_show_cover', gprefs)
         r('bd_overlay_cover_size', gprefs)
         r('cover_grid_width', gprefs)

--- a/src/calibre/gui2/preferences/look_feel.ui
+++ b/src/calibre/gui2/preferences/look_feel.ui
@@ -1111,7 +1111,7 @@ see the counts by hovering your mouse over any item.</string>
        <item row="14" column="0" colspan="2">
         <widget class="QCheckBox" name="opt_tag_browser_allow_keyboard_focus">
          <property name="text">
-          <string>Allow the Tag browser to have keyboard focus (needs restart)</string>
+          <string>Allow the Tag browser to have keyboard focus</string>
          </property>
          <property name="toolTip">
           <string>&lt;p&gt;When checked, the Tag browser can get keyboard focus, allowing


### PR DESCRIPTION
For the record:
1) When the option to give the tag browser focus is enabled:
- Clicking on the tag browser should always give it focus, even if a
node is toggled in the process
- Toggling a node should not give the focus back to the library view
2) When the option to give the tag browser focus is disabled:
- Clicking on the tag browser should never give it focus, and the
shortcut to give it focus should have no effect.