### PR TITLE
E-book viewer: Add shortcut option for syncing

### DIFF
--- a/src/pyj/read_book/shortcuts.pyj
+++ b/src/pyj/read_book/shortcuts.pyj
@@ -4,6 +4,8 @@ from __python__ import bound_methods, hash_literals
 
 from gettext import gettext as _
 
+from read_book.globals import runtime
+
 
 def parse_key_repr(sc):
     parts = sc.split('+')
@@ -363,6 +365,14 @@ def shortcuts_definition():
     ),
 
     }
+
+    if not runtime.is_standalone_viewer:
+        ans['sync_book'] = desc(
+            v"[]",
+            'ui',
+            _('Sync last read position/annotations'),
+        )
+
     return ans
 
 

--- a/src/pyj/read_book/view.pyj
+++ b/src/pyj/read_book/view.pyj
@@ -530,6 +530,8 @@ class View:
             self.toggle_read_aloud()
         elif data.name is 'reload_book':
             ui_operations.reload_book()
+        elif data.name is 'sync_book':
+            self.overlay.sync_book()
         elif data.name is 'next_section':
             self.on_next_section({'forward': True})
         elif data.name is 'previous_section':


### PR DESCRIPTION
Add a shortcut option for syncing last position and annotations. The option is only added for non-standalone viewer mode since book syncing only applies there. No default binding is assigned.

----------------

Testing done:
- [x] Tested in standalone viewer, and verified that the shortcut option does *not* show up.
- [x] Tested in content-server viewer, and verified that the shortcut option shows up.
- [x] Tested binding in content-server viewer, and verified that the shortcut triggers book syncing as expected.

This is my first time contributing to calibre, so apologies in advance if I missed anything.

In terms of code, I'm actually not sure if importing and using `globals.runtime` is the right way to go here. Having callsites pass in a `is_standalone_viewer` argument to `shortcuts_definition` is potentially cleaner - and if we do that we can also merge `add_standalone_viewer_shortcuts` and `shortcuts_definition`. Let me know if you want me to make that refactor instead.

Thank you for your hard work on calibre!