### PR TITLE
Add a method to db.cache to return the size of a format stored in the…

### DIFF
--- a/src/calibre/db/cache.py
+++ b/src/calibre/db/cache.py
@@ -607,7 +607,8 @@ class Cache(object):
         if not fmt:
             return {}
         fmt = fmt.upper()
-        if allow_cache:
+        # allow_cache and update_db are mutually exclusive. Give priority to update_db
+        if allow_cache and not update_db:
             x = self.format_metadata_cache[book_id].get(fmt, None)
             if x is not None:
                 return x
@@ -634,6 +635,11 @@ class Cache(object):
         field = self.fields['formats']
         fmts = field.table.book_col_map.get(book_id, ())
         return {fmt:field.format_fname(book_id, fmt) for fmt in fmts}
+
+    @read_api
+    def format_db_size(self, book_id, fmt):
+        field = self.fields['formats']
+        return field.format_size(book_id, fmt)
 
     @read_api
     def pref(self, name, default=None, namespace=None):

--- a/src/calibre/db/fields.py
+++ b/src/calibre/db/fields.py
@@ -623,6 +623,9 @@ class FormatsField(ManyToManyField):
     def format_fname(self, book_id, fmt):
         return self.table.fname_map[book_id][fmt.upper()]
 
+    def format_size(self, book_id, fmt):
+        return self.table.size_map.get(book_id, {}).get(fmt.upper(), None)
+
     def iter_searchable_values(self, get_metadata, candidates, default_value=None):
         val_map = defaultdict(set)
         cbm = self.table.book_col_map


### PR DESCRIPTION
… database table 'data'. With this method one can compare the real size to the stored size.

Let me know if there is a better way to get the stored size.