### PR TITLE
restore HTTPS when accessing cc.bingj.com

### DIFF
--- a/src/calibre/ebooks/metadata/sources/search_engines.py
+++ b/src/calibre/ebooks/metadata/sources/search_engines.py
@@ -188,9 +188,7 @@ def bing_search(terms, site=None, br=None, log=prints, safe_search=False, dump_r
             log('Ignoring {!r} as it has no cached page'.format(title))
             continue
         d, w = div.get('u').split('|')[-2:]
-        # The bing cache does not have a valid https certificate currently
-        # (March 2017)
-        cached_url = 'http://cc.bingj.com/cache.aspx?q={q}&d={d}&mkt=en-US&setlang=en-US&w={w}'.format(
+        cached_url = 'https://cc.bingj.com/cache.aspx?q={q}&d={d}&mkt=en-US&setlang=en-US&w={w}'.format(
             q=q, d=d, w=w)
         ans.append(Result(a.get('href'), title, cached_url))
     if not ans:


### PR DESCRIPTION
The certificate is corrected by now:
```
* Server certificate:
*  subject: CN=cc.bingj.com
*  start date: Jan 19 01:42:44 2021 GMT
*  expire date: Jul 19 01:42:44 2021 GMT
*  subjectAltName: host "cc.bingj.com" matched cert's "cc.bingj.com"
*  issuer: C=US; O=Microsoft Corporation; CN=Microsoft RSA TLS CA 01
*  SSL certificate verify ok.
```