### PR TITLE
Use an em dash to separate window title fragments

### DIFF
--- a/src/calibre/gui2/ui.py
+++ b/src/calibre/gui2/ui.py
@@ -907,7 +907,7 @@ class Main(MainWindow, MainWindowMixin, DeviceMixin, EmailMixin,  # {{{
             font.setBold(True)
             font.setItalic(True)
         self.virtual_library.setFont(font)
-        title = '{0} - || {1}{2} ||'.format(
+        title = '{0} — || {1}{2} ||'.format(
                 __appname__, self.iactions['Choose Library'].library_name(), restrictions)
         self.setWindowTitle(title)
 


### PR DESCRIPTION
Em dash is a more visible and more beautiful separator that also looks more native on systems like macOS. A number of applications have switched to using em dash as window title separator, including Firefox, VS Code, and Wireshark. 

See the discussion here: https://bugzilla.mozilla.org/show_bug.cgi?id=1279647