### PR TITLE
Suppress BrokenPipeError in logging

### DIFF
--- a/src/calibre/utils/logging.py
+++ b/src/calibre/utils/logging.py
@@ -31,7 +31,11 @@ class Stream(object):
         self._prints(text, end='')
 
     def flush(self):
-        self.stream.flush()
+        try:
+            self.stream.flush()
+        except BrokenPipeError:
+            # Don't make any fuss if we were logging to a pipe and it got closed
+            pass
 
     def prints(self, level, *args, **kwargs):
         self._prints(*args, **kwargs)
@@ -60,9 +64,6 @@ class ANSIStream(Stream):
         from calibre.utils.terminal import ColoredStream
         with ColoredStream(self.stream, self.color[level]):
             self._prints(*args, **kwargs)
-
-    def flush(self):
-        self.stream.flush()
 
 
 class FileStream(Stream):
@@ -93,9 +94,6 @@ class HTMLStream(Stream):
         self._prints(self.color[level], end='')
         self._prints(*args, **kwargs)
         self._prints(self.normal, end='')
-
-    def flush(self):
-        self.stream.flush()
 
 
 class UnicodeHTMLStream(HTMLStream):


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1903583 sports the following traceback:
```
Traceback (most recent call last):
  File "/usr/bin/ebook-convert", line 20, in <module>
    sys.exit(main())
  File "/usr/lib64/calibre/calibre/ebooks/conversion/cli.py", line 401, in main
    plumber.run()
  File "/usr/lib64/calibre/calibre/ebooks/conversion/plumber.py", line 1135, in run
    pr(0., _('Running transforms on e-book...'))
  File "/usr/lib64/calibre/calibre/ebooks/conversion/plumber.py", line 67, in __call__
    self.global_reporter(global_frac, msg)
  File "/usr/lib64/calibre/calibre/ebooks/conversion/cli.py", line 288, in __call__
    self.log('%d%% %s'%(percent, msg))
  File "/usr/lib64/calibre/calibre/utils/logging.py", line 179, in __call__
    self.info(*args, **kwargs)
  File "/usr/lib64/calibre/calibre/utils/logging.py", line 171, in print_with_flush
    self.flush()
  File "/usr/lib64/calibre/calibre/utils/logging.py", line 191, in flush
    o.flush()
  File "/usr/lib64/calibre/calibre/utils/logging.py", line 53, in flush
    self.stream.flush()
BrokenPipeError: [Errno 32] Datenübergabe unterbrochen (broken pipe)
```
If logging fails because somebody closed the output pipe, this is not an error.
Let's just ignore this this silently.

I removed the two .flush() implementations because those two classes inherit
from Stream.