### PR TITLE
Two commits: 

### DIFF
--- a/resources/default_tweaks.py
+++ b/resources/default_tweaks.py
@@ -570,3 +570,8 @@ exclude_fields_on_paste = []
 # Useful if for some reason your operating systems network checking
 # facilities are not reliable (for example NetworkManager on Linux).
 skip_network_check = False
+
+#: Tab stop width in the template editor
+# Sets the width of the tab stop in the template editor in "average characters".
+# For example, a value of 1 results in a space the width of one average character.
+template_editor_tab_stop_width = 4

--- a/src/calibre/utils/formatter.py
+++ b/src/calibre/utils/formatter.py
@@ -796,6 +796,8 @@ class _Interpreter(object):
             saved_line_number = self.override_line_number
             self.override_line_number = (self.override_line_number if self.override_line_number
                                          else prog.line_number)
+        else:
+            saved_line_number = None
         try:
             val = self.expression_list(prog.function)
         except ReturnExecuted as e:


### PR DESCRIPTION
- Fix a serious regression breaking calling stored templates introduced on 12/4. This easily could be serious enough to provoke an interim release. Apologies.

- Add a tweak to set the tab stop width in the template editor.