### PR TITLE
python 3.10: explicitly cast some numbers to int

### DIFF
--- a/src/calibre/gui2/__init__.py
+++ b/src/calibre/gui2/__init__.py
@@ -1221,7 +1221,7 @@ class Application(QApplication):
 
     def signal_received(self):
         try:
-            os.read(self.signal_notifier.socket(), 1024)
+            os.read(int(self.signal_notifier.socket()), 1024)
         except OSError:
             return
         self.shutdown_signal_received.emit()

--- a/src/calibre/gui2/library/alternate_views.py
+++ b/src/calibre/gui2/library/alternate_views.py
@@ -430,7 +430,7 @@ class CoverDelegate(QStyledItemDelegate):
             width = 0.75 * height
         else:
             width *= self.parent().logicalDpiX() * CM_TO_INCH
-        self.cover_size = QSize(width, height)
+        self.cover_size = QSize(int(width), int(height))
         self.title_height = 0
         if show_title:
             f = self.parent().font()

--- a/src/calibre/gui2/store/search/results_view.py
+++ b/src/calibre/gui2/store/search/results_view.py
@@ -31,7 +31,7 @@ class ImageDelegate(QStyledItemDelegate):
                 dpr = img.devicePixelRatio()
                 scaled, nw, nh = fit_image(img.width(), img.height(), w, h)
                 if scaled:
-                    img = img.scaled(nw*dpr, nh*dpr, Qt.AspectRatioMode.IgnoreAspectRatio, Qt.TransformationMode.SmoothTransformation)
+                    img = img.scaled(int(nw*dpr), int(nh*dpr), Qt.AspectRatioMode.IgnoreAspectRatio, Qt.TransformationMode.SmoothTransformation)
             iw, ih = int(img.width()/dpr), int(img.height()/dpr)
             dx, dy = (option.rect.width() - iw) // 2, (option.rect.height() - ih) // 2
             painter.drawPixmap(option.rect.adjusted(dx, dy, -dx, -dy), img)


### PR DESCRIPTION
These currently raise deprecation warnings, but will no longer get autoconverted in python 3.10

- Some Qt functions expect int, not float, and got truncated automatically.
- The QSocketNotifier is sip.voidptr wrapping an int file descriptor