### PR TITLE
Revert "Fix building on Arch"

### DIFF
--- a/setup/arch-ci.sh
+++ b/setup/arch-ci.sh
@@ -5,7 +5,7 @@
 
 set -xe
 
-pacman -S --noconfirm --needed base-devel sudo git sip pyqt-builder chmlib icu jxrlib hunspell libmtp libusb libwmf optipng podofo python-apsw python-beautifulsoup4 python-cssselect python-css-parser python-dateutil python-dbus python-dnspython python-dukpy python-feedparser python-html2text python-html5-parser python-lxml python-markdown python-mechanize python-msgpack python-netifaces python-unrardll libraqm python-pillow python-psutil python-pygments python-pyqt5 python-regex python-zeroconf python-pyqtwebengine qt5-x11extras qt5-svg qt5-imageformats udisks2 hyphen python-pychm python-pycryptodome speech-dispatcher python-sphinx python-urllib3 python-py7zr python-pip python-cchardet
+pacman -S --noconfirm --needed base-devel sudo git sip pyqt-builder chmlib icu jxrlib hunspell libmtp libusb libwmf optipng podofo python-apsw python-beautifulsoup4 python-cssselect python-css-parser python-dateutil python-dbus python-dnspython python-dukpy python-feedparser python-html2text python-html5-parser python-lxml python-markdown python-mechanize python-msgpack python-netifaces python-unrardll python-pillow python-psutil python-pygments python-pyqt5 python-regex python-zeroconf python-pyqtwebengine qt5-x11extras qt5-svg qt5-imageformats udisks2 hyphen python-pychm python-pycryptodome speech-dispatcher python-sphinx python-urllib3 python-py7zr python-pip python-cchardet
 
 useradd -m ci
 chown -R ci:users $GITHUB_WORKSPACE


### PR DESCRIPTION
This reverts commit b8d8cf27e290f75791679cb3bce3f250904f2367.

libraqm (an obscure PIL functionality) was recently switched to be directly linked by Pillow, rather than dlopened, which meant it was a bit of a hidden dependency since calibre uses the imagingft module. But it is now directly depended on by the Arch packaging, so it no longer needs to be installed to get a functional Pillow.