### PR TITLE
Correct problem where the booklist doesn't refresh after …

### DIFF
--- a/src/calibre/gui2/search_restriction_mixin.py
+++ b/src/calibre/gui2/search_restriction_mixin.py
@@ -352,6 +352,7 @@ class SearchRestrictionMixin(object):
         virt_libs[name] = search
         db.new_api.set_pref('virtual_libraries', virt_libs)
         db.new_api.clear_search_caches()
+        self.library_view.model().db.refresh()
 
     def do_create_edit(self, name=None):
         db = self.library_view.model().db
@@ -498,6 +499,7 @@ class SearchRestrictionMixin(object):
             'confirm_vl_removal', parent=self):
             return
         self._remove_vl(name, reapply=True)
+        self.library_view.model().db.refresh()
 
     def choose_vl_triggerred(self):
         from calibre.gui2.tweak_book.widgets import QuickOpen, emphasis_style


### PR DESCRIPTION
…changing/adding/deleting a vl name. Clearing the cache isn't sufficient.

This problem isn't related to the new cache. It has been there for a long time.

Note that this PR changes calibre's behavior when VLs are edited. Before the booklist didn't change, possibly showing incorrect data. Now the booklist always refreshes.