### PR TITLE
Bug #1906063: regression: template function first_non_empty fails if …

### DIFF
--- a/src/calibre/utils/formatter.py
+++ b/src/calibre/utils/formatter.py
@@ -538,6 +538,7 @@ class _Interpreter(object):
         for expr in prog.expression_list:
             if v := self.expr(expr):
                 return v
+        return ''
 
     NODE_OPS = {
         Node.NODE_IF:             do_node_if,


### PR DESCRIPTION
…no argument evaluates non-empty