### PR TITLE
Fix Guardian Recipe CSS: Images are distorted

### DIFF
--- a/recipes/guardian.recipe
+++ b/recipes/guardian.recipe
@@ -65,11 +65,8 @@ class Guardian(BasicNewsRecipe):
 
     extra_css = """
             img {
-                width: 100% !important;
-                height: 100% !important;
                 max-width: 100% !important;
                 max-height: 100% !important;
-                min-width: 480px;
             }
 
             a span {


### PR DESCRIPTION
Images were scaled to 100% height/width. Fixed by removing CSS.

Before: https://imgur.com/a/2VG9W7E
After Patch: https://imgur.com/a/DgUhS9G
