### PR TITLE
docs: fix simple typo, specal -> special

### DIFF
--- a/src/tinycss/tests/tokenizing.py
+++ b/src/tinycss/tests/tokenizing.py
@@ -186,7 +186,7 @@ foo(int x) {\
             ('S', '\n'), ('IDENT', 'Ipsum')]),
 
         # Cancel the meaning of special characters
-        (r'"Lore\m Ipsum"', [('STRING', 'Lorem Ipsum')]),  # or not specal
+        (r'"Lore\m Ipsum"', [('STRING', 'Lorem Ipsum')]),  # or not special
         (r'"Lorem \49psum"', [('STRING', 'Lorem Ipsum')]),
         (r'"Lorem \49 psum"', [('STRING', 'Lorem Ipsum')]),
         (r'"Lorem\"Ipsum"', [('STRING', 'Lorem"Ipsum')]),


### PR DESCRIPTION
There is a small typo in src/tinycss/tests/tokenizing.py.

Should read `special` rather than `specal`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md