### PR TITLE
Split author field in xmp author metadata to keep consistency

### DIFF
--- a/src/calibre/ebooks/metadata/xmp.py
+++ b/src/calibre/ebooks/metadata/xmp.py
@@ -13,7 +13,7 @@ from lxml import etree
 from lxml.builder import ElementMaker
 
 from calibre import prints
-from calibre.ebooks.metadata import check_isbn, check_doi
+from calibre.ebooks.metadata import string_to_authors, check_isbn, check_doi
 from calibre.utils.xml_parse import safe_xml_fromstring
 from calibre.ebooks.metadata.book.base import Metadata
 from calibre.ebooks.metadata.opf2 import dump_dict
@@ -249,7 +249,7 @@ def metadata_from_xmp_packet(raw_bytes):
         mi.title = title
     authors = multiple_sequences('//dc:creator', root)
     if authors:
-        mi.authors = authors
+        mi.authors = [au for aus in authors for au in string_to_authors(aus)]
     tags = multiple_sequences('//dc:subject', root) or multiple_sequences('//pdf:Keywords', root)
     if tags:
         mi.tags = tags


### PR DESCRIPTION
A pdf contains xmp data like this:

```xml
<dc:creator>
  <rdf:Seq>
    <rdf:li>A</rdf:li>
    <rdf:li>B and C</rdf:li>
  </rdf:Seq>
</dc:creator>
```

This kind of less rigorous xmp data may cause a bug in calibre.

After add this book to db. I found:

- authors field in `books` table is `['A', 'B and C']`
- author in `authors` table is `['A', 'B', 'C']`

And the inconsistency can make this book **added multiple time without triggering duplicate**.

The `MetaInformation` to insert into `books` table is directly  provided by pdf plugin. But each author form  `MetaInformation` will process by [string_to_authors][] again before being inserted into `authors` table. See [calibre/cache.py#L1418](https://github.com/douo/calibre/blob/f6517cc81888fba2ddb668b6414cae177c25b77d/src/calibre/db/cache.py#L1418).

if [string_to_authors][] is always idempotent. I believe this fix can avoid this inconsistency.

[string_to_authors]: https://github.com/douo/calibre/blob/master/src/calibre/ebooks/metadata/__init__.py#L29