### PR TITLE
Fix ThrobbingButton init with Python 3.10

### DIFF
--- a/src/calibre/gui2/throbber.py
+++ b/src/calibre/gui2/throbber.py
@@ -33,7 +33,7 @@ class ThrobbingButton(QToolButton):
         QToolButton.setIcon(self, QIcon(I('donate.png')))
         self.setText('\xa0')
         self.animation = QPropertyAnimation(self, b'icon_size', self)
-        self.animation.setDuration(60/72.*1000)
+        self.animation.setDuration(int(60/72.*1000))
         self.animation.setLoopCount(4)
         self.animation.valueChanged.connect(self.value_changed)
         self.setCursor(Qt.CursorShape.PointingHandCursor)


### PR DESCRIPTION
It is no longer possible to pass floats to C functions where ints are expected, so explicitly convert to int in this case.