### PR TITLE
Fix for Bug #1909738: Strangeness with hierarchical searches

### DIFF
--- a/src/calibre/gui2/tag_browser/model.py
+++ b/src/calibre/gui2/tag_browser/model.py
@@ -1372,10 +1372,12 @@ class TagsModel(QAbstractItemModel):  # {{{
         if index.isValid():
             node = self.data(index, Qt.ItemDataRole.UserRole)
             if node.type == TagTreeItem.TAG:
-                if node.tag.is_editable or node.tag.is_hierarchical:
+                tag = node.tag
+                category = tag.category
+                if (tag.is_editable or tag.is_hierarchical) and category != 'search':
                     ans |= Qt.ItemFlag.ItemIsDragEnabled
-                fm = self.db.metadata_for_field(node.tag.category)
-                if node.tag.category in \
+                fm = self.db.metadata_for_field(category)
+                if category in \
                     ('tags', 'series', 'authors', 'rating', 'publisher', 'languages') or \
                     (fm['is_custom'] and
                         fm['datatype'] in ['text', 'rating', 'series', 'enumeration']):

--- a/src/calibre/gui2/tag_browser/view.py
+++ b/src/calibre/gui2/tag_browser/view.py
@@ -685,7 +685,9 @@ class TagsView(QTreeView):  # {{{
                 if tag:
                     # If the user right-clicked on an editable item, then offer
                     # the possibility of renaming that item.
-                    if fm['datatype'] != 'composite' and (tag.is_editable or tag.is_hierarchical):
+                    if (fm['datatype'] != 'composite' and
+                            (tag.is_editable or tag.is_hierarchical) and
+                            key != 'search'):
                         # Add the 'rename' items to both interior and leaf nodes
                         if fm['datatype'] != 'enumeration':
                             if self.model().get_in_vl():


### PR DESCRIPTION
Because it is useful I decided to continue to permit hierarchy for saved searches even though behavior will be a bit strange.

The following behaviors exist and will not be changed.
- Renames will not rename all items in the the hierarchy.
- Intermediate nodes that aren't 'real' searches will not offer the rename option.
- Drag & drop is disabled.

In addition I changed the behavior of "Add search" in "Manage saved searches". It used to act like a rename if the target name already exists, throwing away the old search expression. It now refuses.