### PR TITLE
Use python 3.7 compatible syntax.

### DIFF
--- a/src/calibre/gui2/tag_browser/view.py
+++ b/src/calibre/gui2/tag_browser/view.py
@@ -782,8 +782,9 @@ class TagsView(QTreeView):  # {{{
                                 partial(self.context_menu_handler, action='search',
                                         search_state=TAG_SEARCH_STATES['mark_plus'],
                                         index=index))
-                        if add_child_search := (tag.is_hierarchical == '5state' and
-                                                len(tag_item.children)):
+                        add_child_search = (tag.is_hierarchical == '5state' and
+                                            len(tag_item.children))
+                        if add_child_search:
                             search_submenu.addAction(self.search_icon,
                                     _('Search for %s and its children')%display_name(tag),
                                     partial(self.context_menu_handler, action='search',


### PR DESCRIPTION
The := operator was introduced in python 3.8. I don't think making calibre incompatible with previous python versions is worth the use of the new operator here.

FreeBSD at least uses python 3.7 by default and this would cause problems in providing calibre to users, and require them to custom compile software to get it.

I can also patch it locally on FreeBSD ports tree but I'd rather have this patch accepted.

The := operator was introduced in a2411ef0a0f3517ae06a509000561c90168a10fa