### PR TITLE
ci: remove glibc workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,14 +40,8 @@ jobs:
                 CI: 'true'
         steps:
             - name: Setup container
-              # WORKAROUND for glibc 2.33 and old Docker
-              # See https://github.com/actions/virtual-environments/issues/2658
-              # Thanks to https://github.com/lxqt/lxqt-panel/pull/1562
               run: |
-                patched_glibc=glibc-linux4-2.33-4-x86_64.pkg.tar.zst
-                curl -LO "https://repo.archlinuxcn.org/x86_64/$patched_glibc"
-                bsdtar -C / -xf "$patched_glibc"
-                pacman -Syu --noconfirm --ignore glibc
+                pacman -Syu --noconfirm
                 pacman -S --noconfirm tar
 
             - name: Checkout source code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         name: Test on Arch
         runs-on: ubuntu-latest
         container:
-            image: 'archlinux/base:latest'
+            image: 'archlinux/archlinux:latest'
             env:
                 CI: 'true'
         steps:

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -10,7 +10,7 @@ jobs:
         if: github.repository == 'kovidgoyal/calibre'
         runs-on: ubuntu-latest
         container:
-            image: 'archlinux/base:latest'
+            image: 'archlinux/archlinux:latest'
             env:
                 CI: 'true'
         steps:

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -15,14 +15,8 @@ jobs:
                 CI: 'true'
         steps:
             - name: Setup container
-              # WORKAROUND for glibc 2.33 and old Docker
-              # See https://github.com/actions/virtual-environments/issues/2658
-              # Thanks to https://github.com/lxqt/lxqt-panel/pull/1562
               run: |
-                patched_glibc=glibc-linux4-2.33-4-x86_64.pkg.tar.zst
-                curl -LO "https://repo.archlinuxcn.org/x86_64/$patched_glibc"
-                bsdtar -C / -xf "$patched_glibc"
-                pacman -Syu --noconfirm --ignore glibc
+                pacman -Syu --noconfirm
                 pacman -S --noconfirm tar
 
             - name: Checkout source code


### PR DESCRIPTION
The container runs successfully now.

Switching off of the "base" container reduces the runtime by 20s. The old one is frozen and does not get updated, so it has to do tons of updates.