### PR TITLE
Recipe for Substack newsletters

### DIFF
--- a/recipes/substack.recipe
+++ b/recipes/substack.recipe
@@ -23,7 +23,7 @@ from mechanize import Request
 
 class Substack(BasicNewsRecipe):
     title          = 'Substack'
-    __author__     ='topynate'
+    __author__     = 'topynate'
     oldest_article = 7
     max_articles_per_feed = 100
     auto_cleanup   = True
@@ -40,7 +40,7 @@ class Substack(BasicNewsRecipe):
         br = BasicNewsRecipe.get_browser(self)
         if self.username is not None and self.password is not None:
             br.open('https://substack.com/account/login?redirect=%2F&email=&with_password=')
-            data = json.dumps({'email': self.username, 'password': self.password, 'captch_response':None})
+            data = json.dumps({'email': self.username, 'password': self.password, 'captcha_response':None})
             req = Request(
                 url='https://substack.com/api/v1/login',
                 headers = {

--- a/recipes/substack.recipe
+++ b/recipes/substack.recipe
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+# vim:fileencoding=utf-8
+#
+# Title:        Substack
+# License:      GNU General Public License v3 – https://www.gnu.org/licenses/gpl-3.0.html
+# Copyright:    Nathan Cook (nathan.cook@gmail.com)
+##
+# Written:      2020-12-18
+##
+
+__license__ = 'GNU General Public License v3 – https://www.gnu.org/licenses/gpl-3.0.html'
+__copyright__ = 'Nathan Cook – 2020-12-18'
+__version__ = 'v0.1.0'
+__date__ = '2020-12-18'
+
+
+from calibre.web.feeds.news import BasicNewsRecipe
+import json
+from mechanize import Request
+
+class Substack(BasicNewsRecipe):
+    title          = 'Substack'
+    oldest_article = 7
+    max_articles_per_feed = 100
+    auto_cleanup   = True
+
+# Every Substack publication has an RSS feed at https://{name}.substack.com/feed.
+# The same URL provides either all posts, or all free posts + previews of paid posts,
+# depending on whether you're logged in.
+    feeds          = [
+        ('Novum Lumen', 'https://novumlumen.substack.com/feed'),    # gratuitously self-promotional example
+    ]
+    
+    def get_browser(self):
+        br = BasicNewsRecipe.get_browser(self)
+        if self.username is not None and self.password is not None:
+            br.open('https://substack.com/account/login?redirect=%2F&email=&with_password=')
+            data = json.dumps({'email': self.username, 'password': self.password, 'captch_response':None})
+            req = Request(
+                url='https://substack.com/api/v1/login',
+                headers = {
+                    'Accept': '*/*',
+                    'Content-Type': 'application/json',
+                    'Origin': 'https://substack.com',
+                    'Referer': 'https://substack.com/account/login?redirect=%2F&email=&with_password=',
+                },
+                data=data,
+                method='POST')
+            res = br.open(req)
+            if res.getcode() != 200:
+                raise ValueError('Login failed, check username and password')        
+        return br
+    

--- a/recipes/substack.recipe
+++ b/recipes/substack.recipe
@@ -9,9 +9,12 @@
 ##
 
 __license__ = 'GNU General Public License v3 – https://www.gnu.org/licenses/gpl-3.0.html'
-__copyright__ = 'Nathan Cook – 2020-12-18'
-__version__ = 'v0.1.0'
-__date__ = '2020-12-18'
+__copyright__ = 'Nathan Cook – 2020-12-19'
+__version__ = 'v0.1.1'
+__date__ = '2020-12-19'
+__author__ = 'topynate'
+
+language = 'en'
 
 
 from calibre.web.feeds.news import BasicNewsRecipe
@@ -20,9 +23,11 @@ from mechanize import Request
 
 class Substack(BasicNewsRecipe):
     title          = 'Substack'
+    __author__     ='topynate'
     oldest_article = 7
     max_articles_per_feed = 100
     auto_cleanup   = True
+    needs_subscription = 'optional'
 
 # Every Substack publication has an RSS feed at https://{name}.substack.com/feed.
 # The same URL provides either all posts, or all free posts + previews of paid posts,


### PR DESCRIPTION
This recipe uses the RSS feeds which Substack provides for each newsletter. Unlike the built-in RSS recipe, this one also lets Calibre download all posts from your paid subscriptions.

If you don't add a username and password, it will work exactly like the built-in recipe.