### PR TITLE
Filter read only device on macOS and add test of os.makedirs()

### DIFF
--- a/src/calibre/devices/usbms/device.py
+++ b/src/calibre/devices/usbms/device.py
@@ -424,6 +424,7 @@ class Device(DeviceConfig, DevicePlugin):
             return ans
         self._card_a_prefix = get_card_prefix('carda')
         self._card_b_prefix = get_card_prefix('cardb')
+        self.filter_read_only_mount_points()
 
     def find_device_nodes(self, detected_device=None):
 

--- a/src/calibre/devices/usbms/device.py
+++ b/src/calibre/devices/usbms/device.py
@@ -600,12 +600,12 @@ class Device(DeviceConfig, DevicePlugin):
             try:
                 with lopen(path, 'wb'):
                     ro = False
-            except:
+            except OSError:
                 pass
             else:
                 try:
                     os.remove(path)
-                except:
+                except OSError:
                     pass
             if DEBUG and ro:
                 print('\nThe mountpoint', mp, 'is readonly, ignoring it')

--- a/src/calibre/devices/usbms/device.py
+++ b/src/calibre/devices/usbms/device.py
@@ -597,15 +597,19 @@ class Device(DeviceConfig, DevicePlugin):
             if mp is None:
                 return True
             path = os.path.join(mp, 'calibre_readonly_test')
+            test_dir = os.path.join(mp, self.get_main_ebook_dir(),
+                                    'calibre, test')
             ro = True
             try:
                 with lopen(path, 'wb'):
+                    os.makedirs(test_dir)
                     ro = False
             except OSError:
                 pass
             else:
                 try:
                     os.remove(path)
+                    os.rmdir(test_dir)
                 except OSError:
                     pass
             if DEBUG and ro:


### PR DESCRIPTION
macOS seems to ignore the dirty bit in FAT and most of the time it works fine but last night I encountered an `OSError`(I/O error) at https://github.com/kovidgoyal/calibre/blob/43c70c10d07ec8a9fd8ecf1624c44685b8e41aaf/src/calibre/devices/usbms/device.py#L995

when I sent a book, so I think it would be nice to add the tests.