### PR TITLE
Fixed Pageup Occasionally Failing

### DIFF
--- a/src/pyj/read_book/paged_mode.pyj
+++ b/src/pyj/read_book/paged_mode.pyj
@@ -453,7 +453,7 @@ def previous_screen_location():
     if is_full_screen_layout:
         return -1
     cc = current_column_location()
-    ans = cc - screen_inline
+    ans = cc - cols_per_screen * col_and_gap
     if ans < 0:
         # We ignore small scrolls (less than 15px) when going to previous
         # screen


### PR DESCRIPTION
Before, pageup failed when the page margins were greater than half the
screen width, because previous_screen_location() went backward by
screen_inline, which did not account for the margins but worked most of
the time due to later rounding. Now this has been fixed.

Signed-off-by: Morgan Seltzer <MorganSeltzer000@gmail.com>