### PR TITLE
Fix custom series indicies being preserved when a custom series is …

### DIFF
--- a/src/calibre/db/tests/writing.py
+++ b/src/calibre/db/tests/writing.py
@@ -426,9 +426,6 @@ class WritingTest(BaseTest):
         self.compare_metadata(nmi, oldmi, exclude={'last_modified', 'format_metadata', 'formats'})
         cache.set_metadata(1, mi2, force_changes=True)
         nmi2 = cache.get_metadata(1, get_cover=True, cover_as_data=True)
-        # The new code does not allow setting of #series_index to None, instead
-        # it is reset to 1.0
-        ae(nmi2.get_extra('#series'), 1.0)
         self.compare_metadata(nmi2, oldmi2, exclude={'last_modified', 'format_metadata', '#series_index', 'formats'})
 
         cache = self.init_cache(self.cloned_library)

--- a/src/calibre/db/write.py
+++ b/src/calibre/db/write.py
@@ -239,7 +239,10 @@ def custom_series_index(book_id_val_map, db, field, *args):
         ids = series_field.ids_for_book(book_id)
         if ids:
             sequence.append((sidx, book_id, ids[0]))
-        field.table.book_col_map[book_id] = sidx
+        if series_field.table.book_col_map.get(book_id) is None:
+            field.table.book_col_map.pop(book_id, None)
+        else:
+            field.table.book_col_map[book_id] = sidx
     if sequence:
         db.executemany('UPDATE %s SET %s=? WHERE book=? AND value=?'%(
                 field.metadata['table'], field.metadata['column']), sequence)


### PR DESCRIPTION
…cleared, making the column sort correctly. The problem is that the series index is still in the table cache for a book after the series is removed.

See https://www.mobileread.com/forums/showthread.php?p=4142361#post4142361

I freely confess that this might not be the best fix. :)