### PR TITLE
Fixed Gutenberg-store search issue (missing author names)

### DIFF
--- a/src/calibre/gui2/store/stores/gutenberg_plugin.py
+++ b/src/calibre/gui2/store/stores/gutenberg_plugin.py
@@ -52,7 +52,10 @@ def search(query, max_results=10, timeout=60, write_raw_to=None):
         a = next(CSSSelect('a.link', li))
         s.detail_item = absurl(a.get('href'))
         s.title = etree.tostring(next(CSSSelect('span.title', li)), method='text', encoding='unicode').strip()
-        s.author = etree.tostring(next(CSSSelect('span.subtitle', li)), method='text', encoding='unicode').strip()
+        try:
+            s.author = etree.tostring(next(CSSSelect('span.subtitle', li)), method='text', encoding='unicode').strip()
+        except StopIteration:
+            s.author = ""
         for img in CSSSelect('img.cover-thumb', li):
             s.cover_url = absurl(img.get('src'))
             break


### PR DESCRIPTION
Collected works may lack the author name field, and its HTML div. This
interrupted the search results processing.

For example, searching on title or author using "erasmus" yielded no or
two results out of 25 max.

- Title search now works as expected.
- Author search omits discussed results. Apparently at a later stage a
match is required between 's.author' and the query.