### PR TITLE
Fix haodoo reader to properly pick encoding in python3

### DIFF
--- a/src/calibre/ebooks/pdb/haodoo/reader.py
+++ b/src/calibre/ebooks/pdb/haodoo/reader.py
@@ -19,8 +19,8 @@ from calibre.ebooks.metadata import MetaInformation
 from calibre.ebooks.txt.processor import opf_writer, HTML_TEMPLATE
 from polyglot.builtins import range, map
 
-BPDB_IDENT = b'BOOKMTIT'
-UPDB_IDENT = b'BOOKMTIU'
+BPDB_IDENT = 'BOOKMTIT'
+UPDB_IDENT = 'BOOKMTIU'
 
 punct_table = {
     u"︵": u"（",


### PR DESCRIPTION
It was broken before because the comparison on line 94 would compare header.ident (a unicode string) to BPDB_IDENT (a byte string), which is not comparable in python3.