### PR TITLE
Add ASIN to MOBI EXTH header and metadata

### DIFF
--- a/src/calibre/ebooks/metadata/mobi.py
+++ b/src/calibre/ebooks/metadata/mobi.py
@@ -325,7 +325,7 @@ class MetadataUpdater(object):
             stop, = unpack('>I', self.data[offoff + 8:offoff + 12])
         return StreamSlicer(self.stream, start, stop)
 
-    def update(self, mi):
+    def update(self, mi, asin=None):
         mi.title = normalize(mi.title)
 
         def update_exth_record(rec):
@@ -399,6 +399,11 @@ class MetadataUpdater(object):
                 not added_501 and not share_not_sync):
             from uuid import uuid4
             update_exth_record((113, unicode_type(uuid4()).encode(self.codec)))
+
+        if asin is not None:
+            update_exth_record((113, asin.encode(self.codec)))
+            update_exth_record((504, asin.encode(self.codec)))
+
         # Add a 112 record with actual UUID
         if getattr(mi, 'uuid', None):
             update_exth_record((112,


### PR DESCRIPTION
This pull request adds two features:

1. Save ASIN from EXTH header to the 'mobi-asin' metadata.
2. Save ASIN to EXTH headers if the book's metadata has 'mobi-asin' record, this can be used by plugins to update a book's ASIN for Word Wise and X-Ray.