### PR TITLE
Use HTTPS when downloading metadata via Google Books feed

### DIFF
--- a/src/calibre/ebooks/metadata/sources/google.py
+++ b/src/calibre/ebooks/metadata/sources/google.py
@@ -90,7 +90,7 @@ def to_metadata(browser, log, entry_, timeout):  # {{{
             log.exception('Programming error:')
         return None
 
-    id_url = entry_id(entry_)[0].text
+    id_url = entry_id(entry_)[0].text.replace("http://","https://")
     google_id = id_url.split('/')[-1]
     title_ = ': '.join([x.text for x in title(entry_)]).strip()
     authors = [x.text.strip() for x in creator(entry_) if x.text]

--- a/src/calibre/ebooks/metadata/sources/google.py
+++ b/src/calibre/ebooks/metadata/sources/google.py
@@ -90,7 +90,7 @@ def to_metadata(browser, log, entry_, timeout):  # {{{
             log.exception('Programming error:')
         return None
 
-    id_url = entry_id(entry_)[0].text.replace("http://","https://")
+    id_url = entry_id(entry_)[0].text.replace('http://', 'https://')
     google_id = id_url.split('/')[-1]
     title_ = ': '.join([x.text for x in title(entry_)]).strip()
     authors = [x.text.strip() for x in creator(entry_) if x.text]


### PR DESCRIPTION
At the moment the metadata URL is retrieved from the Google Books feed entries' `<id>` element, but that data contains (or may contain) an insecure (cleartext HTTP) endpoint.

This patch does the simplest possible thing and replaces `http://` with `https://` to use the latter, secure protocol to subsequently download the metadata itself.

Alternatively, it's possible to retrieve the HTTPS URL directly from the feed entry, with this patch:
```diff
--- src/calibre/ebooks/metadata/sources/google.py	2021-02-06 22:03:55.000000000 +0000
+++ src/calibre/ebooks/metadata/sources/google-secure.py	2021-02-06 22:04:32.000000000 +0000
@@ -67,7 +67,7 @@
     # start_index    = XPath('//openSearch:startIndex')
     # items_per_page = XPath('//openSearch:itemsPerPage')
     entry = XPath('//atom:entry')
-    entry_id = XPath('descendant::atom:id')
+    entry_id = XPath('//atom:link[@href and @rel="self"]/@href')
     creator = XPath('descendant::dc:creator')
     identifier = XPath('descendant::dc:identifier')
     title = XPath('descendant::dc:title')
@@ -90,7 +90,7 @@
             log.exception('Programming error:')
         return None
 
-    id_url = entry_id(entry_)[0].text
+    id_url = entry_id(entry_)[0]
     google_id = id_url.split('/')[-1]
     title_ = ': '.join([x.text for x in title(entry_)]).strip()
     authors = [x.text.strip() for x in creator(entry_) if x.text]
```

&hellip;to pick feed entry elements like this one (e.g. via ISBN `9781476755847`):
```xml
<link rel="self" type="application/atom+xml" href="https://www.google.com/books/feeds/volumes/sZXEfocFYTQC"/>
```

It should be safe, assuming this element is always returned by Google Books. In my limited tests, it was always present.
