### PR TITLE
setup: fix installing without develop mode + system plugins option

### DIFF
--- a/setup/install.py
+++ b/setup/install.py
@@ -256,6 +256,8 @@ class Install(Develop):
             help='Where to put the calibre binaries. Default is <root>/bin')
         parser.add_option('--staging-sharedir',
             help='Where to put the calibre data files. Default is <root>/share')
+        parser.add_option('--system-plugins-location',
+                help='Path to a directory from which the installed calibre will load plugins')
         self.add_postinstall_options(parser)
 
     def install_files(self):


### PR DESCRIPTION
options for Develop() are not automatically added to Install(), so the new option in commit 8fb6d5f37e8055ce720bd0b1d56587f88c0071f285966ba17e72b2b12672aa73 only worked for the former. And since consolidate_paths unconditionally checked opts.system_plugins_location, trying to run an ordinary install ended in:

```
  File "/build/calibre-git/src/calibre/setup/install.py", line 117, in consolidate_paths
    self.system_plugins_loc = opts.system_plugins_location
AttributeError: 'Values' object has no attribute 'system_plugins_location'
```