### PR TITLE
remove references to deleted dbus code

### DIFF
--- a/src/calibre/gui2/preferences/main.py
+++ b/src/calibre/gui2/preferences/main.py
@@ -433,8 +433,6 @@ class Preferences(QDialog):
 
 if __name__ == '__main__':
     from calibre.gui2 import Application
-    from calibre.gui_launch import init_dbus
-    init_dbus()
     app = Application([])
     app
     gui = init_gui()


### PR DESCRIPTION
In commit 06847efbeef3fc52501222f8d7afcb19f9d853f2 the init_dbus function got removed due to not being needed in jeepney. But it still got imported and run in a manually launched `__main__` test.