### PR TITLE
Change MOBI EXTH cdeType metadata to EBOK if it's not EBOK

### DIFF
--- a/src/calibre/ebooks/metadata/mobi.py
+++ b/src/calibre/ebooks/metadata/mobi.py
@@ -395,7 +395,7 @@ class MetadataUpdater(object):
             update_exth_record((202, pack('>I', self.thumbnail_rindex)))
         # Add a 113 record if not present to allow Amazon syncing
         if (113 not in self.original_exth_records and
-                self.original_exth_records.get(501, None) == 'EBOK' and
+                self.original_exth_records.get(501, None) == b'EBOK' and
                 not added_501 and not share_not_sync):
             from uuid import uuid4
             update_exth_record((113, unicode_type(uuid4()).encode(self.codec)))
@@ -403,6 +403,8 @@ class MetadataUpdater(object):
         if asin is not None:
             update_exth_record((113, asin.encode(self.codec)))
             update_exth_record((504, asin.encode(self.codec)))
+            if self.original_exth_records.get(501) != b'EBOK':
+                update_exth_record((501, b'EBOK'))
 
         # Add a 112 record with actual UUID
         if getattr(mi, 'uuid', None):


### PR DESCRIPTION
Only EBOK type book can use Word Wise and X-Ray. If the book is a personal document or doesn't have a type, it would be meaningless to add the ASIN without changing the 501 record.