### PR TITLE
Bug #1924247: Possible to create recursive VL that crashes Calibre

### DIFF
--- a/src/calibre/db/search.py
+++ b/src/calibre/db/search.py
@@ -513,7 +513,8 @@ class Parser(SearchQueryParser):  # {{{
             if not vl:
                 raise ParseException(_('No such Virtual library: {}').format(query))
             try:
-                return candidates & self.dbcache.books_in_virtual_library(query)
+                return candidates & self.dbcache.books_in_virtual_library(
+                            query, virtual_fields=self.virtual_fields)
             except RuntimeError:
                 raise ParseException(_('Virtual library search is recursive: {}').format(query))
 

--- a/src/calibre/gui2/tag_browser/model.py
+++ b/src/calibre/gui2/tag_browser/model.py
@@ -312,7 +312,7 @@ class TagsModel(QAbstractItemModel):  # {{{
     search_item_renamed = pyqtSignal()
     tag_item_renamed = pyqtSignal()
     refresh_required = pyqtSignal()
-    restriction_error = pyqtSignal()
+    restriction_error = pyqtSignal(object)
     drag_drop_finished = pyqtSignal(object)
     user_categories_edited = pyqtSignal(object, object)
     user_category_added = pyqtSignal()
@@ -1113,12 +1113,11 @@ class TagsModel(QAbstractItemModel):  # {{{
             data = self.db.new_api.get_categories(sort=sort,
                     book_ids=self.get_book_ids_to_use(),
                     first_letter_sort=self.collapse_model == 'first letter')
-        except:
-            import traceback
+        except Exception as e:
             traceback.print_exc()
             data = self.db.new_api.get_categories(sort=sort,
                     first_letter_sort=self.collapse_model == 'first letter')
-            self.restriction_error.emit()
+            self.restriction_error.emit(str(e))
 
         if self.filter_categories_by:
             if self.filter_categories_by.startswith('='):

--- a/src/calibre/gui2/tag_browser/ui.py
+++ b/src/calibre/gui2/tag_browser/ui.py
@@ -99,9 +99,10 @@ class TagBrowserMixin(object):  # {{{
     def user_categories_edited(self):
         self.library_view.model().refresh()
 
-    def do_restriction_error(self):
+    def do_restriction_error(self, e):
         error_dialog(self.tags_view, _('Invalid search restriction'),
-                         _('The current search restriction is invalid'), show=True)
+                         _('The current search restriction is invalid'),
+                         det_msg=str(e) if e else '', show=True)
 
     def do_add_subcategory(self, on_category_key, new_category_name=None):
         '''

--- a/src/calibre/gui2/tag_browser/view.py
+++ b/src/calibre/gui2/tag_browser/view.py
@@ -172,7 +172,7 @@ class TagsView(QTreeView):  # {{{
     tag_item_renamed        = pyqtSignal()
     search_item_renamed     = pyqtSignal()
     drag_drop_finished      = pyqtSignal(object)
-    restriction_error       = pyqtSignal()
+    restriction_error       = pyqtSignal(object)
     tag_item_delete         = pyqtSignal(object, object, object, object, object)
     tag_identifier_delete   = pyqtSignal(object, object)
     apply_tag_to_selected   = pyqtSignal(object, object, object)


### PR DESCRIPTION
The actual fix is in cache.py line 2218. Another change added the virtual fields to vl:x searches. The rest are improvements to error messages.