### PR TITLE
calibre-gui.desktop: rename "calibre" to "Calibre"

### DIFF
--- a/src/calibre/linux.py
+++ b/src/calibre/linux.py
@@ -1119,7 +1119,7 @@ GUI = '''\
 [Desktop Entry]
 Version=1.0
 Type=Application
-Name=calibre
+Name=Calibre
 GenericName=E-book library management
 Comment=E-book library management: Convert, view, share, catalogue all your e-books
 TryExec=calibre


### PR DESCRIPTION
Rationale: all other .desktop files created by linux.py script are
capitalizing the application names but this one. Also, as Calibre uses
"Calibre" in its titlebar, it would make it more consistent.