### PR TITLE
feat: add primary-writing-mode option ePub/azw3 output

### DIFF
--- a/src/calibre/ebooks/conversion/plugins/epub_output.py
+++ b/src/calibre/ebooks/conversion/plugins/epub_output.py
@@ -125,6 +125,12 @@ class EPUBOutput(OutputFormatPlugin):
                 ' actually need it.')
         ),
 
+        OptionRecommendation(name='primary_writing_mode', recommended_value=None,
+            help=_('The `primary-writing-mode` metadata for controlling page rendering order,'
+                ' reading mode and reader navigation. Valid values are: %s' %
+                ['horizontal-lr', 'horizontal-rl', 'vertical-lr', 'vertical-rl'])
+        ),
+
         }
 
     recommendations = {('pretty_print', True, OptionRecommendation.HIGH)}
@@ -235,6 +241,12 @@ class EPUBOutput(OutputFormatPlugin):
             from uuid import uuid4
             uuid = unicode_type(uuid4())
             oeb.metadata.add('identifier', uuid, scheme='uuid', id=uuid)
+
+        valid_writing_mode = ['horizontal-lr', 'horizontal-rl', 'vertical-lr', 'vertical-rl']
+        if opts.primary_writing_mode in valid_writing_mode:
+            self.oeb.metadata.add('primary-writing-mode', opts.primary_writing_mode)
+            _, direction = opts.primary_writing_mode.split('-')
+            self.oeb.spine.page_progression_direction = 'rtl' if direction == 'rl' else 'ltr'
 
         if encrypted_fonts and not uuid.startswith('urn:uuid:'):
             # Apparently ADE requires this value to start with urn:uuid:

--- a/src/calibre/ebooks/conversion/plugins/mobi_output.py
+++ b/src/calibre/ebooks/conversion/plugins/mobi_output.py
@@ -306,6 +306,11 @@ class AZW3Output(OutputFormatPlugin):
                 ' the book will not auto sync its last read position '
                 ' on multiple devices. Complain to Amazon.')
         ),
+        OptionRecommendation(name='primary_writing_mode', recommended_value=None,
+            help=_('The `primary-writing-mode` metadata for controlling page rendering order,'
+                ' reading mode and reader navigation. Valid values are: %s' %
+                ['horizontal-lr', 'horizontal-rl', 'vertical-lr', 'vertical-rl'])
+        ),
     }
 
     def convert(self, oeb, output_path, input_plugin, opts, log):
@@ -317,6 +322,12 @@ class AZW3Output(OutputFormatPlugin):
         opts.mobi_periodical = self.is_periodical
         passthrough = getattr(opts, 'mobi_passthrough', False)
         remove_duplicate_anchors(oeb)
+
+        valid_writing_mode = ['horizontal-lr', 'horizontal-rl', 'vertical-lr', 'vertical-rl']
+        if opts.primary_writing_mode in valid_writing_mode:
+            self.oeb.metadata.add('primary-writing-mode', opts.primary_writing_mode)
+            _, direction = opts.primary_writing_mode.split('-')
+            self.oeb.spine.page_progression_direction = 'rtl' if direction == 'rl' else 'ltr'
 
         resources = Resources(self.oeb, self.opts, self.is_periodical,
                 add_fonts=True, process_images=False)


### PR DESCRIPTION
Add `primary-writing-mode` option for supporting right-to-left language ebooks such as Japanese Manga.

Feature request here:

https://bugs.launchpad.net/calibre/+bug/1919006