### PR TITLE
Fix regression in template language caused by commit bde8cd5: …

### DIFF
--- a/src/calibre/utils/formatter.py
+++ b/src/calibre/utils/formatter.py
@@ -616,7 +616,8 @@ class _Parser(object):
                 return AssignNode(arguments[0].name, arguments[1])
             if id_ == 'arguments' or id_ == 'globals' or id_ == 'set_globals':
                 new_args = []
-                for arg in arguments:
+                for arg_list in arguments:
+                    arg = arg_list[0]
                     if arg.node_type not in (Node.NODE_ASSIGN, Node.NODE_RVALUE):
                         self.error(_("Parameters to '{}' must be "
                                      "variables or assignments").format(id_))


### PR DESCRIPTION
…expression lists. The commit broke the arguments(), globals(), and set_globals() functions.