### PR TITLE
Use Pixel-Based Scrolling in the Main Library View

### DIFF
--- a/src/calibre/gui2/library/views.py
+++ b/src/calibre/gui2/library/views.py
@@ -227,6 +227,12 @@ class BooksView(QTableView):  # {{{
         QTableView.__init__(self, parent)
         self.pin_view = PinTableView(self, parent)
         self.gesture_manager = GestureManager(self)
+
+        self.setHorizontalScrollMode(QAbstractItemView.ScrollMode.ScrollPerPixel)
+        self.setVerticalScrollMode(QAbstractItemView.ScrollMode.ScrollPerPixel)
+        self.horizontalScrollBar().setSingleStep(1)
+        self.verticalScrollBar().setSingleStep(1)
+
         self.default_row_height = self.verticalHeader().defaultSectionSize()
         self.gui = parent
         self.setProperty('highlight_current_item', 150)


### PR DESCRIPTION
The fact that Qt defaults to `ScrollPerItem` is a perennial annoyance for me. The changes here allow the main library view to scroll smoothly, which is the norm on macOS.

(If you prefer `ScrollPerItem` on Windows and/or Linux, this change could probably be made Mac-only. I’m not sure what the norms are on Windows and on Linux.)

The scroll increment could probably stand to be finessed, and there are probably other places where smooth scrolling could be turned on.

(The righthand sidebar has smooth scrolling, but the lefthand sidebar does not. The main Preferences window has smooth scrolling, too. I’m not sure where else to check.)

I’m not sure how to rebase my merge request. It would be easiest if you have a bot that lets me just type `/rebase`.

Anyway, thoughts?