### PR TITLE
Add a change event test setting an already empty many-many field …

### DIFF
--- a/src/calibre/db/tests/writing.py
+++ b/src/calibre/db/tests/writing.py
@@ -871,6 +871,14 @@ class WritingTest(BaseTest):
         cache.set_field('tags', {1:'foo', 2:'bar', 3:'mumble'})
         ae(event_set, {2, 3})
 
+        # test setting a many-many field to empty
+        event_set = set()
+        cache.set_field('tags', {1:''})
+        ae(event_set, {1,})
+        event_set = set()
+        cache.set_field('tags', {1:''})
+        ae(event_set, set())
+
         # test setting title
         event_set = set()
         cache.set_field('title', {1:'Book 1'})


### PR DESCRIPTION
…(tags) to empty.

This test would have failed without the fix d455406