### PR TITLE
Drop (object) from class definitions

### DIFF
--- a/bypy/linux/__main__.py
+++ b/bypy/linux/__main__.py
@@ -58,7 +58,7 @@ def binary_includes():
     ] + list(map(qt_get_dll_path, QT_DLLS))
 
 
-class Env(object):
+class Env:
 
     def __init__(self):
         self.src_root = CALIBRE_DIR

--- a/bypy/macos/__main__.py
+++ b/bypy/macos/__main__.py
@@ -146,7 +146,7 @@ def flush(func):
     return ff
 
 
-class Freeze(object):
+class Freeze:
 
     FID = '@executable_path/../Frameworks'
 

--- a/bypy/windows/__main__.py
+++ b/bypy/windows/__main__.py
@@ -98,7 +98,7 @@ def run_compiler(env, *cmd):
     run(*cmd, cwd=env.obj_dir)
 
 
-class Env(object):
+class Env:
 
     def __init__(self, build_dir):
         self.python_base = os.path.join(PREFIX, 'private', 'python')

--- a/recipes/metro_news_nl.recipe
+++ b/recipes/metro_news_nl.recipe
@@ -162,7 +162,7 @@ class MerryExtract():
         return killingSoup
 
 
-class MerryProcess(object):
+class MerryProcess:
     myKiller = MerryExtract()
     myPrepare = MerryPreProcess()
 

--- a/setup/__init__.py
+++ b/setup/__init__.py
@@ -165,7 +165,7 @@ def edit_file(path):
     ]).wait() == 0
 
 
-class Command(object):
+class Command:
 
     SRC = SRC
     RESOURCES = os.path.join(os.path.dirname(SRC), 'resources')

--- a/setup/build.py
+++ b/setup/build.py
@@ -31,7 +31,7 @@ def absolutize(paths):
     return list(set([x if os.path.isabs(x) else os.path.join(SRC, x.replace('/', os.sep)) for x in paths]))
 
 
-class Extension(object):
+class Extension:
 
     def __init__(self, name, sources, **kwargs):
         self.data = d = {}

--- a/setup/hosting.py
+++ b/setup/hosting.py
@@ -69,7 +69,7 @@ class ReadFileWithProgressReporting:  # {{{
 # }}}
 
 
-class Base(object):  # {{{
+class Base:  # {{{
 
     def __init__(self):
         self.d = os.path.dirname

--- a/setup/plugins_mirror.py
+++ b/setup/plugins_mirror.py
@@ -194,7 +194,7 @@ def convert_node(fields, x, names={}, import_data=None):
 Alias = namedtuple('Alias', 'name asname')
 
 
-class Module(object):
+class Module:
     pass
 
 

--- a/setup/translations.py
+++ b/setup/translations.py
@@ -369,7 +369,7 @@ class Translations(POT):  # {{{
 
     def auto_fix_iso639_files(self, files):
 
-        class Fix(object):
+        class Fix:
 
             def __init__(self):
                 self.seen = set()
@@ -391,7 +391,7 @@ class Translations(POT):  # {{{
                     self.seen.add(msgstr)
                 return match.group()
 
-        class Fix2(object):
+        class Fix2:
 
             def __init__(self, fix1):
                 self.bad = fix1.bad

--- a/src/calibre/__init__.py
+++ b/src/calibre/__init__.py
@@ -358,7 +358,7 @@ def fit_image(width, height, pwidth, pheight):
     return scaled, int(width), int(height)
 
 
-class CurrentDir(object):
+class CurrentDir:
 
     def __init__(self, path):
         self.path = path

--- a/src/calibre/customize/__init__.py
+++ b/src/calibre/customize/__init__.py
@@ -30,7 +30,7 @@ class PluginInstallationType(enum.IntEnum):
     BUILTIN = 3
 
 
-class Plugin(object):  # {{{
+class Plugin:  # {{{
     '''
     A calibre plugin. Useful members include:
 

--- a/src/calibre/customize/conversion.py
+++ b/src/calibre/customize/conversion.py
@@ -10,7 +10,7 @@ from calibre.customize import Plugin
 from polyglot.builtins import unicode_type
 
 
-class ConversionOption(object):
+class ConversionOption:
 
     '''
     Class representing conversion options
@@ -50,7 +50,7 @@ class ConversionOption(object):
                 choices=self.choices)
 
 
-class OptionRecommendation(object):
+class OptionRecommendation:
     LOW  = 1
     MED  = 2
     HIGH = 3
@@ -86,7 +86,7 @@ class OptionRecommendation(object):
                 self.recommended_value) + ' is not a string or a number')
 
 
-class DummyReporter(object):
+class DummyReporter:
 
     def __init__(self):
         self.cancel_requested = False

--- a/src/calibre/customize/ui.py
+++ b/src/calibre/customize/ui.py
@@ -373,7 +373,7 @@ def metadata_writers():
     return ans
 
 
-class QuickMetadata(object):
+class QuickMetadata:
 
     def __init__(self):
         self.quick = False
@@ -388,7 +388,7 @@ class QuickMetadata(object):
 quick_metadata = QuickMetadata()
 
 
-class ApplyNullMetadata(object):
+class ApplyNullMetadata:
 
     def __init__(self):
         self.apply_null = False
@@ -403,7 +403,7 @@ class ApplyNullMetadata(object):
 apply_null_metadata = ApplyNullMetadata()
 
 
-class ForceIdentifiers(object):
+class ForceIdentifiers:
 
     def __init__(self):
         self.force_identifiers = False

--- a/src/calibre/db/backend.py
+++ b/src/calibre/db/backend.py
@@ -70,7 +70,7 @@ CUSTOM_DATA_TYPES = frozenset(('rating', 'text', 'comments', 'datetime',
 WINDOWS_RESERVED_NAMES = frozenset('CON PRN AUX NUL COM1 COM2 COM3 COM4 COM5 COM6 COM7 COM8 COM9 LPT1 LPT2 LPT3 LPT4 LPT5 LPT6 LPT7 LPT8 LPT9'.split())
 
 
-class DynamicFilter(object):  # {{{
+class DynamicFilter:  # {{{
 
     'No longer used, present for legacy compatibility'
 
@@ -410,7 +410,7 @@ def rmtree_with_retry(path, sleep_time=1):
         shutil.rmtree(path)
 
 
-class DB(object):
+class DB:
 
     PATH_LIMIT = 40 if iswindows else 100
     WINDOWS_LIBRARY_PATH_LIMIT = 75

--- a/src/calibre/db/cache.py
+++ b/src/calibre/db/cache.py
@@ -126,7 +126,7 @@ def _add_default_custom_column_values(mi, fm):
 dynamic_category_preferences = frozenset({'grouped_search_make_user_categories', 'grouped_search_terms', 'user_categories'})
 
 
-class Cache(object):
+class Cache:
 
     '''
     An in-memory cache of the metadata.db file from a calibre library.
@@ -1069,7 +1069,7 @@ class Cache(object):
         orders = tuple(1 if order else -1 for _, order in fields)
         Lazy = object()  # Lazy load the sort keys for sub-sort fields
 
-        class SortKey(object):
+        class SortKey:
 
             __slots__ = 'book_id', 'sort_key'
 

--- a/src/calibre/db/categories.py
+++ b/src/calibre/db/categories.py
@@ -17,7 +17,7 @@ from calibre.utils.icu import sort_key, collation_order
 CATEGORY_SORTS = ('name', 'popularity', 'rating')  # This has to be a tuple not a set
 
 
-class Tag(object):
+class Tag:
 
     __slots__ = ('name', 'original_name', 'id', 'count', 'state', 'is_hierarchical',
             'is_editable', 'is_searchable', 'id_set', 'avg_rating', 'sort',

--- a/src/calibre/db/cli/cmd_backup_metadata.py
+++ b/src/calibre/db/cli/cmd_backup_metadata.py
@@ -42,7 +42,7 @@ automatically, every time metadata is changed.
     return parser
 
 
-class BackupProgress(object):
+class BackupProgress:
 
     def __init__(self):
         self.total = 0

--- a/src/calibre/db/cli/cmd_export.py
+++ b/src/calibre/db/cli/cmd_export.py
@@ -101,7 +101,7 @@ an opf file). You can get id numbers from the search command.
     return parser
 
 
-class DBProxy(object):
+class DBProxy:
 
     # Proxy to allow do_save_book_to_disk() to work with remote database
 

--- a/src/calibre/db/cli/cmd_restore_database.py
+++ b/src/calibre/db/cli/cmd_restore_database.py
@@ -46,7 +46,7 @@ what is found in the OPF files.
     return parser
 
 
-class Progress(object):
+class Progress:
 
     def __init__(self):
         self.total = 1

--- a/src/calibre/db/cli/main.py
+++ b/src/calibre/db/cli/main.py
@@ -125,7 +125,7 @@ def read_credentials(opts):
     return username, pw
 
 
-class DBCtx(object):
+class DBCtx:
 
     def __init__(self, opts):
         self.library_path = opts.library_path or prefs['library_path']

--- a/src/calibre/db/cli/tests.py
+++ b/src/calibre/db/cli/tests.py
@@ -16,7 +16,7 @@ from polyglot.builtins import iteritems
 from polyglot.io import PolyglotBytesIO
 
 
-class Checker(object):
+class Checker:
 
     def __init__(self, kw):
         for k, v in iteritems(kw):

--- a/src/calibre/db/fields.py
+++ b/src/calibre/db/fields.py
@@ -39,7 +39,7 @@ class InvalidLinkTable(Exception):
         self.field_name = name
 
 
-class Field(object):
+class Field:
 
     is_many = False
     is_many_many = False
@@ -441,7 +441,7 @@ class OnDeviceField(OneToOneField):
             yield val, book_ids
 
 
-class LazySortMap(object):
+class LazySortMap:
 
     __slots__ = ('default_sort_key', 'sort_key_func', 'id_map', 'cache')
 
@@ -666,7 +666,7 @@ class FormatsField(ManyToManyField):
         return ans
 
 
-class LazySeriesSortMap(object):
+class LazySeriesSortMap:
 
     __slots__ = ('default_sort_key', 'sort_key_func', 'id_map', 'cache')
 

--- a/src/calibre/db/lazy.py
+++ b/src/calibre/db/lazy.py
@@ -34,7 +34,7 @@ def resolved(f):
     return wrapper
 
 
-class MutableBase(object):
+class MutableBase:
 
     @resolved
     def __str__(self):

--- a/src/calibre/db/legacy.py
+++ b/src/calibre/db/legacy.py
@@ -161,7 +161,7 @@ class ThreadSafePrefs(MutableMapping):
         return json.loads(raw, object_hook=from_json)
 
 
-class LibraryDatabase(object):
+class LibraryDatabase:
 
     ''' Emulate the old LibraryDatabase2 interface '''
 

--- a/src/calibre/db/locking.py
+++ b/src/calibre/db/locking.py
@@ -62,7 +62,7 @@ def create_locks():
     return wrapper(l), wrapper(l, is_shared=False)
 
 
-class SHLock(object):  # {{{
+class SHLock:  # {{{
     '''
     Shareable lock class. Used to implement the Multiple readers-single writer
     paradigm. As best as I can tell, neither writer nor reader starvation
@@ -222,7 +222,7 @@ class SHLock(object):  # {{{
 # }}}
 
 
-class RWLockWrapper(object):
+class RWLockWrapper:
 
     def __init__(self, shlock, is_shared=True):
         self._shlock = shlock
@@ -266,7 +266,7 @@ class DebugRWLockWrapper(RWLockWrapper):
     __exit__ = release
 
 
-class SafeReadLock(object):
+class SafeReadLock:
 
     def __init__(self, read_lock):
         self.read_lock = read_lock

--- a/src/calibre/db/schema_upgrades.py
+++ b/src/calibre/db/schema_upgrades.py
@@ -13,7 +13,7 @@ from calibre.utils.date import isoformat, DEFAULT_DATE
 from polyglot.builtins import itervalues, unicode_type
 
 
-class SchemaUpgrade(object):
+class SchemaUpgrade:
 
     def __init__(self, db, library_path, field_metadata):
         db.execute('BEGIN EXCLUSIVE TRANSACTION')

--- a/src/calibre/db/search.py
+++ b/src/calibre/db/search.py
@@ -87,7 +87,7 @@ def _match(query, value, matchkind, use_primary_find_in_search=True, case_sensit
 # }}}
 
 
-class DateSearch(object):  # {{{
+class DateSearch:  # {{{
 
     def __init__(self):
         self.operators = OrderedDict((
@@ -212,7 +212,7 @@ class DateSearch(object):  # {{{
 # }}}
 
 
-class NumericSearch(object):  # {{{
+class NumericSearch:  # {{{
 
     def __init__(self):
         self.operators = OrderedDict((
@@ -305,7 +305,7 @@ class NumericSearch(object):  # {{{
 # }}}
 
 
-class BooleanSearch(object):  # {{{
+class BooleanSearch:  # {{{
 
     def __init__(self):
         self.local_no        = icu_lower(_('no'))
@@ -347,7 +347,7 @@ class BooleanSearch(object):  # {{{
 # }}}
 
 
-class KeyPairSearch(object):  # {{{
+class KeyPairSearch:  # {{{
 
     def __call__(self, query, field_iter, candidates, use_primary_find):
         matches = set()
@@ -388,7 +388,7 @@ class KeyPairSearch(object):  # {{{
 # }}}
 
 
-class SavedSearchQueries(object):  # {{{
+class SavedSearchQueries:  # {{{
     queries = {}
     opt_name = ''
 
@@ -794,7 +794,7 @@ class Parser(SearchQueryParser):  # {{{
 # }}}
 
 
-class LRUCache(object):  # {{{
+class LRUCache:  # {{{
 
     'A simple Least-Recently-Used cache'
 
@@ -851,7 +851,7 @@ class LRUCache(object):  # {{{
 # }}}
 
 
-class Search(object):
+class Search:
 
     MAX_CACHE_UPDATE = 50
 

--- a/src/calibre/db/tables.py
+++ b/src/calibre/db/tables.py
@@ -47,7 +47,7 @@ ONE_ONE, MANY_ONE, MANY_MANY = range(3)
 null = object()
 
 
-class Table(object):
+class Table:
 
     def __init__(self, name, metadata, link_table=None):
         self.name, self.metadata = name, metadata

--- a/src/calibre/db/tests/legacy.py
+++ b/src/calibre/db/tests/legacy.py
@@ -18,7 +18,7 @@ from polyglot import reprlib
 # Utils {{{
 
 
-class ET(object):
+class ET:
 
     def __init__(self, func_name, args, kwargs={}, old=None, legacy=None):
         self.func_name = func_name

--- a/src/calibre/db/utils.py
+++ b/src/calibre/db/utils.py
@@ -102,7 +102,7 @@ class CacheError(Exception):
     pass
 
 
-class ThumbnailCache(object):
+class ThumbnailCache:
 
     ' This is a persistent disk cache to speed up loading and resizing of covers '
 

--- a/src/calibre/db/view.py
+++ b/src/calibre/db/view.py
@@ -23,7 +23,7 @@ def sanitize_sort_field_name(field_metadata, field):
     return field
 
 
-class MarkedVirtualField(object):
+class MarkedVirtualField:
 
     def __init__(self, marked_ids):
         self.marked_ids = marked_ids
@@ -37,7 +37,7 @@ class MarkedVirtualField(object):
         return lambda book_id:g(book_id, '')
 
 
-class TableRow(object):
+class TableRow:
 
     def __init__(self, book_id, view):
         self.book_id = book_id
@@ -74,7 +74,7 @@ def format_identifiers(x):
     return ','.join('%s:%s'%(k, v) for k, v in iteritems(x))
 
 
-class View(object):
+class View:
 
     ''' A table view of the database, with rows and columns. Also supports
     filtering and sorting.  '''

--- a/src/calibre/db/write.py
+++ b/src/calibre/db/write.py
@@ -530,7 +530,7 @@ def dummy(book_id_val_map, *args):
     return set()
 
 
-class Writer(object):
+class Writer:
 
     def __init__(self, field):
         self.adapter = get_adapter(field.name, field.metadata)

--- a/src/calibre/devices/cli.py
+++ b/src/calibre/devices/cli.py
@@ -23,7 +23,7 @@ from polyglot.io import PolyglotStringIO
 MINIMUM_COL_WIDTH = 12  # : Minimum width of columns in ls output
 
 
-class FileFormatter(object):
+class FileFormatter:
 
     def __init__(self, file):
         self.is_dir      = file.is_dir

--- a/src/calibre/devices/interface.py
+++ b/src/calibre/devices/interface.py
@@ -767,7 +767,7 @@ class BookList(list):
         raise NotImplementedError()
 
 
-class CurrentlyConnectedDevice(object):
+class CurrentlyConnectedDevice:
 
     def __init__(self):
         self._device = None

--- a/src/calibre/devices/kindle/apnx.py
+++ b/src/calibre/devices/kindle/apnx.py
@@ -21,7 +21,7 @@ from calibre.constants import DEBUG
 from polyglot.builtins import range, as_unicode, as_bytes, unicode_type, map
 
 
-class APNXBuilder(object):
+class APNXBuilder:
     '''
     Create an APNX file using a pseudo page mapping.
     '''

--- a/src/calibre/devices/kobo/books.py
+++ b/src/calibre/devices/kobo/books.py
@@ -120,7 +120,7 @@ class Book(Book_):
         return super(Book,self).__str__() + "\n" + ans
 
 
-class ImageWrapper(object):
+class ImageWrapper:
 
     def __init__(self, image_path):
         self.image_path = image_path

--- a/src/calibre/devices/kobo/driver.py
+++ b/src/calibre/devices/kobo/driver.py
@@ -68,7 +68,7 @@ def any_in(haystack, *needles):
     return False
 
 
-class DummyCSSPreProcessor(object):
+class DummyCSSPreProcessor:
 
     def __call__(self, data, add_namespace=False):
 

--- a/src/calibre/devices/mtp/defaults.py
+++ b/src/calibre/devices/mtp/defaults.py
@@ -12,7 +12,7 @@ from calibre.constants import iswindows
 from polyglot.builtins import iteritems
 
 
-class DeviceDefaults(object):
+class DeviceDefaults:
 
     def __init__(self):
         self.rules = (

--- a/src/calibre/devices/mtp/driver.py
+++ b/src/calibre/devices/mtp/driver.py
@@ -535,7 +535,7 @@ class MTP_DEVICE(BASE):
         cw.commit()
 
     def settings(self):
-        class Opts(object):
+        class Opts:
 
             def __init__(s):
                 s.format_map = self.get_pref('format_map')

--- a/src/calibre/devices/mtp/filesystem_cache.py
+++ b/src/calibre/devices/mtp/filesystem_cache.py
@@ -20,7 +20,7 @@ from calibre.ebooks import BOOK_EXTENSIONS
 bexts = frozenset(BOOK_EXTENSIONS) - {'mbp', 'tan', 'rar', 'zip', 'xml'}
 
 
-class FileOrFolder(object):
+class FileOrFolder:
 
     def __init__(self, entry, fs_cache):
         self.all_storage_ids = fs_cache.all_storage_ids
@@ -181,7 +181,7 @@ class FileOrFolder(object):
         return 'mtp:::' + json.dumps(self.object_id) + ':::' + '/'.join(self.full_path)
 
 
-class FilesystemCache(object):
+class FilesystemCache:
 
     def __init__(self, all_storage, entries):
         self.entries = []

--- a/src/calibre/devices/mtp/test.py
+++ b/src/calibre/devices/mtp/test.py
@@ -15,7 +15,7 @@ from calibre.devices.scanner import DeviceScanner
 from polyglot.builtins import range
 
 
-class ProgressCallback(object):
+class ProgressCallback:
 
     def __init__(self):
         self.count = 0

--- a/src/calibre/devices/mtp/unix/sysfs.py
+++ b/src/calibre/devices/mtp/unix/sysfs.py
@@ -9,7 +9,7 @@ __docformat__ = 'restructuredtext en'
 import os, glob
 
 
-class MTPDetect(object):
+class MTPDetect:
 
     SYSFS_PATH = os.environ.get('SYSFS_PATH', '/sys')
 

--- a/src/calibre/devices/paladin/driver.py
+++ b/src/calibre/devices/paladin/driver.py
@@ -18,7 +18,7 @@ from calibre.devices.usbms.books import CollectionsBookList, BookList
 DBPATH = 'paladin/database/books.db'
 
 
-class ImageWrapper(object):
+class ImageWrapper:
 
     def __init__(self, image_path):
         self.image_path = image_path

--- a/src/calibre/devices/prs505/sony_cache.py
+++ b/src/calibre/devices/prs505/sony_cache.py
@@ -89,7 +89,7 @@ def uuid():
 # }}}
 
 
-class XMLCache(object):
+class XMLCache:
 
     def __init__(self, paths, ext_paths, prefixes, use_author_sort):
         from calibre.utils.xml_parse import safe_xml_fromstring

--- a/src/calibre/devices/prst1/driver.py
+++ b/src/calibre/devices/prst1/driver.py
@@ -29,7 +29,7 @@ DBPATH = 'Sony_Reader/database/books.db'
 THUMBPATH = 'Sony_Reader/database/cache/books/%s/thumbnail/main_thumbnail.jpg'
 
 
-class ImageWrapper(object):
+class ImageWrapper:
 
     def __init__(self, image_path):
         self.image_path = image_path

--- a/src/calibre/devices/scanner.py
+++ b/src/calibre/devices/scanner.py
@@ -56,7 +56,7 @@ class USBDevice(_USBDevice):
     __unicode__ = __repr__
 
 
-class LibUSBScanner(object):
+class LibUSBScanner:
 
     def __call__(self):
         if not hasattr(self, 'libusb'):
@@ -93,7 +93,7 @@ class LibUSBScanner(object):
             print('after', num, 'repeats')
 
 
-class LinuxScanner(object):
+class LinuxScanner:
 
     SYSFS_PATH = os.environ.get('SYSFS_PATH', '/sys')
 
@@ -178,7 +178,7 @@ if isnetbsd:
     netbsd_scanner = None
 
 
-class DeviceScanner(object):
+class DeviceScanner:
 
     def __init__(self, *args):
         if iswindows:

--- a/src/calibre/devices/usbms/cli.py
+++ b/src/calibre/devices/usbms/cli.py
@@ -12,7 +12,7 @@ from calibre.devices.errors import PathError
 from calibre.utils.filenames import case_preserving_open_file
 
 
-class File(object):
+class File:
 
     def __init__(self, path):
         stats = os.stat(path)
@@ -33,7 +33,7 @@ def check_transfer(infile, dest):
     return infile.read() == dest.read()
 
 
-class CLI(object):
+class CLI:
 
     def get_file(self, path, outfile, end_session=True):
         path = self.munge_path(path)

--- a/src/calibre/devices/usbms/deviceconfig.py
+++ b/src/calibre/devices/usbms/deviceconfig.py
@@ -9,7 +9,7 @@ from calibre.utils.config_base import Config, ConfigProxy
 from polyglot.builtins import unicode_type
 
 
-class DeviceConfig(object):
+class DeviceConfig:
 
     HELP_MESSAGE = _('Configure Device')
 

--- a/src/calibre/devices/winusb.py
+++ b/src/calibre/devices/winusb.py
@@ -443,7 +443,7 @@ def devid_pat():
     return _devid_pat
 
 
-class DeviceSet(object):
+class DeviceSet:
 
     def __init__(self, guid=GUID_DEVINTERFACE_VOLUME, enumerator=None, flags=DIGCF_PRESENT | DIGCF_DEVICEINTERFACE):
         self.guid_ref, self.enumerator, self.flags = (None if guid is None else byref(guid)), enumerator, flags

--- a/src/calibre/ebooks/chardet.py
+++ b/src/calibre/ebooks/chardet.py
@@ -26,7 +26,7 @@ def compile_pats(binary):
         yield re.compile(raw, flags=re.IGNORECASE)
 
 
-class LazyEncodingPats(object):
+class LazyEncodingPats:
 
     def __call__(self, binary=False):
         attr = 'binary_pats' if binary else 'unicode_pats'

--- a/src/calibre/ebooks/comic/input.py
+++ b/src/calibre/ebooks/comic/input.py
@@ -223,7 +223,7 @@ def render_pages(tasks, dest, opts, notification=lambda x, y: x):
     return pages, failures
 
 
-class Progress(object):
+class Progress:
 
     def __init__(self, total, update):
         self.total  = total

--- a/src/calibre/ebooks/compression/tcr.py
+++ b/src/calibre/ebooks/compression/tcr.py
@@ -9,7 +9,7 @@ import re
 from polyglot.builtins import int_to_byte, range
 
 
-class TCRCompressor(object):
+class TCRCompressor:
     '''
     TCR compression takes the form header+code_dict+coded_text.
     The header is always "!!8-Bit!!". The code dict is a list of 256 strings.

--- a/src/calibre/ebooks/conversion/cli.py
+++ b/src/calibre/ebooks/conversion/cli.py
@@ -277,7 +277,7 @@ def option_parser():
     return parser
 
 
-class ProgressBar(object):
+class ProgressBar:
 
     def __init__(self, log):
         self.log = log

--- a/src/calibre/ebooks/conversion/plugins/lrf_output.py
+++ b/src/calibre/ebooks/conversion/plugins/lrf_output.py
@@ -13,7 +13,7 @@ from calibre.customize.conversion import OptionRecommendation
 from polyglot.builtins import unicode_type
 
 
-class LRFOptions(object):
+class LRFOptions:
 
     def __init__(self, output, opts, oeb):
         def f2s(f):

--- a/src/calibre/ebooks/conversion/plugins/snb_output.py
+++ b/src/calibre/ebooks/conversion/plugins/snb_output.py
@@ -255,7 +255,7 @@ if __name__ == '__main__':
     from calibre.ebooks.conversion.preprocess import HTMLPreProcessor
     from calibre.customize.profiles import HanlinV3Output
 
-    class OptionValues(object):
+    class OptionValues:
         pass
 
     opts = OptionValues()

--- a/src/calibre/ebooks/conversion/plumber.py
+++ b/src/calibre/ebooks/conversion/plumber.py
@@ -51,11 +51,11 @@ def supported_input_formats():
     return fmts
 
 
-class OptionValues(object):
+class OptionValues:
     pass
 
 
-class CompositeProgressReporter(object):
+class CompositeProgressReporter:
 
     def __init__(self, global_min, global_max, global_reporter):
         self.global_min, self.global_max = global_min, global_max
@@ -70,7 +70,7 @@ class CompositeProgressReporter(object):
 ARCHIVE_FMTS = ('zip', 'rar', 'oebzip')
 
 
-class Plumber(object):
+class Plumber:
 
     '''
     The `Plumber` manages the conversion pipeline. An UI should call the methods

--- a/src/calibre/ebooks/conversion/preprocess.py
+++ b/src/calibre/ebooks/conversion/preprocess.py
@@ -86,7 +86,7 @@ def smarten_punctuation(html, log=None):
     return substitute_entites(html)
 
 
-class DocAnalysis(object):
+class DocAnalysis:
     '''
     Provides various text analysis functions to determine how the document is structured.
     format is the type of document analysis will be done against.
@@ -191,7 +191,7 @@ class DocAnalysis(object):
             return True
 
 
-class Dehyphenator(object):
+class Dehyphenator:
     '''
     Analyzes words to determine whether hyphens should be retained/removed.  Uses the document
     itself is as a dictionary. This method handles all languages along with uncommon, made-up, and
@@ -299,7 +299,7 @@ class Dehyphenator(object):
         return html
 
 
-class CSSPreProcessor(object):
+class CSSPreProcessor:
 
     # Remove some of the broken CSS Microsoft products
     # create
@@ -455,7 +455,7 @@ def book_designer_rules():
     return ans
 
 
-class HTMLPreProcessor(object):
+class HTMLPreProcessor:
 
     def __init__(self, log=None, extra_opts=None, regex_wizard_callback=None):
         self.log = log

--- a/src/calibre/ebooks/conversion/utils.py
+++ b/src/calibre/ebooks/conversion/utils.py
@@ -14,7 +14,7 @@ from calibre.utils.wordcount import get_wordcount_obj
 from polyglot.builtins import unicode_type
 
 
-class HeuristicProcessor(object):
+class HeuristicProcessor:
 
     def __init__(self, extra_opts=None, log=None):
         self.log = default_log if log is None else log

--- a/src/calibre/ebooks/covers.py
+++ b/src/calibre/ebooks/covers.py
@@ -126,7 +126,7 @@ def parse_text_formatting(text):
     return text, formats
 
 
-class Block(object):
+class Block:
 
     def __init__(self, text='', width=0, font=None, img=None, max_height=100, align=Qt.AlignmentFlag.AlignCenter):
         self.layouts = []
@@ -340,7 +340,7 @@ def color(color_theme, name):
 # Styles {{{
 
 
-class Style(object):
+class Style:
 
     TITLE_ALIGN = SUBTITLE_ALIGN = FOOTER_ALIGN = Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignTop
 

--- a/src/calibre/ebooks/css_transform_rules.py
+++ b/src/calibre/ebooks/css_transform_rules.py
@@ -29,7 +29,7 @@ def all_properties(decl):
             yield p
 
 
-class StyleDeclaration(object):
+class StyleDeclaration:
 
     def __init__(self, css_declaration):
         self.css_declaration = css_declaration
@@ -164,7 +164,7 @@ def transform_number(val, op, raw):
     return unicode_type(v) + u
 
 
-class Rule(object):
+class Rule:
 
     def __init__(self, property='color', match_type='*', query='', action='remove', action_data=''):
         self.property_name = property.lower()

--- a/src/calibre/ebooks/djvu/djvu.py
+++ b/src/calibre/ebooks/djvu/djvu.py
@@ -16,7 +16,7 @@ import struct
 from calibre.ebooks.djvu.djvubzzdec import BZZDecoder
 
 
-class DjvuChunk(object):
+class DjvuChunk:
 
     def __init__(self, buf, start, end, align=True, bigendian=True,
             inclheader=False, verbose=0):
@@ -105,7 +105,7 @@ class DjvuChunk(object):
             schunk.dump(verbose=verbose, indent=indent+1, out=out, txtout=txtout)
 
 
-class DJVUFile(object):
+class DJVUFile:
 
     def __init__(self, instream, verbose=0):
         self.instream = instream

--- a/src/calibre/ebooks/docx/block_styles.py
+++ b/src/calibre/ebooks/docx/block_styles.py
@@ -10,7 +10,7 @@ from collections import OrderedDict
 from polyglot.builtins import iteritems
 
 
-class Inherit(object):
+class Inherit:
 
     def __eq__(self, other):
         return other is self
@@ -250,7 +250,7 @@ def read_numbering(parent, dest, XPath, get):
     setattr(dest, 'numbering_level', lvl)
 
 
-class Frame(object):
+class Frame:
 
     all_attributes = ('drop_cap', 'h', 'w', 'h_anchor', 'h_rule', 'v_anchor', 'wrap',
                       'h_space', 'v_space', 'lines', 'x_align', 'y_align', 'x', 'y')
@@ -337,7 +337,7 @@ def read_frame(parent, dest, XPath, get):
 # }}}
 
 
-class ParagraphStyle(object):
+class ParagraphStyle:
 
     all_properties = (
         'adjustRightInd', 'autoSpaceDE', 'autoSpaceDN', 'bidi',

--- a/src/calibre/ebooks/docx/char_styles.py
+++ b/src/calibre/ebooks/docx/char_styles.py
@@ -174,7 +174,7 @@ def read_font_cs(parent, dest, XPath, get):
 # }}}
 
 
-class RunStyle(object):
+class RunStyle:
 
     all_properties = {
         'b', 'bCs', 'caps', 'cs', 'dstrike', 'emboss', 'i', 'iCs', 'imprint',

--- a/src/calibre/ebooks/docx/container.py
+++ b/src/calibre/ebooks/docx/container.py
@@ -86,7 +86,7 @@ def read_default_style_language(raw, mi, XPath):
 # }}}
 
 
-class DOCX(object):
+class DOCX:
 
     def __init__(self, path_or_stream, log=None, extract=True):
         self.docx_is_transitional = True

--- a/src/calibre/ebooks/docx/fields.py
+++ b/src/calibre/ebooks/docx/fields.py
@@ -11,7 +11,7 @@ from calibre.ebooks.docx.index import process_index, polish_index_markup
 from polyglot.builtins import iteritems, native_string_type
 
 
-class Field(object):
+class Field:
 
     def __init__(self, start):
         self.start = start
@@ -98,7 +98,7 @@ parse_noteref = parser('noteref',
                    'f:footnote h:hyperlink p:position')
 
 
-class Fields(object):
+class Fields:
 
     def __init__(self, namespace):
         self.namespace = namespace

--- a/src/calibre/ebooks/docx/fonts.py
+++ b/src/calibre/ebooks/docx/fonts.py
@@ -51,7 +51,7 @@ def get_best_font(fonts, style, stretch):
         pass
 
 
-class Family(object):
+class Family:
 
     def __init__(self, elem, embed_relationships, XPath, get):
         self.name = self.family_name = get(elem, 'w:name')
@@ -134,7 +134,7 @@ def map_symbol_text(text, font):
     return ''.join(do_map(m, ord_string(text)))
 
 
-class Fonts(object):
+class Fonts:
 
     def __init__(self, namespace):
         self.namespace = namespace

--- a/src/calibre/ebooks/docx/footnotes.py
+++ b/src/calibre/ebooks/docx/footnotes.py
@@ -9,7 +9,7 @@ from collections import OrderedDict
 from polyglot.builtins import iteritems, unicode_type
 
 
-class Note(object):
+class Note:
 
     def __init__(self, namespace, parent, rels):
         self.type = namespace.get(parent, 'w:type', 'normal')
@@ -22,7 +22,7 @@ class Note(object):
             yield p
 
 
-class Footnotes(object):
+class Footnotes:
 
     def __init__(self, namespace):
         self.namespace = namespace

--- a/src/calibre/ebooks/docx/images.py
+++ b/src/calibre/ebooks/docx/images.py
@@ -129,7 +129,7 @@ def get_hpos(anchor, page_width, XPath, get, width_frac):
     return 0
 
 
-class Images(object):
+class Images:
 
     def __init__(self, namespace, log):
         self.namespace = namespace

--- a/src/calibre/ebooks/docx/names.py
+++ b/src/calibre/ebooks/docx/names.py
@@ -94,7 +94,7 @@ def generate_anchor(name, existing):
     return y
 
 
-class DOCXNamespace(object):
+class DOCXNamespace:
 
     def __init__(self, transitional=True):
         self.xpath_cache = {}

--- a/src/calibre/ebooks/docx/numbering.py
+++ b/src/calibre/ebooks/docx/numbering.py
@@ -44,7 +44,7 @@ alphabet_map = {
 }
 
 
-class Level(object):
+class Level:
 
     def __init__(self, namespace, lvl=None):
         self.namespace = namespace
@@ -152,7 +152,7 @@ class Level(object):
         return css
 
 
-class NumberingDefinition(object):
+class NumberingDefinition:
 
     def __init__(self, namespace, parent=None, an_id=None):
         self.namespace = namespace
@@ -174,7 +174,7 @@ class NumberingDefinition(object):
         return ans
 
 
-class Numbering(object):
+class Numbering:
 
     def __init__(self, namespace):
         self.namespace = namespace

--- a/src/calibre/ebooks/docx/settings.py
+++ b/src/calibre/ebooks/docx/settings.py
@@ -6,7 +6,7 @@ __license__ = 'GPL v3'
 __copyright__ = '2013, Kovid Goyal <kovid at kovidgoyal.net>'
 
 
-class Settings(object):
+class Settings:
 
     def __init__(self, namespace):
         self.default_tab_stop = 720 / 20

--- a/src/calibre/ebooks/docx/styles.py
+++ b/src/calibre/ebooks/docx/styles.py
@@ -14,7 +14,7 @@ from calibre.ebooks.docx.tables import TableStyle
 from polyglot.builtins import iteritems, itervalues
 
 
-class PageProperties(object):
+class PageProperties:
 
     '''
     Class representing page level properties (page size/margins) read from
@@ -39,7 +39,7 @@ class PageProperties(object):
                 setval('margin_left', l), setval('margin_right', r)
 
 
-class Style(object):
+class Style:
     '''
     Class representing a <w:style> element. Can contain block, character, etc. styles.
     '''
@@ -104,7 +104,7 @@ class Style(object):
             self.character_style.resolve_based_on(parent.character_style)
 
 
-class Styles(object):
+class Styles:
 
     '''
     Collection of all styles defined in the document. Used to get the final styles applicable to elements in the document markup.

--- a/src/calibre/ebooks/docx/tables.py
+++ b/src/calibre/ebooks/docx/tables.py
@@ -174,7 +174,7 @@ def clone(style):
     return ans
 
 
-class Style(object):
+class Style:
 
     is_bidi = False
 
@@ -375,7 +375,7 @@ class TableStyle(Style):
         return self._css
 
 
-class Table(object):
+class Table:
 
     def __init__(self, namespace, tbl, styles, para_map, is_sub_table=False):
         self.namespace = namespace
@@ -670,7 +670,7 @@ class Table(object):
                 elem.set('class', self.styles.register(css, elem.tag))
 
 
-class Tables(object):
+class Tables:
 
     def __init__(self, namespace):
         self.tables = []

--- a/src/calibre/ebooks/docx/theme.py
+++ b/src/calibre/ebooks/docx/theme.py
@@ -6,7 +6,7 @@ __license__ = 'GPL v3'
 __copyright__ = '2013, Kovid Goyal <kovid at kovidgoyal.net>'
 
 
-class Theme(object):
+class Theme:
 
     def __init__(self, namespace):
         self.major_latin_font = 'Cambria'

--- a/src/calibre/ebooks/docx/to_html.py
+++ b/src/calibre/ebooks/docx/to_html.py
@@ -57,7 +57,7 @@ def html_lang(docx_lang):
             return lang
 
 
-class Convert(object):
+class Convert:
 
     def __init__(self, path_or_stream, dest_dir=None, log=None, detect_cover=True, notes_text=None, notes_nopb=False, nosupsub=False):
         self.docx = DOCX(path_or_stream, log=log)

--- a/src/calibre/ebooks/docx/writer/container.py
+++ b/src/calibre/ebooks/docx/writer/container.py
@@ -115,7 +115,7 @@ def update_doc_props(root, mi, namespace):
         setm('language', lang_as_iso639_1(l) or l)
 
 
-class DocumentRelationships(object):
+class DocumentRelationships:
 
     def __init__(self, namespace):
         self.rmap = {}
@@ -153,7 +153,7 @@ class DocumentRelationships(object):
         return xml2str(relationships)
 
 
-class DOCX(object):
+class DOCX:
 
     def __init__(self, opts, log):
         self.namespace = DOCXNamespace()

--- a/src/calibre/ebooks/docx/writer/fonts.py
+++ b/src/calibre/ebooks/docx/writer/fonts.py
@@ -20,7 +20,7 @@ def obfuscate_font_data(data, key):
     return prefix + data[32:]
 
 
-class FontsManager(object):
+class FontsManager:
 
     def __init__(self, namespace, oeb, opts):
         self.namespace = namespace

--- a/src/calibre/ebooks/docx/writer/from_html.py
+++ b/src/calibre/ebooks/docx/writer/from_html.py
@@ -54,7 +54,7 @@ class Stylizer(Sz):
             return Style(element, self)
 
 
-class TextRun(object):
+class TextRun:
 
     ws_pat = soft_hyphen_pat = None
 
@@ -144,7 +144,7 @@ class TextRun(object):
         return ans
 
 
-class Block(object):
+class Block:
 
     def __init__(self, namespace, styles_manager, links_manager, html_block, style, is_table_cell=False, float_spec=None, is_list_item=False, parent_bg=None):
         self.force_not_empty = False
@@ -262,7 +262,7 @@ class Block(object):
         return True
 
 
-class Blocks(object):
+class Blocks:
 
     def __init__(self, namespace, styles_manager, links_manager):
         self.top_bookmark = None
@@ -417,7 +417,7 @@ class Blocks(object):
         return 'Block(%r)' % self.runs
 
 
-class Convert(object):
+class Convert:
 
     # Word does not apply default styling to hyperlinks, so we ensure they get
     # default styling (the conversion pipeline does not apply any styling to

--- a/src/calibre/ebooks/docx/writer/images.py
+++ b/src/calibre/ebooks/docx/writer/images.py
@@ -38,7 +38,7 @@ def get_image_margins(style):
     return ans
 
 
-class ImagesManager(object):
+class ImagesManager:
 
     def __init__(self, oeb, document_relationships, opts):
         self.oeb, self.log = oeb, oeb.log

--- a/src/calibre/ebooks/docx/writer/links.py
+++ b/src/calibre/ebooks/docx/writer/links.py
@@ -27,7 +27,7 @@ def start_text(tag, prefix_len=0, top_level=True):
     return ans
 
 
-class TOCItem(object):
+class TOCItem:
 
     def __init__(self, title, bmark, level):
         self.title, self.bmark, self.level = title, bmark, level
@@ -65,7 +65,7 @@ def sanitize_bookmark_name(base):
     return re.sub(r'[^0-9a-zA-Z]', '_', ascii_text(base))[:32].rstrip('_')
 
 
-class LinksManager(object):
+class LinksManager:
 
     def __init__(self, namespace, document_relationships, log):
         self.namespace = namespace

--- a/src/calibre/ebooks/docx/writer/lists.py
+++ b/src/calibre/ebooks/docx/writer/lists.py
@@ -50,7 +50,7 @@ def find_list_containers(list_tag, tag_style):
     return ans
 
 
-class NumberingDefinition(object):
+class NumberingDefinition:
 
     def __init__(self, top_most, stylizer, namespace):
         self.namespace = namespace
@@ -90,7 +90,7 @@ class NumberingDefinition(object):
             level.serialize(an, makeelement)
 
 
-class Level(object):
+class Level:
 
     def __init__(self, list_type, container, items, ilvl=0):
         self.ilvl = ilvl
@@ -125,7 +125,7 @@ class Level(object):
             makeelement(makeelement(lvl, 'w:rPr'), 'w:rFonts', w_ascii=ff, w_hAnsi=ff, w_hint="default")
 
 
-class ListsManager(object):
+class ListsManager:
 
     def __init__(self, docx):
         self.namespace = docx.namespace

--- a/src/calibre/ebooks/docx/writer/styles.py
+++ b/src/calibre/ebooks/docx/writer/styles.py
@@ -49,7 +49,7 @@ def is_dropcaps(html_tag, tag_style):
     return len(html_tag) < 2 and len(etree.tostring(html_tag, method='text', encoding='unicode', with_tail=False)) < 5 and tag_style['float'] == 'left'
 
 
-class CombinedStyle(object):
+class CombinedStyle:
 
     def __init__(self, bs, rs, blocks, namespace):
         self.bs, self.rs, self.blocks = bs, rs, blocks
@@ -81,7 +81,7 @@ class CombinedStyle(object):
         self.rs.serialize_properties(rPr, normal_style.rs)
 
 
-class FloatSpec(object):
+class FloatSpec:
 
     def __init__(self, namespace, html_tag, tag_style):
         self.makeelement = namespace.makeelement
@@ -141,7 +141,7 @@ class FloatSpec(object):
                 bdr, 'w:'+edge, w_space=unicode_type(padding), w_val=bstyle, w_sz=unicode_type(width), w_color=getattr(self, 'border_%s_color' % edge))
 
 
-class DOCXStyle(object):
+class DOCXStyle:
 
     ALL_PROPS = ()
     TYPE = 'paragraph'
@@ -356,7 +356,7 @@ class TextStyle(DOCXStyle):
             rPr.append(bdr)
 
 
-class DescendantTextStyle(object):
+class DescendantTextStyle:
 
     def __init__(self, parent_style, child_style):
         self.id = self.name = None
@@ -632,7 +632,7 @@ class BlockStyle(DOCXStyle):
             pPr.append(makeelement(pPr, 'next', val=self.next_style))
 
 
-class StylesManager(object):
+class StylesManager:
 
     def __init__(self, namespace, log, document_lang):
         self.namespace = namespace

--- a/src/calibre/ebooks/docx/writer/tables.py
+++ b/src/calibre/ebooks/docx/writer/tables.py
@@ -12,7 +12,7 @@ from calibre.ebooks.docx.writer.styles import read_css_block_borders as rcbb, bo
 from polyglot.builtins import iteritems, range, unicode_type
 
 
-class Dummy(object):
+class Dummy:
     pass
 
 
@@ -21,7 +21,7 @@ border_style_weight = {
     x:100-i for i, x in enumerate(('double', 'solid', 'dashed', 'dotted', 'ridge', 'outset', 'groove', 'inset'))}
 
 
-class SpannedCell(object):
+class SpannedCell:
 
     def __init__(self, spanning_cell, horizontal=True):
         self.spanning_cell = spanning_cell
@@ -79,7 +79,7 @@ def convert_width(tag_style):
     return ('auto', 0)
 
 
-class Cell(object):
+class Cell:
 
     BLEVEL = 2
 
@@ -211,7 +211,7 @@ class Cell(object):
         return getattr(ans, 'spanning_cell', ans)
 
 
-class Row(object):
+class Row:
 
     BLEVEL = 1
 
@@ -257,7 +257,7 @@ class Row(object):
             cell.serialize(tr, makeelement)
 
 
-class Table(object):
+class Table:
 
     BLEVEL = 0
 

--- a/src/calibre/ebooks/epub/cfi/parse.py
+++ b/src/calibre/ebooks/epub/cfi/parse.py
@@ -9,7 +9,7 @@ import regex
 from polyglot.builtins import map, zip
 
 
-class Parser(object):
+class Parser:
 
     ''' See epubcfi.ebnf for the specification that this parser tries to
     follow. I have implemented it manually, since I dont want to depend on

--- a/src/calibre/ebooks/fb2/fb2ml.py
+++ b/src/calibre/ebooks/fb2/fb2ml.py
@@ -25,7 +25,7 @@ from polyglot.binary import as_base64_unicode
 from polyglot.urllib import urlparse
 
 
-class FB2MLizer(object):
+class FB2MLizer:
     '''
     Todo: * Include more FB2 specific tags in the conversion.
           * Handle notes and anchor links.

--- a/src/calibre/ebooks/html/input.py
+++ b/src/calibre/ebooks/html/input.py
@@ -21,7 +21,7 @@ from polyglot.builtins import unicode_type
 from polyglot.urllib import urlparse, urlunparse
 
 
-class Link(object):
+class Link:
 
     '''
     Represents a link in a HTML file.
@@ -76,7 +76,7 @@ class IgnoreFile(Exception):
         self.errno = errno
 
 
-class HTMLFile(object):
+class HTMLFile:
 
     '''
     Contains basic information about an HTML file. This

--- a/src/calibre/ebooks/html/meta.py
+++ b/src/calibre/ebooks/html/meta.py
@@ -5,7 +5,7 @@ __copyright__ = '2010, Fabian Grassl <fg@jusmeum.de>'
 __docformat__ = 'restructuredtext en'
 
 
-class EasyMeta(object):
+class EasyMeta:
 
     def __init__(self, meta):
         self.meta = meta

--- a/src/calibre/ebooks/htmlz/oeb2html.py
+++ b/src/calibre/ebooks/htmlz/oeb2html.py
@@ -26,7 +26,7 @@ from polyglot.urllib import urldefrag
 SELF_CLOSING_TAGS = {'area', 'base', 'basefont', 'br', 'hr', 'input', 'img', 'link', 'meta'}
 
 
-class OEB2HTML(object):
+class OEB2HTML:
     '''
     Base class. All subclasses should implement dump_text to actually transform
     content. Also, callers should use oeb2html to get the transformed html.

--- a/src/calibre/ebooks/lit/lzx.py
+++ b/src/calibre/ebooks/lit/lzx.py
@@ -15,7 +15,7 @@ LZXError = _lzx.LZXError
 Compressor = _lzx.Compressor
 
 
-class Decompressor(object):
+class Decompressor:
 
     def __init__(self, wbits):
         self.wbits = wbits

--- a/src/calibre/ebooks/lit/mssha1.py
+++ b/src/calibre/ebooks/lit/mssha1.py
@@ -121,7 +121,7 @@ K = [
     ]
 
 
-class mssha1(object):
+class mssha1:
     "An implementation of the MD5 hash function in pure Python."
 
     def __init__(self):

--- a/src/calibre/ebooks/lit/reader.py
+++ b/src/calibre/ebooks/lit/reader.py
@@ -124,7 +124,7 @@ def encode(string):
     return unicode_type(string).encode('ascii', 'xmlcharrefreplace')
 
 
-class UnBinary(object):
+class UnBinary:
     AMPERSAND_RE = re.compile(
         br'&(?!(?:#[0-9]+|#x[0-9a-fA-F]+|[a-zA-Z_:][a-zA-Z0-9.-_:]+);)')
     OPEN_ANGLE_RE = re.compile(br'<<(?![!]--)')
@@ -384,7 +384,7 @@ class UnBinary(object):
                     state = 'get attr'
 
 
-class DirectoryEntry(object):
+class DirectoryEntry:
 
     def __init__(self, name, section, offset, size):
         self.name = name
@@ -400,7 +400,7 @@ class DirectoryEntry(object):
         return repr(self)
 
 
-class ManifestItem(object):
+class ManifestItem:
 
     def __init__(self, original, internal, mime_type, offset, root, state):
         self.original = original
@@ -442,7 +442,7 @@ def preserve(function):
     return wrapper
 
 
-class LitFile(object):
+class LitFile:
     PIECE_SIZE = 16
 
     def __init__(self, filename_or_stream, log):
@@ -889,7 +889,7 @@ class LitFile(object):
         return (tags, attrs)
 
 
-class LitContainer(object):
+class LitContainer:
     """Simple Container-interface, read-only accessor for LIT files."""
 
     def __init__(self, filename_or_stream, log):

--- a/src/calibre/ebooks/lit/writer.py
+++ b/src/calibre/ebooks/lit/writer.py
@@ -140,7 +140,7 @@ def warn(x):
     print(x)
 
 
-class ReBinary(object):
+class ReBinary:
     NSRMAP = {'': None, XML_NS: 'xml'}
 
     def __init__(self, root, item, oeb, opts, map=HTML_MAP):
@@ -304,7 +304,7 @@ def preserve(function):
     return wrapper
 
 
-class LitWriter(object):
+class LitWriter:
 
     def __init__(self, opts):
         self.opts = opts

--- a/src/calibre/ebooks/lrf/__init__.py
+++ b/src/calibre/ebooks/lrf/__init__.py
@@ -20,7 +20,7 @@ class LRFParseError(Exception):
     pass
 
 
-class PRS500_PROFILE(object):
+class PRS500_PROFILE:
     screen_width  = 600
     screen_height = 775
     dpi           = 166

--- a/src/calibre/ebooks/lrf/html/convert_from.py
+++ b/src/calibre/ebooks/lrf/html/convert_from.py
@@ -86,7 +86,7 @@ def tag_regex(tagname):
                 close=r'</\s*%(t)s\s*>'%dict(t=tagname))
 
 
-class HTMLConverter(object):
+class HTMLConverter:
     SELECTOR_PAT   = re.compile(r"([A-Za-z0-9\-\_\:\.]+[A-Za-z0-9\-\_\:\.\s\,]*)\s*\{([^\}]*)\}")
     PAGE_BREAK_PAT = re.compile(r'page-break-(?:after|before)\s*:\s*(\w+)', re.IGNORECASE)
     IGNORED_TAGS   = (Comment, Declaration, ProcessingInstruction)

--- a/src/calibre/ebooks/lrf/html/table.py
+++ b/src/calibre/ebooks/lrf/html/table.py
@@ -69,7 +69,7 @@ def tokens(tb):
                     yield k
 
 
-class Cell(object):
+class Cell:
 
     def __init__(self, conv, tag, css):
         self.conv = conv
@@ -210,7 +210,7 @@ class Cell(object):
         return sum([self.text_block_size(i, width)[1] for i in self.text_blocks])
 
 
-class Row(object):
+class Row:
 
     def __init__(self, conv, row, css, colpad):
         self.cells = []
@@ -277,7 +277,7 @@ class Row(object):
             yield c
 
 
-class Table(object):
+class Table:
 
     def __init__(self, conv, table, css, rowpad=10, colpad=10):
         self.rows = []

--- a/src/calibre/ebooks/lrf/lrfparser.py
+++ b/src/calibre/ebooks/lrf/lrfparser.py
@@ -18,7 +18,7 @@ from polyglot.builtins import unicode_type, itervalues
 
 class LRFDocument(LRFMetaFile):
 
-    class temp(object):
+    class temp:
         pass
 
     def __init__(self, stream):

--- a/src/calibre/ebooks/lrf/lrs/convert_from.py
+++ b/src/calibre/ebooks/lrf/lrs/convert_from.py
@@ -25,7 +25,7 @@ from calibre.utils.config import OptionParser
 from polyglot.builtins import string_or_bytes, unicode_type
 
 
-class LrsParser(object):
+class LrsParser:
 
     def __init__(self, stream, logger):
         self.logger = logger

--- a/src/calibre/ebooks/lrf/meta.py
+++ b/src/calibre/ebooks/lrf/meta.py
@@ -29,7 +29,7 @@ DWORD     = "<I"  #: Unsigned integer little endian encoded in 4 bytes
 QWORD     = "<Q"  #: Unsigned long long little endian encoded in 8 bytes
 
 
-class field(object):
+class field:
     """ A U{Descriptor<http://www.cafepy.com/article/python_attributes_and_methods/python_attributes_and_methods.html>}, that implements access
     to protocol packets in a human readable way.
     """
@@ -81,7 +81,7 @@ class LRFException(Exception):
     pass
 
 
-class fixed_stringfield(object):
+class fixed_stringfield:
     """ A field storing a variable length string. """
 
     def __init__(self, length=8, start=0):
@@ -111,7 +111,7 @@ class fixed_stringfield(object):
                 " starting at byte " + unicode_type(self._start)
 
 
-class xml_attr_field(object):
+class xml_attr_field:
 
     def __init__(self, tag_name, attr, parent='BookInfo'):
         self.tag_name = tag_name
@@ -152,7 +152,7 @@ class xml_attr_field(object):
         return self.tag_name+'.'+self.attr
 
 
-class xml_field(object):
+class xml_field:
     """
     Descriptor that gets and sets XML based meta information from an LRF file.
     Works for simple XML fields of the form <tagname>data</tagname>
@@ -299,7 +299,7 @@ def get_metadata(stream):
     return mi
 
 
-class LRFMetaFile(object):
+class LRFMetaFile:
     """ Has properties to read and write all Meta information in a LRF file. """
     #: The first 6 bytes of all valid LRF files
     LRF_HEADER = 'LRF'.encode('utf-16le')

--- a/src/calibre/ebooks/lrf/objects.py
+++ b/src/calibre/ebooks/lrf/objects.py
@@ -19,7 +19,7 @@ ruby_tags = {
 }
 
 
-class LRFObject(object):
+class LRFObject:
 
     tag_map = {
         0xF500: ['', ''],
@@ -192,7 +192,7 @@ class PageTree(LRFObject):
             yield self._document.objects[id]
 
 
-class StyleObject(object):
+class StyleObject:
 
     def _tags_to_xml(self):
         s = ''
@@ -245,7 +245,7 @@ class PageAttr(StyleObject, LRFObject):
         return ''
 
 
-class Color(object):
+class Color:
 
     def __init__(self, val):
         self.a, self.r, self.g, self.b = val & 0xFF, (val>>8)&0xFF, (val>>16)&0xFF, (val>>24)&0xFF
@@ -263,7 +263,7 @@ class Color(object):
         return 'rgb(%d, %d, %d)'%(self.r, self.g, self.b)
 
 
-class EmptyPageElement(object):
+class EmptyPageElement:
 
     def __iter__(self):
         for i in range(0):
@@ -486,7 +486,7 @@ class BlockAttr(StyleObject, LRFObject):
         return ans
 
 
-class TextCSS(object):
+class TextCSS:
 
     @classmethod
     def to_css(cls, obj, inline=False):
@@ -682,7 +682,7 @@ class Text(LRFStream):
            0xF5D2: 'cr',
         }
 
-    class TextTag(object):
+    class TextTag:
 
         def __init__(self, name, attrs={}, self_closing=False):
             self.name = name
@@ -1198,7 +1198,7 @@ class SimpleText(Text):
     pass
 
 
-class TocLabel(object):
+class TocLabel:
 
     def __init__(self, refpage, refobject, label):
         self.refpage, self.refobject, self.label = refpage, refobject, label

--- a/src/calibre/ebooks/lrf/pylrs/elements.py
+++ b/src/calibre/ebooks/lrf/pylrs/elements.py
@@ -5,7 +5,7 @@
 from polyglot.builtins import unicode_type, string_or_bytes
 
 
-class ElementWriter(object):
+class ElementWriter:
 
     def __init__(self, e, header=False, sourceEncoding="ascii",
                  spaceBeforeClose=True, outputEncodingName="UTF-16"):

--- a/src/calibre/ebooks/lrf/pylrs/pylrf.py
+++ b/src/calibre/ebooks/lrf/pylrs/pylrf.py
@@ -357,7 +357,7 @@ TAG_INFO = dict(
     )
 
 
-class ObjectTableEntry(object):
+class ObjectTableEntry:
 
     def __init__(self, objId, offset, size):
         self.objId = objId
@@ -368,7 +368,7 @@ class ObjectTableEntry(object):
         writeDWords(f, self.objId, self.offset, self.size, 0)
 
 
-class LrfTag(object):
+class LrfTag:
 
     def __init__(self, name, *parameters):
         try:
@@ -420,7 +420,7 @@ STREAM_FORCE_COMPRESSED = 0x8100
 STREAM_TOC = 0x0051
 
 
-class LrfStreamBase(object):
+class LrfStreamBase:
 
     def __init__(self, streamFlags, streamData=None):
         self.streamFlags = streamFlags
@@ -496,7 +496,7 @@ class LrfFileStream(LrfStreamBase):
             self.streamData = f.read()
 
 
-class LrfObject(object):
+class LrfObject:
 
     def __init__(self, name, objId):
         if objId <= 0:
@@ -618,7 +618,7 @@ class LrfToc(LrfObject):
         return streamData
 
 
-class LrfWriter(object):
+class LrfWriter:
 
     def __init__(self, sourceEncoding):
         self.sourceEncoding = sourceEncoding

--- a/src/calibre/ebooks/lrf/pylrs/pylrs.py
+++ b/src/calibre/ebooks/lrf/pylrs/pylrs.py
@@ -134,7 +134,7 @@ def appendTextElements(e, contentsList, se):
                 lastElement.tail = uconcat(lastElement.tail, content.text, se)
 
 
-class Delegator(object):
+class Delegator:
     """ A mixin class to create delegated methods that create elements. """
 
     def __init__(self, delegates):
@@ -217,7 +217,7 @@ class Delegator(object):
         self.toLrfDelegates(lrfWriter)
 
 
-class LrsAttributes(object):
+class LrsAttributes:
     """ A mixin class to handle default and user supplied attributes. """
 
     def __init__(self, defaults, alsoAllow=None, **settings):
@@ -233,7 +233,7 @@ class LrsAttributes(object):
             self.attrs[name] = value
 
 
-class LrsContainer(object):
+class LrsContainer:
     """ This class is a mixin class for elements that are contained in or
         contain an unknown number of other elements.
     """
@@ -309,7 +309,7 @@ class LrsContainer(object):
                     yield grandchild
 
 
-class LrsObject(object):
+class LrsObject:
     """ A mixin class for elements that need an object id. """
     nextObjId = 0
 
@@ -679,7 +679,7 @@ class Info(Delegator):
         lrfWriter.docInfoXml = xmlInfo
 
 
-class TableOfContents(object):
+class TableOfContents:
 
     def __init__(self):
         self.tocEntries = []
@@ -738,7 +738,7 @@ class TableOfContents(object):
         lrfWriter.setTocObject(lrfToc)
 
 
-class TocLabel(object):
+class TocLabel:
 
     def __init__(self, label, textBlock):
         self.label = escape(re.sub(r'&(\S+?);', entity_to_unicode, label))
@@ -750,7 +750,7 @@ class TocLabel(object):
                  refpage=unicode_type(self.textBlock.parent.objId))
 
 
-class BookInfo(object):
+class BookInfo:
 
     def __init__(self):
         self.title = "Untitled"
@@ -802,7 +802,7 @@ class BookInfo(object):
         return bi
 
 
-class DocInfo(object):
+class DocInfo:
 
     def __init__(self):
         self.thumbnail = None
@@ -922,7 +922,7 @@ class Solo(Main):
     pass
 
 
-class Template(object):
+class Template:
     """ Does nothing that I know of. """
 
     def appendReferencedObjects(self, parent):
@@ -1549,7 +1549,7 @@ class LrsTextTag(LrsContainer):
         return p
 
 
-class LrsSimpleChar1(object):
+class LrsSimpleChar1:
 
     def isEmpty(self):
         for content in self.contents:

--- a/src/calibre/ebooks/lrf/tags.py
+++ b/src/calibre/ebooks/lrf/tags.py
@@ -10,7 +10,7 @@ from calibre.ebooks.lrf import LRFParseError
 from polyglot.builtins import unicode_type
 
 
-class Tag(object):
+class Tag:
 
     tags = {
                 0x00 : (6, "*ObjectStart"),

--- a/src/calibre/ebooks/metadata/__init__.py
+++ b/src/calibre/ebooks/metadata/__init__.py
@@ -228,7 +228,7 @@ def fmt_sidx(i, fmt='%.2f', use_roman=False):
     return fmt%i
 
 
-class Resource(object):
+class Resource:
 
     '''
     Represents a resource (usually a file on the filesystem or a URL pointing
@@ -309,7 +309,7 @@ class Resource(object):
         return 'Resource(%s, %s)'%(repr(self.path), repr(self.href()))
 
 
-class ResourceCollection(object):
+class ResourceCollection:
 
     def __init__(self):
         self._resources = []

--- a/src/calibre/ebooks/metadata/book/base.py
+++ b/src/calibre/ebooks/metadata/book/base.py
@@ -59,7 +59,7 @@ ck = lambda typ: icu_lower(typ).strip().replace(':', '').replace(',', '')
 cv = lambda val: val.strip().replace(',', '|')
 
 
-class Metadata(object):
+class Metadata:
 
     '''
     A class representing all the metadata for a book. The various standard metadata

--- a/src/calibre/ebooks/metadata/book/json_codec.py
+++ b/src/calibre/ebooks/metadata/book/json_codec.py
@@ -127,7 +127,7 @@ def decode_is_multiple(fm):
         fm['is_multiple'] = im
 
 
-class JsonCodec(object):
+class JsonCodec:
 
     def __init__(self, field_metadata=None):
         self.field_metadata = field_metadata or FieldMetadata()

--- a/src/calibre/ebooks/metadata/epub.py
+++ b/src/calibre/ebooks/metadata/epub.py
@@ -54,7 +54,7 @@ class Container(dict):
             self[mt] = fp
 
 
-class OCF(object):
+class OCF:
     MIMETYPE        = 'application/epub+zip'
     CONTAINER_PATH  = 'META-INF/container.xml'
     ENCRYPTION_PATH = 'META-INF/encryption.xml'
@@ -63,7 +63,7 @@ class OCF(object):
         raise NotImplementedError('Abstract base class')
 
 
-class Encryption(object):
+class Encryption:
 
     OBFUSCATION_ALGORITHMS = frozenset(['http://ns.adobe.com/pdf/enc#RC',
             'http://www.idpf.org/2008/embedding'])

--- a/src/calibre/ebooks/metadata/fb2.py
+++ b/src/calibre/ebooks/metadata/fb2.py
@@ -38,7 +38,7 @@ def XLINK(tag):
     return '{%s}%s'%(NAMESPACES['xlink'], tag)
 
 
-class Context(object):
+class Context:
 
     def __init__(self, root):
         try:

--- a/src/calibre/ebooks/metadata/kfx.py
+++ b/src/calibre/ebooks/metadata/kfx.py
@@ -68,7 +68,7 @@ def hexs(string, sep=' '):
     return sep.join('%02x' % b for b in string)
 
 
-class PackedData(object):
+class PackedData:
 
     '''
     Simplify unpacking of packed binary data structures

--- a/src/calibre/ebooks/metadata/mobi.py
+++ b/src/calibre/ebooks/metadata/mobi.py
@@ -29,7 +29,7 @@ def is_image(ss):
     return what(None, ss[:200]) is not None
 
 
-class StreamSlicer(object):
+class StreamSlicer:
 
     def __init__(self, stream, start=0, stop=None):
         self._stream = stream
@@ -97,7 +97,7 @@ class StreamSlicer(object):
         self._stream.truncate(value)
 
 
-class MetadataUpdater(object):
+class MetadataUpdater:
     DRM_KEY_SIZE = 48
 
     def __init__(self, stream):

--- a/src/calibre/ebooks/metadata/opf.py
+++ b/src/calibre/ebooks/metadata/opf.py
@@ -12,7 +12,7 @@ from calibre.ebooks.metadata import MetaInformation
 from polyglot.builtins import iteritems
 
 
-class DummyFile(object):
+class DummyFile:
 
     def __init__(self, raw):
         self.raw = raw

--- a/src/calibre/ebooks/metadata/opf2.py
+++ b/src/calibre/ebooks/metadata/opf2.py
@@ -30,7 +30,7 @@ from polyglot.urllib import unquote, urlparse
 pretty_print_opf = False
 
 
-class PrettyPrint(object):
+class PrettyPrint:
 
     def __enter__(self):
         global pretty_print_opf
@@ -44,7 +44,7 @@ class PrettyPrint(object):
 pretty_print = PrettyPrint()
 
 
-class Resource(object):  # {{{
+class Resource:  # {{{
 
     '''
     Represents a resource (usually a file on the filesystem or a URL pointing
@@ -127,7 +127,7 @@ class Resource(object):  # {{{
 # }}}
 
 
-class ResourceCollection(object):  # {{{
+class ResourceCollection:  # {{{
 
     def __init__(self):
         self._resources = []
@@ -408,7 +408,7 @@ class Guide(ResourceCollection):  # {{{
 # }}}
 
 
-class MetadataField(object):
+class MetadataField:
 
     def __init__(self, name, is_dc=True, formatter=None, none_is=None,
             renderer=lambda x: unicode_type(x)):
@@ -523,7 +523,7 @@ def dump_dict(cats):
             skipkeys=True)
 
 
-class OPF(object):  # {{{
+class OPF:  # {{{
 
     MIMETYPE         = 'application/oebps-package+xml'
     NAMESPACES       = {

--- a/src/calibre/ebooks/metadata/opf_2_to_3.py
+++ b/src/calibre/ebooks/metadata/opf_2_to_3.py
@@ -15,7 +15,7 @@ from calibre.ebooks.metadata.utils import parse_opf, pretty_print_opf
 from polyglot.builtins import itervalues
 
 
-class Data(object):
+class Data:
     pass
 
 

--- a/src/calibre/ebooks/metadata/sources/base.py
+++ b/src/calibre/ebooks/metadata/sources/base.py
@@ -42,7 +42,7 @@ def cleanup_title(s):
 
 
 @total_ordering
-class InternalMetadataCompareKeyGen(object):
+class InternalMetadataCompareKeyGen:
 
     '''
     Generate a sort key for comparison of the relevance of Metadata objects,
@@ -162,7 +162,7 @@ def fixcase(x):
     return x
 
 
-class Option(object):
+class Option:
     __slots__ = ['type', 'default', 'label', 'desc', 'name', 'choices']
 
     def __init__(self, name, type_, default, label, desc, choices=None):

--- a/src/calibre/ebooks/metadata/sources/identify.py
+++ b/src/calibre/ebooks/metadata/sources/identify.py
@@ -84,7 +84,7 @@ class xISBN(Thread):
             self.tb = traceback.format_exception()
 
 
-class ISBNMerge(object):
+class ISBNMerge:
 
     def __init__(self, log):
         self.pools = {}

--- a/src/calibre/ebooks/metadata/sources/update.py
+++ b/src/calibre/ebooks/metadata/sources/update.py
@@ -44,7 +44,7 @@ def load_plugin(src):
             return x
 
 
-class PatchedSearchEngines(object):
+class PatchedSearchEngines:
 
     def __init__(self, ns):
         self.__ns = ns

--- a/src/calibre/ebooks/metadata/topaz.py
+++ b/src/calibre/ebooks/metadata/topaz.py
@@ -26,7 +26,7 @@ class StringIO(io.StringIO):
         return io.StringIO.write(self, x)
 
 
-class StreamSlicer(object):
+class StreamSlicer:
 
     def __init__(self, stream, start=0, stop=None):
         self._stream = stream
@@ -94,7 +94,7 @@ class StreamSlicer(object):
         self._stream.truncate(value)
 
 
-class MetadataUpdater(object):
+class MetadataUpdater:
 
     def __init__(self, stream):
         self.stream = stream

--- a/src/calibre/ebooks/metadata/xisbn.py
+++ b/src/calibre/ebooks/metadata/xisbn.py
@@ -11,7 +11,7 @@ import threading, re, json
 from calibre import browser
 
 
-class xISBN(object):
+class xISBN:
 
     '''
     This class is used to find the ISBN numbers of "related" editions of a

--- a/src/calibre/ebooks/mobi/debug/containers.py
+++ b/src/calibre/ebooks/mobi/debug/containers.py
@@ -11,7 +11,7 @@ from calibre.ebooks.mobi.debug.headers import EXTHHeader
 from polyglot.builtins import filter, unicode_type
 
 
-class ContainerHeader(object):
+class ContainerHeader:
 
     def __init__(self, data):
         self.ident = data[:4]

--- a/src/calibre/ebooks/mobi/debug/headers.py
+++ b/src/calibre/ebooks/mobi/debug/headers.py
@@ -18,9 +18,9 @@ from polyglot.builtins import iteritems, range, unicode_type
 # PalmDB {{{
 
 
-class PalmDOCAttributes(object):
+class PalmDOCAttributes:
 
-    class Attr(object):
+    class Attr:
 
         def __init__(self, name, field, val):
             self.name = name
@@ -48,7 +48,7 @@ class PalmDOCAttributes(object):
     __unicode__ = __str__
 
 
-class PalmDB(object):
+class PalmDB:
 
     def __init__(self, raw):
         self.raw = raw
@@ -108,7 +108,7 @@ class PalmDB(object):
 # }}}
 
 
-class Record(object):  # {{{
+class Record:  # {{{
 
     def __init__(self, raw, header):
         self.offset, self.flags, self.uid = header
@@ -123,7 +123,7 @@ class Record(object):  # {{{
 # EXTH {{{
 
 
-class EXTHRecord(object):
+class EXTHRecord:
 
     def __init__(self, type_, data, length):
         self.type = type_
@@ -216,7 +216,7 @@ class EXTHRecord(object):
         return '%s (%d): %r'%(self.name, self.type, self.data)
 
 
-class EXTHHeader(object):
+class EXTHHeader:
 
     def __init__(self, raw):
         self.raw = raw
@@ -265,7 +265,7 @@ class EXTHHeader(object):
 # }}}
 
 
-class MOBIHeader(object):  # {{{
+class MOBIHeader:  # {{{
 
     def __init__(self, record0, offset):
         self.raw = record0.raw
@@ -514,7 +514,7 @@ class MOBIHeader(object):  # {{{
 # }}}
 
 
-class MOBIFile(object):
+class MOBIFile:
 
     def __init__(self, stream):
         self.raw = stream.read()
@@ -586,7 +586,7 @@ class MOBIFile(object):
         self.decompress6, self.decompress8 = d6, d8
 
 
-class TextRecord(object):  # {{{
+class TextRecord:  # {{{
 
     def __init__(self, idx, record, extra_data_flags, decompress):
         self.trailing_data, self.raw = get_trailing_data(record.raw, extra_data_flags)

--- a/src/calibre/ebooks/mobi/debug/index.py
+++ b/src/calibre/ebooks/mobi/debug/index.py
@@ -86,7 +86,7 @@ def read_index(sections, idx, codec):
     return table, cncx, indx_header, index_headers
 
 
-class Index(object):
+class Index:
 
     def __init__(self, idx, records, codec):
         self.table = self.cncx = self.header = self.records = None

--- a/src/calibre/ebooks/mobi/debug/mobi6.py
+++ b/src/calibre/ebooks/mobi/debug/mobi6.py
@@ -22,7 +22,7 @@ from calibre.ebooks.mobi.debug.headers import TextRecord
 from polyglot.builtins import unicode_type, range, iteritems, as_bytes, print_to_binary_file
 
 
-class TagX(object):  # {{{
+class TagX:  # {{{
 
     def __init__(self, tag, num_values, bitmask, eof):
         self.tag, self.num_values, self.bitmask, self.eof = (tag, num_values,
@@ -36,7 +36,7 @@ class TagX(object):  # {{{
     # }}}
 
 
-class SecondaryIndexHeader(object):  # {{{
+class SecondaryIndexHeader:  # {{{
 
     def __init__(self, record):
         self.record = record
@@ -133,7 +133,7 @@ class SecondaryIndexHeader(object):  # {{{
 # }}}
 
 
-class IndexHeader(object):  # {{{
+class IndexHeader:  # {{{
 
     def __init__(self, record):
         self.record = record
@@ -235,7 +235,7 @@ class IndexHeader(object):  # {{{
     # }}}
 
 
-class Tag(object):  # {{{
+class Tag:  # {{{
 
     '''
     Index entries are a collection of tags. Each tag is represented by this
@@ -290,7 +290,7 @@ class Tag(object):  # {{{
 # }}}
 
 
-class IndexEntry(object):  # {{{
+class IndexEntry:  # {{{
 
     '''
     The index is made up of entries, each of which is represented by an
@@ -377,7 +377,7 @@ class IndexEntry(object):  # {{{
 # }}}
 
 
-class IndexRecord(object):  # {{{
+class IndexRecord:  # {{{
 
     '''
     Represents all indexing information in the MOBI, apart from indexing info
@@ -437,7 +437,7 @@ class IndexRecord(object):  # {{{
 # }}}
 
 
-class CNCX(object):  # {{{
+class CNCX:  # {{{
 
     '''
     Parses the records that contain the compiled NCX (all strings from the
@@ -479,7 +479,7 @@ class CNCX(object):  # {{{
 
 # }}}
 
-class ImageRecord(object):  # {{{
+class ImageRecord:  # {{{
 
     def __init__(self, idx, record, fmt):
         self.raw = record.raw
@@ -494,7 +494,7 @@ class ImageRecord(object):  # {{{
 # }}}
 
 
-class BinaryRecord(object):  # {{{
+class BinaryRecord:  # {{{
 
     def __init__(self, idx, record):
         self.raw = record.raw
@@ -514,7 +514,7 @@ class BinaryRecord(object):  # {{{
 # }}}
 
 
-class FontRecord(object):  # {{{
+class FontRecord:  # {{{
 
     def __init__(self, idx, record):
         self.raw = record.raw
@@ -534,7 +534,7 @@ class FontRecord(object):  # {{{
 # }}}
 
 
-class TBSIndexing(object):  # {{{
+class TBSIndexing:  # {{{
 
     def __init__(self, text_records, indices, doc_type):
         self.record_indices = OrderedDict()
@@ -725,7 +725,7 @@ class TBSIndexing(object):  # {{{
 # }}}
 
 
-class MOBIFile(object):  # {{{
+class MOBIFile:  # {{{
 
     def __init__(self, mf):
         for x in ('raw', 'palmdb', 'record_headers', 'records', 'mobi_header',

--- a/src/calibre/ebooks/mobi/debug/mobi8.py
+++ b/src/calibre/ebooks/mobi/debug/mobi8.py
@@ -20,7 +20,7 @@ from calibre.utils.imghdr import what
 from polyglot.builtins import iteritems, itervalues, map, unicode_type, zip, print_to_binary_file
 
 
-class FDST(object):
+class FDST:
 
     def __init__(self, raw):
         if raw[:4] != b'FDST':
@@ -48,7 +48,7 @@ class FDST(object):
         return '\n'.join(ans)
 
 
-class File(object):
+class File:
 
     def __init__(self, skel, skeleton, text, first_aid, sections):
         self.name = 'part%04d'%skel.file_number
@@ -68,7 +68,7 @@ class File(object):
                     f.write(text)
 
 
-class MOBIFile(object):
+class MOBIFile:
 
     def __init__(self, mf):
         self.mf = mf

--- a/src/calibre/ebooks/mobi/huffcdic.py
+++ b/src/calibre/ebooks/mobi/huffcdic.py
@@ -17,7 +17,7 @@ from calibre.ebooks.mobi import MobiError
 from polyglot.builtins import map
 
 
-class Reader(object):
+class Reader:
 
     def __init__(self):
         self.q = struct.Struct(b'>Q').unpack_from
@@ -96,7 +96,7 @@ class Reader(object):
         return b''.join(s)
 
 
-class HuffReader(object):
+class HuffReader:
 
     def __init__(self, huffs):
         self.reader = Reader()

--- a/src/calibre/ebooks/mobi/mobiml.py
+++ b/src/calibre/ebooks/mobi/mobiml.py
@@ -69,7 +69,7 @@ def isspace(text):
     return text.isspace()
 
 
-class BlockState(object):
+class BlockState:
 
     def __init__(self, body):
         self.body = body
@@ -84,7 +84,7 @@ class BlockState(object):
         self.content = False
 
 
-class FormatState(object):
+class FormatState:
 
     def __init__(self):
         self.rendered = False
@@ -123,7 +123,7 @@ class FormatState(object):
         return not self.__eq__(other)
 
 
-class MobiMLizer(object):
+class MobiMLizer:
 
     def __init__(self, ignore_tables=False):
         self.ignore_tables = ignore_tables

--- a/src/calibre/ebooks/mobi/reader/containers.py
+++ b/src/calibre/ebooks/mobi/reader/containers.py
@@ -14,7 +14,7 @@ def find_imgtype(data):
     return what(None, data) or 'unknown'
 
 
-class Container(object):
+class Container:
 
     def __init__(self, data):
         self.is_image_container = False

--- a/src/calibre/ebooks/mobi/reader/headers.py
+++ b/src/calibre/ebooks/mobi/reader/headers.py
@@ -29,7 +29,7 @@ def uniq(vals):
     return list(x for x in vals if x not in seen and not seen_add(x))
 
 
-class EXTHHeader(object):  # {{{
+class EXTHHeader:  # {{{
 
     def __init__(self, raw, codec, title):
         self.doctype = raw[:4]
@@ -188,7 +188,7 @@ class EXTHHeader(object):  # {{{
 # }}}
 
 
-class BookHeader(object):
+class BookHeader:
 
     def __init__(self, raw, ident, user_encoding, log, try_extra_data_fix=False):
         self.log = log

--- a/src/calibre/ebooks/mobi/reader/index.py
+++ b/src/calibre/ebooks/mobi/reader/index.py
@@ -82,7 +82,7 @@ def parse_indx_header(data):
     return ans
 
 
-class CNCX(object):  # {{{
+class CNCX:  # {{{
 
     '''
     Parses the records that contain the compiled NCX (all strings from the

--- a/src/calibre/ebooks/mobi/reader/mobi6.py
+++ b/src/calibre/ebooks/mobi/reader/mobi6.py
@@ -44,7 +44,7 @@ class KFXError(ValueError):
         ).format('https://www.mobileread.com/forums/showthread.php?t=283371'))
 
 
-class MobiReader(object):
+class MobiReader:
     PAGE_BREAK_PAT = re.compile(
         r'<\s*/{0,1}\s*mbp:pagebreak((?:\s+[^/>]*){0,1})/{0,1}\s*>\s*(?:<\s*/{0,1}\s*mbp:pagebreak\s*/{0,1}\s*>)*',
         re.IGNORECASE)

--- a/src/calibre/ebooks/mobi/reader/mobi8.py
+++ b/src/calibre/ebooks/mobi/reader/mobi8.py
@@ -71,7 +71,7 @@ def get_first_resource_index(first_image_index, num_of_text_records, first_text_
     return first_resource_index
 
 
-class Mobi8Reader(object):
+class Mobi8Reader:
 
     def __init__(self, mobi6_reader, log, for_tweak=False):
         self.for_tweak = for_tweak

--- a/src/calibre/ebooks/mobi/utils.py
+++ b/src/calibre/ebooks/mobi/utils.py
@@ -584,7 +584,7 @@ def create_text_record(text):
     return data, overlap
 
 
-class CNCX(object):  # {{{
+class CNCX:  # {{{
 
     '''
     Create the CNCX records. These are records containing all the strings from

--- a/src/calibre/ebooks/mobi/writer2/indexer.py
+++ b/src/calibre/ebooks/mobi/writer2/indexer.py
@@ -32,7 +32,7 @@ class CNCX(CNCX_):  # {{{
 # }}}
 
 
-class TAGX(object):  # {{{
+class TAGX:  # {{{
 
     BITMASKS = {11:0b1}
     BITMASKS.update({x:(1 << i) for i, x in enumerate([1, 2, 3, 4, 5, 21, 22, 23])})
@@ -90,7 +90,7 @@ class TAGX(object):  # {{{
 
 # Index Entries {{{
 
-class IndexEntry(object):
+class IndexEntry:
 
     TAG_VALUES = {
             'offset': 1,
@@ -243,7 +243,7 @@ class SecondaryIndexEntry(IndexEntry):
 # }}}
 
 
-class TBS(object):  # {{{
+class TBS:  # {{{
 
     '''
     Take the list of index nodes starting/ending on a record and calculate the
@@ -428,7 +428,7 @@ class TBS(object):  # {{{
 # }}}
 
 
-class Indexer(object):  # {{{
+class Indexer:  # {{{
 
     def __init__(self, serializer, number_of_text_records,
             size_of_last_text_record, masthead_offset, is_periodical,

--- a/src/calibre/ebooks/mobi/writer2/main.py
+++ b/src/calibre/ebooks/mobi/writer2/main.py
@@ -35,7 +35,7 @@ def fcis(text_length):
     return fcis
 
 
-class MobiWriter(object):
+class MobiWriter:
 
     def __init__(self, opts, resources, kf8, write_page_breaks_after_item=True):
         self.opts = opts

--- a/src/calibre/ebooks/mobi/writer2/resources.py
+++ b/src/calibre/ebooks/mobi/writer2/resources.py
@@ -38,7 +38,7 @@ def process_jpegs_for_amazon(data: bytes) -> bytes:
     return data
 
 
-class Resources(object):
+class Resources:
 
     def __init__(self, oeb, opts, is_periodical, add_fonts=False,
             process_images=True):

--- a/src/calibre/ebooks/mobi/writer2/serializer.py
+++ b/src/calibre/ebooks/mobi/writer2/serializer.py
@@ -29,7 +29,7 @@ class Buf(BytesIO):
         BytesIO.write(self, x)
 
 
-class Serializer(object):
+class Serializer:
     NSRMAP = {'': None, XML_NS: 'xml', XHTML_NS: '', MBP_NS: 'mbp'}
 
     def __init__(self, oeb, images, is_periodical, write_page_breaks_after_item=True):

--- a/src/calibre/ebooks/mobi/writer8/cleanup.py
+++ b/src/calibre/ebooks/mobi/writer8/cleanup.py
@@ -9,7 +9,7 @@ __docformat__ = 'restructuredtext en'
 from calibre.ebooks.oeb.base import XPath
 
 
-class CSSCleanup(object):
+class CSSCleanup:
 
     def __init__(self, log, opts):
         self.log, self.opts = log, opts

--- a/src/calibre/ebooks/mobi/writer8/index.py
+++ b/src/calibre/ebooks/mobi/writer8/index.py
@@ -92,7 +92,7 @@ class IndexHeader(Header):  # {{{
 # }}}
 
 
-class Index(object):  # {{{
+class Index:  # {{{
 
     control_byte_count = 1
     cncx = CNCX()

--- a/src/calibre/ebooks/mobi/writer8/main.py
+++ b/src/calibre/ebooks/mobi/writer8/main.py
@@ -39,7 +39,7 @@ XML_DOCS = OEB_DOCS | {SVG_MIME}
 to_ref = partial(to_base, base=32, min_num_digits=4)
 
 
-class KF8Writer(object):
+class KF8Writer:
 
     def __init__(self, oeb, opts, resources):
         self.oeb, self.opts, self.log = oeb, opts, oeb.log

--- a/src/calibre/ebooks/mobi/writer8/mobi.py
+++ b/src/calibre/ebooks/mobi/writer8/mobi.py
@@ -218,7 +218,7 @@ HEADER_FIELDS = {'compression', 'text_length', 'last_text_record', 'book_type',
                     'flis_record', 'fcis_record', 'uid'}
 
 
-class KF8Book(object):
+class KF8Book:
 
     def __init__(self, writer, for_joint=False):
         self.build_records(writer, for_joint)

--- a/src/calibre/ebooks/mobi/writer8/skeleton.py
+++ b/src/calibre/ebooks/mobi/writer8/skeleton.py
@@ -78,7 +78,7 @@ def tostring(raw, **kwargs):
             ans).encode(encoding)
 
 
-class Chunk(object):
+class Chunk:
 
     def __init__(self, raw, selector):
         self.raw = raw
@@ -102,7 +102,7 @@ class Chunk(object):
     __str__ = __repr__
 
 
-class Skeleton(object):
+class Skeleton:
 
     def __init__(self, file_number, item, root, chunks):
         self.file_number, self.item = file_number, item
@@ -155,7 +155,7 @@ class Skeleton(object):
         return b''.join([self.skeleton] + [x.raw for x in self.chunks])
 
 
-class Chunker(object):
+class Chunker:
 
     def __init__(self, oeb, data_func, placeholder_map):
         self.oeb, self.log = oeb, oeb.log

--- a/src/calibre/ebooks/mobi/writer8/toc.py
+++ b/src/calibre/ebooks/mobi/writer8/toc.py
@@ -42,7 +42,7 @@ def find_previous_calibre_inline_toc(oeb):
                 return item
 
 
-class TOCAdder(object):
+class TOCAdder:
 
     def __init__(self, oeb, opts, replace_previous_inline_toc=True, ignore_existing_toc=False):
         self.oeb, self.opts, self.log = oeb, opts, oeb.log

--- a/src/calibre/ebooks/oeb/base.py
+++ b/src/calibre/ebooks/oeb/base.py
@@ -521,7 +521,7 @@ class OEBError(Exception):
     pass
 
 
-class NullContainer(object):
+class NullContainer:
     """An empty container.
 
     For use with book formats which do not support container-like access.
@@ -543,7 +543,7 @@ class NullContainer(object):
         return []
 
 
-class DirContainer(object):
+class DirContainer:
     """Filesystem directory container."""
 
     def __init__(self, path, log, ignore_opf=False):
@@ -623,7 +623,7 @@ class DirContainer(object):
         return names
 
 
-class Metadata(object):
+class Metadata:
     """A collection of OEB data model metadata.
 
     Provides access to the list of items associated with a particular metadata
@@ -645,7 +645,7 @@ class Metadata(object):
     OPF2_NSMAP    = {'opf': OPF2_NS, 'dc': DC11_NS, 'dcterms': DCTERMS_NS,
                      'xsi': XSI_NS, 'calibre': CALIBRE_NS}
 
-    class Item(object):
+    class Item:
         """An item of OEB data model metadata.
 
         The metadata term or name may be accessed via the :attr:`term` or
@@ -658,7 +658,7 @@ class Metadata(object):
         their local names using Python attribute syntax.  Only attributes
         allowed by the OPF 2.0 specification are supported.
         """
-        class Attribute(object):
+        class Attribute:
             """Smart accessor for allowed OEB metadata item attributes."""
 
             def __init__(self, attr, allowed=None):
@@ -876,7 +876,7 @@ class Metadata(object):
         return elem
 
 
-class Manifest(object):
+class Manifest:
     """Collection of files composing an OEB data model book.
 
     Provides access to the content of the files composing the book and
@@ -892,7 +892,7 @@ class Manifest(object):
         manifest items and the values are the items themselves.
     """
 
-    class Item(object):
+    class Item:
         """An OEB data model book content file.
 
         Provides the following data members for accessing the file content and
@@ -1273,7 +1273,7 @@ class Manifest(object):
         self._main_stylesheet = item
 
 
-class Spine(object):
+class Spine:
     """Collection of manifest items composing an OEB data model book's main
     textual content.
 
@@ -1356,7 +1356,7 @@ class Spine(object):
         return elem
 
 
-class Guide(object):
+class Guide:
     """Collection of references to standard frequently-occurring sections
     within an OEB data model book.
 
@@ -1364,7 +1364,7 @@ class Guide(object):
     type identifiers and the values are `Reference` objects.
     """
 
-    class Reference(object):
+    class Reference:
         """Reference to a standard book section.
 
         Provides the following instance data members:
@@ -1488,7 +1488,7 @@ class Guide(object):
         return elem
 
 
-class TOC(object):
+class TOC:
     """Represents a hierarchical table of contents or navigation tree for
     accessing arbitrary semantic sections within an OEB data model book.
 
@@ -1671,14 +1671,14 @@ class TOC(object):
                 x.play_order = y.play_order
 
 
-class PageList(object):
+class PageList:
     """Collection of named "pages" to mapped positions within an OEB data model
     book's textual content.
 
     Provides list-like access to the pages.
     """
 
-    class Page(object):
+    class Page:
         """Represents a mapping between a page name and a position within
         the book content.
 
@@ -1751,7 +1751,7 @@ class PageList(object):
         return pmap
 
 
-class OEBBook(object):
+class OEBBook:
     """Representation of a book in the IDPF OEB data model."""
 
     COVER_SVG_XP    = XPath('h:body//svg:svg[position() = 1]')

--- a/src/calibre/ebooks/oeb/display/webview.py
+++ b/src/calibre/ebooks/oeb/display/webview.py
@@ -12,7 +12,7 @@ from calibre import guess_type
 from polyglot.builtins import iteritems
 
 
-class EntityDeclarationProcessor(object):  # {{{
+class EntityDeclarationProcessor:  # {{{
 
     def __init__(self, html):
         self.declared_entities = {}

--- a/src/calibre/ebooks/oeb/iterator/book.py
+++ b/src/calibre/ebooks/oeb/iterator/book.py
@@ -30,7 +30,7 @@ TITLEPAGE = CoverManager.SVG_TEMPLATE.replace(
         ).replace('__width__', '600').replace('__height__', '800')
 
 
-class FakeOpts(object):
+class FakeOpts:
     verbose = 0
     breadth_first = False
     max_levels = 5

--- a/src/calibre/ebooks/oeb/iterator/bookmarks.py
+++ b/src/calibre/ebooks/oeb/iterator/bookmarks.py
@@ -44,7 +44,7 @@ def parse_bookmarks(raw):
             yield {'type':'cfi', 'title':title, 'pos':pos, 'spine':spine}
 
 
-class BookmarksMixin(object):
+class BookmarksMixin:
 
     def __init__(self, copy_bookmarks_to_file=True):
         self.copy_bookmarks_to_file = copy_bookmarks_to_file

--- a/src/calibre/ebooks/oeb/iterator/spine.py
+++ b/src/calibre/ebooks/oeb/iterator/spine.py
@@ -86,7 +86,7 @@ class SpineItem(unicode_type):
         return obj
 
 
-class IndexEntry(object):
+class IndexEntry:
 
     def __init__(self, spine, toc_entry, num):
         self.num = num

--- a/src/calibre/ebooks/oeb/polish/check/base.py
+++ b/src/calibre/ebooks/oeb/polish/check/base.py
@@ -15,7 +15,7 @@ from polyglot.builtins import range
 DEBUG, INFO, WARN, ERROR, CRITICAL = range(5)
 
 
-class BaseError(object):
+class BaseError:
 
     HELP = ''
     INDIVIDUAL_FIX = ''

--- a/src/calibre/ebooks/oeb/polish/check/css.py
+++ b/src/calibre/ebooks/oeb/polish/check/css.py
@@ -173,7 +173,7 @@ class Worker(QWebEnginePage):
         self.work_done.emit(self, result)
 
 
-class Pool(object):
+class Pool:
 
     def __init__(self):
         self.workers = []

--- a/src/calibre/ebooks/oeb/polish/check/links.py
+++ b/src/calibre/ebooks/oeb/polish/check/links.py
@@ -53,7 +53,7 @@ class CaseMismatch(BadLink):
             nhref += '#' + frag
         orig_href = self.href
 
-        class LinkReplacer(object):
+        class LinkReplacer:
             replaced = False
 
             def __call__(self, url):

--- a/src/calibre/ebooks/oeb/polish/check/main.py
+++ b/src/calibre/ebooks/oeb/polish/check/main.py
@@ -24,7 +24,7 @@ from polyglot.builtins import as_unicode
 XML_TYPES = frozenset(map(guess_type, ('a.xml', 'a.svg', 'a.opf', 'a.ncx'))) | {'application/oebps-page-map+xml'}
 
 
-class CSSChecker(object):
+class CSSChecker:
 
     def __init__(self):
         self.jobs = []

--- a/src/calibre/ebooks/oeb/polish/check/parsing.py
+++ b/src/calibre/ebooks/oeb/polish/check/parsing.py
@@ -210,7 +210,7 @@ class NonUTF8(BaseError):
                 return True
 
 
-class EntitityProcessor(object):
+class EntitityProcessor:
 
     def __init__(self, mt):
         self.entities = ALL_ENTITIES if mt in OEB_DOCS else XML_ENTITIES
@@ -429,7 +429,7 @@ class BareTextInBody(BaseError):
         return True
 
 
-class ErrorHandler(object):
+class ErrorHandler:
 
     ' Replacement logger to get useful error/warning info out of css_parser during parsing '
 

--- a/src/calibre/ebooks/oeb/polish/container.py
+++ b/src/calibre/ebooks/oeb/polish/container.py
@@ -124,7 +124,7 @@ def href_to_name(href, root, base=None):
     return unicodedata.normalize('NFC', abspath_to_name(fullpath, root))
 
 
-class ContainerBase(object):  # {{{
+class ContainerBase:  # {{{
     '''
     A base class that implements just the parsing methods. Useful to create
     virtual containers for testing.

--- a/src/calibre/ebooks/oeb/polish/download.py
+++ b/src/calibre/ebooks/oeb/polish/download.py
@@ -78,7 +78,7 @@ def get_content_length(response):
         return -1
 
 
-class ProgressTracker(object):
+class ProgressTracker:
 
     def __init__(self, fobj, url, sz, progress_report):
         self.fobj = fobj

--- a/src/calibre/ebooks/oeb/polish/replace.py
+++ b/src/calibre/ebooks/oeb/polish/replace.py
@@ -19,7 +19,7 @@ from calibre.ebooks.oeb.polish.utils import extract
 from polyglot.urllib import urlparse, urlunparse
 
 
-class LinkReplacer(object):
+class LinkReplacer:
 
     def __init__(self, base, container, link_map, frag_map):
         self.base = base
@@ -52,7 +52,7 @@ class LinkReplacer(object):
         return href
 
 
-class IdReplacer(object):
+class IdReplacer:
 
     def __init__(self, base, container, id_map):
         self.base, self.container, self.replaced = base, container, False
@@ -82,7 +82,7 @@ class IdReplacer(object):
         return href
 
 
-class LinkRebaser(object):
+class LinkRebaser:
 
     def __init__(self, container, old_name, new_name):
         self.old_name, self.new_name = old_name, new_name

--- a/src/calibre/ebooks/oeb/polish/spell.py
+++ b/src/calibre/ebooks/oeb/polish/spell.py
@@ -21,7 +21,7 @@ from polyglot.builtins import iteritems, unicode_type, filter
 _patterns = None
 
 
-class Patterns(object):
+class Patterns:
 
     __slots__ = ('sanitize_invisible_pat', 'split_pat', 'digit_pat', 'fr_elision_pat')
 
@@ -47,7 +47,7 @@ def patterns():
     return _patterns
 
 
-class CharCounter(object):
+class CharCounter:
 
     def __init__(self):
         self.counter = Counter()
@@ -55,7 +55,7 @@ class CharCounter(object):
         self.update = self.counter.update
 
 
-class Location(object):
+class Location:
 
     __slots__ = ('file_name', 'sourceline', 'original_word', 'location_node', 'node_item', 'elided_prefix')
 

--- a/src/calibre/ebooks/oeb/polish/split.py
+++ b/src/calibre/ebooks/oeb/polish/split.py
@@ -149,7 +149,7 @@ def do_split(split_point, log, before=True):
     return tree, tree2
 
 
-class SplitLinkReplacer(object):
+class SplitLinkReplacer:
 
     def __init__(self, base, bottom_anchors, top_name, bottom_name, container):
         self.bottom_anchors, self.bottom_name = bottom_anchors, bottom_name
@@ -298,7 +298,7 @@ def multisplit(container, name, xpath, before=True):
     return all_names[1:]
 
 
-class MergeLinkReplacer(object):
+class MergeLinkReplacer:
 
     def __init__(self, base, anchor_map, master, container):
         self.container, self.anchor_map = container, anchor_map

--- a/src/calibre/ebooks/oeb/polish/stats.py
+++ b/src/calibre/ebooks/oeb/polish/stats.py
@@ -178,7 +178,7 @@ def prepare_font_rule(cssdict):
     cssdict['weight'] = int(cssdict['font-weight'])
 
 
-class StatsCollector(object):
+class StatsCollector:
 
     first_letter_pat = capitalize_pat = None
 

--- a/src/calibre/ebooks/oeb/polish/toc.py
+++ b/src/calibre/ebooks/oeb/polish/toc.py
@@ -31,7 +31,7 @@ ns.prefix = 'calibre'
 ns['lower-case'] = lambda c, x: x.lower() if hasattr(x, 'lower') else x
 
 
-class TOC(object):
+class TOC:
 
     toc_title = None
 

--- a/src/calibre/ebooks/oeb/polish/utils.py
+++ b/src/calibre/ebooks/oeb/polish/utils.py
@@ -72,7 +72,7 @@ def corrected_case_for_name(container, name):
     return '/'.join(ans)
 
 
-class PositionFinder(object):
+class PositionFinder:
 
     def __init__(self, raw):
         pat = br'\n' if isinstance(raw, bytes) else r'\n'
@@ -87,7 +87,7 @@ class PositionFinder(object):
         return (lnum + 1, offset)
 
 
-class CommentFinder(object):
+class CommentFinder:
 
     def __init__(self, raw, pat=r'(?s)/\*.*?\*/'):
         self.starts, self.ends = [], []

--- a/src/calibre/ebooks/oeb/reader.py
+++ b/src/calibre/ebooks/oeb/reader.py
@@ -33,7 +33,7 @@ from polyglot.urllib import unquote, urldefrag, urlparse
 __all__ = ['OEBReader']
 
 
-class OEBReader(object):
+class OEBReader:
     """Read an OEBPS 1.x or OPF/OPS 2.0 file collection."""
 
     COVER_SVG_XP    = XPath('h:body//svg:svg[position() = 1]')

--- a/src/calibre/ebooks/oeb/stylizer.py
+++ b/src/calibre/ebooks/oeb/stylizer.py
@@ -103,7 +103,7 @@ def test_media_ok():
     assert not media_ok('screen and (device-width:10px)')
 
 
-class StylizerRules(object):
+class StylizerRules:
 
     def __init__(self, opts, profile, stylesheets):
         self.opts, self.profile, self.stylesheets = opts, profile, stylesheets
@@ -189,7 +189,7 @@ class StylizerRules(object):
         return True
 
 
-class Stylizer(object):
+class Stylizer:
     STYLESHEETS = WeakKeyDictionary()
 
     def __init__(self, tree, path, oeb, opts, profile=None,
@@ -407,7 +407,7 @@ class Stylizer(object):
         return '\n'.join(rules)
 
 
-class Style(object):
+class Style:
     MS_PAT = re.compile(r'^\s*(mso-|panose-|text-underline|tab-interval)')
 
     def __init__(self, element, stylizer):

--- a/src/calibre/ebooks/oeb/transforms/cover.py
+++ b/src/calibre/ebooks/oeb/transforms/cover.py
@@ -15,7 +15,7 @@ from polyglot.builtins import unicode_type
 from polyglot.urllib import unquote
 
 
-class CoverManager(object):
+class CoverManager:
 
     SVG_TEMPLATE = textwrap.dedent('''\
         <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">

--- a/src/calibre/ebooks/oeb/transforms/data_url.py
+++ b/src/calibre/ebooks/oeb/transforms/data_url.py
@@ -10,7 +10,7 @@ from calibre.ebooks.oeb.base import XPath, urlunquote
 from polyglot.builtins import as_bytes
 
 
-class DataURL(object):
+class DataURL:
 
     def __call__(self, oeb, opts):
         from calibre.utils.imghdr import what

--- a/src/calibre/ebooks/oeb/transforms/embed_fonts.py
+++ b/src/calibre/ebooks/oeb/transforms/embed_fonts.py
@@ -86,7 +86,7 @@ def used_font(style, embedded_fonts):
     return True, matching_set[0]
 
 
-class EmbedFonts(object):
+class EmbedFonts:
 
     '''
     Embed all referenced fonts, if found on system. Must be called after CSS flattening.

--- a/src/calibre/ebooks/oeb/transforms/filenames.py
+++ b/src/calibre/ebooks/oeb/transforms/filenames.py
@@ -14,7 +14,7 @@ from calibre.ebooks.oeb.base import rewrite_links, urlnormalize
 from polyglot.urllib import urldefrag, urlparse
 
 
-class RenameFiles(object):  # {{{
+class RenameFiles:  # {{{
 
     '''
     Rename files and adjust all links pointing to them. Note that the spine
@@ -88,7 +88,7 @@ class RenameFiles(object):  # {{{
 # }}}
 
 
-class UniqueFilenames(object):  # {{{
+class UniqueFilenames:  # {{{
 
     'Ensure that every item in the manifest has a unique filename'
 
@@ -140,7 +140,7 @@ class UniqueFilenames(object):  # {{{
 # }}}
 
 
-class FlatFilenames(object):  # {{{
+class FlatFilenames:  # {{{
 
     'Ensure that every item in the manifest has a unique filename without subfolders.'
 

--- a/src/calibre/ebooks/oeb/transforms/flatcss.py
+++ b/src/calibre/ebooks/oeb/transforms/flatcss.py
@@ -33,7 +33,7 @@ def asfloat(value, default):
     return float(value)
 
 
-class KeyMapper(object):
+class KeyMapper:
 
     def __init__(self, sbase, dbase, dkey):
         self.sbase = float(sbase)
@@ -83,7 +83,7 @@ class KeyMapper(object):
         return dsize
 
 
-class ScaleMapper(object):
+class ScaleMapper:
 
     def __init__(self, sbase, dbase):
         self.dscale = float(dbase) / float(sbase)
@@ -94,7 +94,7 @@ class ScaleMapper(object):
         return dsize
 
 
-class NullMapper(object):
+class NullMapper:
 
     def __init__(self):
         pass
@@ -112,7 +112,7 @@ def FontMapper(sbase=None, dbase=None, dkey=None):
         return NullMapper()
 
 
-class EmbedFontsCSSRules(object):
+class EmbedFontsCSSRules:
 
     def __init__(self, body_font_family, rules):
         self.body_font_family, self.rules = body_font_family, rules
@@ -131,7 +131,7 @@ class EmbedFontsCSSRules(object):
         return self.href
 
 
-class CSSFlattener(object):
+class CSSFlattener:
 
     def __init__(self, fbase=None, fkey=None, lineh=None, unfloat=False,
                  untable=False, page_break_on_body=False, specializer=None,

--- a/src/calibre/ebooks/oeb/transforms/guide.py
+++ b/src/calibre/ebooks/oeb/transforms/guide.py
@@ -7,7 +7,7 @@ __copyright__ = '2009, Kovid Goyal <kovid@kovidgoyal.net>'
 __docformat__ = 'restructuredtext en'
 
 
-class Clean(object):
+class Clean:
     '''Clean up guide, leaving only known values '''
 
     def __call__(self, oeb, opts):

--- a/src/calibre/ebooks/oeb/transforms/htmltoc.py
+++ b/src/calibre/ebooks/oeb/transforms/htmltoc.py
@@ -46,7 +46,7 @@ body > .calibre_toc_block {
     }
 
 
-class HTMLTOCAdder(object):
+class HTMLTOCAdder:
 
     def __init__(self, title=None, style='nested', position='end'):
         self.title = title

--- a/src/calibre/ebooks/oeb/transforms/jacket.py
+++ b/src/calibre/ebooks/oeb/transforms/jacket.py
@@ -39,7 +39,7 @@ class SafeFormatter(Formatter):
             return ''
 
 
-class Base(object):
+class Base:
 
     def remove_images(self, item, limit=1):
         path = XPath('//h:img[@src]')

--- a/src/calibre/ebooks/oeb/transforms/linearize_tables.py
+++ b/src/calibre/ebooks/oeb/transforms/linearize_tables.py
@@ -9,7 +9,7 @@ __docformat__ = 'restructuredtext en'
 from calibre.ebooks.oeb.base import OEB_DOCS, XPath, XHTML
 
 
-class LinearizeTables(object):
+class LinearizeTables:
 
     def linearize(self, root):
         for x in XPath('//h:table|//h:td|//h:tr|//h:th|//h:caption|'

--- a/src/calibre/ebooks/oeb/transforms/manglecase.py
+++ b/src/calibre/ebooks/oeb/transforms/manglecase.py
@@ -23,7 +23,7 @@ CASE_MANGLER_CSS = """
 TEXT_TRANSFORMS = {'capitalize', 'uppercase', 'lowercase'}
 
 
-class CaseMangler(object):
+class CaseMangler:
 
     @classmethod
     def config(cls, cfg):

--- a/src/calibre/ebooks/oeb/transforms/metadata.py
+++ b/src/calibre/ebooks/oeb/transforms/metadata.py
@@ -101,7 +101,7 @@ def meta_info_to_oeb_metadata(mi, m, log, override_input_metadata=False):
         m.add('timestamp', isoformat(now()))
 
 
-class MergeMetadata(object):
+class MergeMetadata:
     'Merge in user metadata, including cover'
 
     def __call__(self, oeb, mi, opts, override_input_metadata=False):

--- a/src/calibre/ebooks/oeb/transforms/page_margin.py
+++ b/src/calibre/ebooks/oeb/transforms/page_margin.py
@@ -13,7 +13,7 @@ from calibre.ebooks.oeb.base import barename, XPath
 from polyglot.builtins import iteritems
 
 
-class RemoveAdobeMargins(object):
+class RemoveAdobeMargins:
     '''
     Remove margins specified in Adobe's page templates.
     '''
@@ -40,7 +40,7 @@ class NegativeTextIndent(Exception):
     pass
 
 
-class RemoveFakeMargins(object):
+class RemoveFakeMargins:
 
     '''
     Remove left and right margins from paragraph/divs if the same margin is specified

--- a/src/calibre/ebooks/oeb/transforms/rasterize.py
+++ b/src/calibre/ebooks/oeb/transforms/rasterize.py
@@ -28,7 +28,7 @@ class Unavailable(Exception):
     pass
 
 
-class SVGRasterizer(object):
+class SVGRasterizer:
 
     def __init__(self, base_css=''):
         self.base_css = base_css

--- a/src/calibre/ebooks/oeb/transforms/rescale.py
+++ b/src/calibre/ebooks/oeb/transforms/rescale.py
@@ -9,7 +9,7 @@ __docformat__ = 'restructuredtext en'
 from calibre import fit_image
 
 
-class RescaleImages(object):
+class RescaleImages:
 
     'Rescale all images to fit inside given screen size'
 

--- a/src/calibre/ebooks/oeb/transforms/split.py
+++ b/src/calibre/ebooks/oeb/transforms/split.py
@@ -43,7 +43,7 @@ class SplitError(ValueError):
                             path=path, size=size))
 
 
-class Split(object):
+class Split:
 
     def __init__(self, split_on_page_breaks=True, page_breaks_xpath=None,
             max_flow_size=0, remove_css_pagebreaks=True):
@@ -186,7 +186,7 @@ class Split(object):
         return url
 
 
-class FlowSplitter(object):
+class FlowSplitter:
     'The actual splitting logic'
 
     def __init__(self, item, page_breaks, page_break_ids, max_flow_size, oeb,

--- a/src/calibre/ebooks/oeb/transforms/structure.py
+++ b/src/calibre/ebooks/oeb/transforms/structure.py
@@ -47,7 +47,7 @@ def at_start(elem):
     return False
 
 
-class DetectStructure(object):
+class DetectStructure:
 
     def __call__(self, oeb, opts):
         self.log = oeb.log

--- a/src/calibre/ebooks/oeb/transforms/subset.py
+++ b/src/calibre/ebooks/oeb/transforms/subset.py
@@ -119,7 +119,7 @@ def elem_style(style_rules, cls, inherited_style):
     return style
 
 
-class SubsetFonts(object):
+class SubsetFonts:
 
     '''
     Subset all embedded fonts. Must be run after CSS flattening, as it requires

--- a/src/calibre/ebooks/oeb/transforms/trimmanifest.py
+++ b/src/calibre/ebooks/oeb/transforms/trimmanifest.py
@@ -11,7 +11,7 @@ from calibre.ebooks.oeb.base import urlnormalize, iterlinks
 from polyglot.urllib import urldefrag
 
 
-class ManifestTrimmer(object):
+class ManifestTrimmer:
 
     @classmethod
     def config(cls, cfg):

--- a/src/calibre/ebooks/oeb/transforms/unsmarten.py
+++ b/src/calibre/ebooks/oeb/transforms/unsmarten.py
@@ -9,7 +9,7 @@ from calibre.ebooks.oeb.base import OEB_DOCS, XPath, barename
 from calibre.utils.unsmarten import unsmarten_text
 
 
-class UnsmartenPunctuation(object):
+class UnsmartenPunctuation:
 
     def __init__(self):
         self.html_tags = XPath('descendant::h:*')

--- a/src/calibre/ebooks/oeb/writer.py
+++ b/src/calibre/ebooks/oeb/writer.py
@@ -13,7 +13,7 @@ from calibre.ebooks.oeb.base import DirContainer, OEBError
 __all__ = ['OEBWriter']
 
 
-class OEBWriter(object):
+class OEBWriter:
     DEFAULT_PROFILE = 'PRS505'
     """Default renderer profile for content written with this Writer."""
 

--- a/src/calibre/ebooks/pdb/ereader/reader132.py
+++ b/src/calibre/ebooks/pdb/ereader/reader132.py
@@ -22,7 +22,7 @@ from calibre.ebooks.pdb.formatreader import FormatReader
 from polyglot.builtins import unicode_type, range
 
 
-class HeaderRecord(object):
+class HeaderRecord:
     '''
     The first record in the file is always the header record. It holds
     information related to the location of text, images, and so on

--- a/src/calibre/ebooks/pdb/ereader/reader202.py
+++ b/src/calibre/ebooks/pdb/ereader/reader202.py
@@ -18,7 +18,7 @@ from calibre.ebooks.pdb.formatreader import FormatReader
 from polyglot.builtins import as_unicode, range, unicode_type
 
 
-class HeaderRecord(object):
+class HeaderRecord:
     '''
     The first record in the file is always the header record. It holds
     information related to the location of text, images, and so on

--- a/src/calibre/ebooks/pdb/formatreader.py
+++ b/src/calibre/ebooks/pdb/formatreader.py
@@ -10,7 +10,7 @@ __copyright__ = '2009, John Schember <john@nachtimwald.com>'
 __docformat__ = 'restructuredtext en'
 
 
-class FormatReader(object):
+class FormatReader:
 
     def __init__(self, header, stream, log, options):
         raise NotImplementedError()

--- a/src/calibre/ebooks/pdb/formatwriter.py
+++ b/src/calibre/ebooks/pdb/formatwriter.py
@@ -10,7 +10,7 @@ __copyright__ = '2009, John Schember <john@nachtimwald.com>'
 __docformat__ = 'restructuredtext en'
 
 
-class FormatWriter(object):
+class FormatWriter:
 
     def __init__(self, opts, log):
         raise NotImplementedError()

--- a/src/calibre/ebooks/pdb/haodoo/reader.py
+++ b/src/calibre/ebooks/pdb/haodoo/reader.py
@@ -58,7 +58,7 @@ def fix_punct(line):
     return line
 
 
-class LegacyHeaderRecord(object):
+class LegacyHeaderRecord:
 
     def __init__(self, raw):
         fields = raw.lstrip().replace(b'\x1b\x1b\x1b', b'\x1b').split(b'\x1b')
@@ -69,7 +69,7 @@ class LegacyHeaderRecord(object):
             fields[2:]))
 
 
-class UnicodeHeaderRecord(object):
+class UnicodeHeaderRecord:
 
     def __init__(self, raw):
         fields = raw.lstrip().replace(b'\x1b\x00\x1b\x00\x1b\x00',

--- a/src/calibre/ebooks/pdb/header.py
+++ b/src/calibre/ebooks/pdb/header.py
@@ -15,7 +15,7 @@ import time
 from polyglot.builtins import long_type
 
 
-class PdbHeaderReader(object):
+class PdbHeaderReader:
 
     def __init__(self, stream):
         self.stream = stream
@@ -66,7 +66,7 @@ class PdbHeaderReader(object):
         return self.stream.read(end - start)
 
 
-class PdbHeaderBuilder(object):
+class PdbHeaderBuilder:
 
     def __init__(self, identity, title):
         self.identity = identity.ljust(3, '\x00')[:8].encode('utf-8')

--- a/src/calibre/ebooks/pdb/palmdoc/reader.py
+++ b/src/calibre/ebooks/pdb/palmdoc/reader.py
@@ -15,7 +15,7 @@ import struct, io
 from calibre.ebooks.pdb.formatreader import FormatReader
 
 
-class HeaderRecord(object):
+class HeaderRecord:
     '''
     The first record in the file is always the header record. It holds
     information related to the location of text, images, and so on

--- a/src/calibre/ebooks/pdb/plucker/reader.py
+++ b/src/calibre/ebooks/pdb/plucker/reader.py
@@ -111,7 +111,7 @@ MIBNUM_TO_NAME = {
 }
 
 
-class HeaderRecord(object):
+class HeaderRecord:
     '''
     Plucker header. PDB record 0.
     '''
@@ -137,7 +137,7 @@ class HeaderRecord(object):
                 self.home_html = id
 
 
-class SectionHeader(object):
+class SectionHeader:
     '''
     Every sections (record) has this header. It gives
     details about the section such as it's uid.
@@ -151,7 +151,7 @@ class SectionHeader(object):
         self.flags, = struct.unpack('>B', raw[7:8])
 
 
-class SectionHeaderText(object):
+class SectionHeaderText:
     '''
     Sub header for text records.
     '''
@@ -176,7 +176,7 @@ class SectionHeaderText(object):
             self.paragraph_offsets.append(running_offset)
 
 
-class SectionMetadata(object):
+class SectionMetadata:
     '''
     Metadata.
 
@@ -234,7 +234,7 @@ class SectionMetadata(object):
             adv += 2*length
 
 
-class SectionText(object):
+class SectionText:
     '''
     Text data. Stores a text section header and the PHTML.
     '''
@@ -244,7 +244,7 @@ class SectionText(object):
         self.data = raw[section_header.paragraphs * 4:]
 
 
-class SectionCompositeImage(object):
+class SectionCompositeImage:
     '''
     A composite image consists of a 2D array
     of rows and columns. The entries in the array

--- a/src/calibre/ebooks/pdb/ztxt/reader.py
+++ b/src/calibre/ebooks/pdb/ztxt/reader.py
@@ -20,7 +20,7 @@ from calibre.ebooks.pdb.ztxt import zTXTError
 SUPPORTED_VERSION = (1, 40)
 
 
-class HeaderRecord(object):
+class HeaderRecord:
     '''
     The first record in the file is always the header record. It holds
     information related to the location of text, images, and so on

--- a/src/calibre/ebooks/pdf/html_writer.py
+++ b/src/calibre/ebooks/pdf/html_writer.py
@@ -535,7 +535,7 @@ def make_anchors_unique(container, log):
     return name_anchor_map
 
 
-class AnchorLocation(object):
+class AnchorLocation:
 
     __slots__ = ('pagenum', 'left', 'top', 'zoom')
 
@@ -591,7 +591,7 @@ def fix_links(pdf_doc, anchor_locations, name_anchor_map, mark_links, log):
 
 
 # Outline creation {{{
-class PDFOutlineRoot(object):
+class PDFOutlineRoot:
 
     def __init__(self, pdf_doc):
         self.pdf_doc = pdf_doc

--- a/src/calibre/ebooks/pdf/image_writer.py
+++ b/src/calibre/ebooks/pdf/image_writer.py
@@ -13,7 +13,7 @@ from calibre.utils.imghdr import identify
 from polyglot.builtins import as_unicode
 
 
-class PDFMetadata(object):  # {{{
+class PDFMetadata:  # {{{
 
     def __init__(self, mi=None):
         from calibre import force_unicode
@@ -91,7 +91,7 @@ def get_page_layout(opts, for_comic=False):
 # }}}
 
 
-class Image(object):  # {{{
+class Image:  # {{{
 
     def __init__(self, path_or_bytes):
         if not isinstance(path_or_bytes, bytes):

--- a/src/calibre/ebooks/pdf/reflow.py
+++ b/src/calibre/ebooks/pdf/reflow.py
@@ -15,7 +15,7 @@ from polyglot.builtins import range, map
 from calibre.utils.xml_parse import safe_xml_fromstring
 
 
-class Font(object):
+class Font:
 
     def __init__(self, spec):
         self.id = spec.get('id')
@@ -24,7 +24,7 @@ class Font(object):
         self.family = spec.get('family')
 
 
-class Element(object):
+class Element:
 
     def __init__(self):
         self.starts_block = None
@@ -119,7 +119,7 @@ class FontSizeStats(dict):
             self[sz] = chars/total
 
 
-class Interval(object):
+class Interval:
 
     def __init__(self, left, right):
         self.left, self.right = left, right
@@ -145,7 +145,7 @@ class Interval(object):
         return hash('(%f,%f)'%self.left, self.right)
 
 
-class Column(object):
+class Column:
 
     # A column contains an element is the element bulges out to
     # the left or the right by at most HFUZZ*col width.
@@ -252,7 +252,7 @@ class ImageBox(Box):
         return ans
 
 
-class Region(object):
+class Region:
 
     def __init__(self, opts, log):
         self.opts, self.log = opts, log
@@ -409,7 +409,7 @@ class Region(object):
                 self.boxes[-1].append(elem)
 
 
-class Page(object):
+class Page:
 
     # Fraction of a character width that two strings have to be apart,
     # for them to be considered part of the same text fragment
@@ -619,7 +619,7 @@ class Page(object):
             region.linearize()
 
 
-class PDFDocument(object):
+class PDFDocument:
 
     def __init__(self, xml, opts, log):
         self.opts, self.log = opts, log

--- a/src/calibre/ebooks/pdf/render/common.py
+++ b/src/calibre/ebooks/pdf/render/common.py
@@ -219,7 +219,7 @@ class Stream(BytesIO):
         BytesIO.write(self, raw)
 
 
-class Reference(object):
+class Reference:
 
     def __init__(self, num, obj):
         self.num, self.obj = num, obj

--- a/src/calibre/ebooks/pdf/render/fonts.py
+++ b/src/calibre/ebooks/pdf/render/fonts.py
@@ -117,7 +117,7 @@ class CMap(Stream):
         self.write(self.skeleton.format(name=name, mapping='\n'.join(mapping)))
 
 
-class Font(object):
+class Font:
 
     def __init__(self, metrics, num, objects, compress):
         self.metrics, self.compress = metrics, compress
@@ -218,7 +218,7 @@ class Font(object):
         self.descendant_font['W'] = objects.add(groups)
 
 
-class FontManager(object):
+class FontManager:
 
     def __init__(self, objects, compress):
         self.objects = objects

--- a/src/calibre/ebooks/pdf/render/graphics.py
+++ b/src/calibre/ebooks/pdf/render/graphics.py
@@ -251,7 +251,7 @@ class TexturePattern(TilingPattern):
             self.write(clone.getvalue())
 
 
-class GraphicsState(object):
+class GraphicsState:
 
     FIELDS = ('fill', 'stroke', 'opacity', 'transform', 'brush_origin',
                   'clip_updated', 'do_fill', 'do_stroke')
@@ -285,7 +285,7 @@ class GraphicsState(object):
         return ans
 
 
-class Graphics(object):
+class Graphics:
 
     def __init__(self, page_width_px, page_height_px):
         self.base_state = GraphicsState()

--- a/src/calibre/ebooks/pdf/render/links.py
+++ b/src/calibre/ebooks/pdf/render/links.py
@@ -32,7 +32,7 @@ class Destination(Array):
         ])
 
 
-class Links(object):
+class Links:
 
     def __init__(self, pdf, mark_links, page_size):
         self.anchors = {}

--- a/src/calibre/ebooks/pdf/render/serialize.py
+++ b/src/calibre/ebooks/pdf/render/serialize.py
@@ -23,7 +23,7 @@ from polyglot.builtins import as_unicode
 PDFVER = b'%PDF-1.4'  # 1.4 is needed for XMP metadata
 
 
-class IndirectObjects(object):
+class IndirectObjects:
 
     def __init__(self):
         self._list = []
@@ -152,7 +152,7 @@ class Page(Stream):
         return ret
 
 
-class Path(object):
+class Path:
 
     def __init__(self):
         self.ops = []
@@ -199,7 +199,7 @@ class PageTree(Dictionary):
             return -1
 
 
-class HashingStream(object):
+class HashingStream:
 
     def __init__(self, f):
         self.f = f
@@ -259,7 +259,7 @@ class Metadata(Stream):
         d['Subtype'] = Name('XML')
 
 
-class PDFStream(object):
+class PDFStream:
 
     PATH_OPS = {
         # stroke fill   fill-rule

--- a/src/calibre/ebooks/pml/pmlconverter.py
+++ b/src/calibre/ebooks/pml/pmlconverter.py
@@ -18,7 +18,7 @@ from calibre import my_unichr, prepare_string_for_xml
 from calibre.ebooks.metadata.toc import TOC
 
 
-class PML_HTMLizer(object):
+class PML_HTMLizer:
 
     STATES = [
         'i',

--- a/src/calibre/ebooks/pml/pmlml.py
+++ b/src/calibre/ebooks/pml/pmlml.py
@@ -74,7 +74,7 @@ SEPARATE_TAGS = [
 ]
 
 
-class PMLMLizer(object):
+class PMLMLizer:
 
     def __init__(self, log):
         self.log = log

--- a/src/calibre/ebooks/rb/rbml.py
+++ b/src/calibre/ebooks/rb/rbml.py
@@ -56,7 +56,7 @@ STYLES = [
 ]
 
 
-class RBMLizer(object):
+class RBMLizer:
 
     def __init__(self, log, name_map={}):
         self.log = log

--- a/src/calibre/ebooks/rb/reader.py
+++ b/src/calibre/ebooks/rb/reader.py
@@ -20,7 +20,7 @@ from polyglot.urllib import unquote
 
 class RBToc(list):
 
-    class Item(object):
+    class Item:
 
         def __init__(self, name='', size=0, offset=0, flags=0):
             self.name = name
@@ -29,7 +29,7 @@ class RBToc(list):
             self.flags = flags
 
 
-class Reader(object):
+class Reader:
 
     def __init__(self, stream, log, encoding=None):
         self.stream = stream

--- a/src/calibre/ebooks/rb/writer.py
+++ b/src/calibre/ebooks/rb/writer.py
@@ -19,7 +19,7 @@ from calibre.constants import __appname__, __version__
 TEXT_RECORD_SIZE = 4096
 
 
-class TocItem(object):
+class TocItem:
 
     def __init__(self, name, size, flags):
         self.name = name
@@ -27,7 +27,7 @@ class TocItem(object):
         self.flags = flags
 
 
-class RBWriter(object):
+class RBWriter:
 
     def __init__(self, opts, log):
         self.opts = opts

--- a/src/calibre/ebooks/rtf/rtfml.py
+++ b/src/calibre/ebooks/rtf/rtfml.py
@@ -95,7 +95,7 @@ def txt2rtf(text):
     return buf.getvalue()
 
 
-class RTFMLizer(object):
+class RTFMLizer:
 
     def __init__(self, log):
         self.log = log

--- a/src/calibre/ebooks/snb/snbml.py
+++ b/src/calibre/ebooks/snb/snbml.py
@@ -56,7 +56,7 @@ CALIBRE_SNB_BM_TAG = "<$$calibre_snb_bm_tag$$>"
 CALIBRE_SNB_PRE_TAG = "<$$calibre_snb_pre_tag$$>"
 
 
-class SNBMLizer(object):
+class SNBMLizer:
 
     curSubItem = ""
 #    curText = [ ]

--- a/src/calibre/ebooks/textile/functions.py
+++ b/src/calibre/ebooks/textile/functions.py
@@ -105,7 +105,7 @@ def getimagesize(url):
         return None
 
 
-class Textile(object):
+class Textile:
     hlgn = r'(?:\<(?!>)|(?<!<)\>|\<\>|\=|[()]+(?! ))'
     vlgn = r'[\-^~]'
     clas = r'(?:\([^)]+\))'

--- a/src/calibre/ebooks/txt/newlines.py
+++ b/src/calibre/ebooks/txt/newlines.py
@@ -8,7 +8,7 @@ __docformat__ = 'restructuredtext en'
 import os
 
 
-class TxtNewlines(object):
+class TxtNewlines:
 
     NEWLINE_TYPES = {
                         'system'  : os.linesep,

--- a/src/calibre/ebooks/txt/txtml.py
+++ b/src/calibre/ebooks/txt/txtml.py
@@ -47,7 +47,7 @@ SPACE_TAGS = [
 ]
 
 
-class TXTMLizer(object):
+class TXTMLizer:
 
     def __init__(self, log):
         self.log = log

--- a/src/calibre/ebooks/unihandecode/__init__.py
+++ b/src/calibre/ebooks/unihandecode/__init__.py
@@ -21,7 +21,7 @@ Tranliterate the string from unicode characters to ASCII in Chinese and others.
 import unicodedata
 
 
-class Unihandecoder(object):
+class Unihandecoder:
     preferred_encoding = None
     decoder = None
 

--- a/src/calibre/ebooks/unihandecode/pykakasi/h2a.py
+++ b/src/calibre/ebooks/unihandecode/pykakasi/h2a.py
@@ -25,7 +25,7 @@
 from polyglot.builtins import range
 
 
-class H2a (object):
+class H2a :
 
     H2a_table = {
         "\u3041":"a", "\u3042":"a",

--- a/src/calibre/ebooks/unihandecode/pykakasi/j2h.py
+++ b/src/calibre/ebooks/unihandecode/pykakasi/j2h.py
@@ -28,7 +28,7 @@ from calibre.ebooks.unihandecode.pykakasi.jisyo import jisyo
 from polyglot.builtins import iteritems
 
 
-class J2H (object):
+class J2H :
 
     kanwa = None
 

--- a/src/calibre/ebooks/unihandecode/pykakasi/jisyo.py
+++ b/src/calibre/ebooks/unihandecode/pykakasi/jisyo.py
@@ -9,7 +9,7 @@ from zlib import decompress
 from polyglot.builtins import unicode_type
 
 
-class jisyo (object):
+class jisyo :
     kanwadict = None
     itaijidict = None
     kanadict = None

--- a/src/calibre/ebooks/unihandecode/pykakasi/k2a.py
+++ b/src/calibre/ebooks/unihandecode/pykakasi/k2a.py
@@ -26,7 +26,7 @@ from calibre.ebooks.unihandecode.pykakasi.jisyo import jisyo
 from polyglot.builtins import range
 
 
-class K2a (object):
+class K2a :
 
     kanwa = None
 

--- a/src/calibre/ebooks/unihandecode/pykakasi/kakasi.py
+++ b/src/calibre/ebooks/unihandecode/pykakasi/kakasi.py
@@ -27,7 +27,7 @@ from calibre.ebooks.unihandecode.pykakasi.h2a import H2a
 from calibre.ebooks.unihandecode.pykakasi.k2a import K2a
 
 
-class kakasi(object):
+class kakasi:
 
     j2h = None
     h2a = None

--- a/src/calibre/ebooks/unihandecode/unidecoder.py
+++ b/src/calibre/ebooks/unihandecode/unidecoder.py
@@ -66,7 +66,7 @@ from calibre.ebooks.unihandecode.zhcodepoints import CODEPOINTS as HANCODES
 from polyglot.builtins import unicode_type
 
 
-class Unidecoder(object):
+class Unidecoder:
 
     codepoints = {}
 

--- a/src/calibre/gui2/actions/choose_library.py
+++ b/src/calibre/gui2/actions/choose_library.py
@@ -28,7 +28,7 @@ def db_class():
     return LibraryDatabase
 
 
-class LibraryUsageStats(object):  # {{{
+class LibraryUsageStats:  # {{{
 
     def __init__(self):
         self.stats = {}

--- a/src/calibre/gui2/auto_add.py
+++ b/src/calibre/gui2/auto_add.py
@@ -22,7 +22,7 @@ from calibre.utils.tdir_in_cache import tdir_in_cache
 AUTO_ADDED = frozenset(BOOK_EXTENSIONS) - {'pdr', 'mbp', 'tan'}
 
 
-class AllAllowed(object):
+class AllAllowed:
 
     def __init__(self):
         self.disallowed = frozenset(gprefs['blocked_auto_formats'])

--- a/src/calibre/gui2/bars.py
+++ b/src/calibre/gui2/bars.py
@@ -605,7 +605,7 @@ else:
 # }}}
 
 
-class AdaptMenuBarForDialog(object):
+class AdaptMenuBarForDialog:
 
     def __init__(self, menu_bar):
         self.menu_bar = menu_bar

--- a/src/calibre/gui2/cover_flow.py
+++ b/src/calibre/gui2/cover_flow.py
@@ -305,7 +305,7 @@ class CBDialog(QDialog):
             self.show_fullscreen()
 
 
-class CoverFlowMixin(object):
+class CoverFlowMixin:
 
     disable_cover_browser_refresh = False
 

--- a/src/calibre/gui2/custom_column_widgets.py
+++ b/src/calibre/gui2/custom_column_widgets.py
@@ -59,7 +59,7 @@ def get_tooltip(col_metadata, add_index=False):
                   label, key, ':' if description else '', description).strip()
 
 
-class Base(object):
+class Base:
 
     def __init__(self, db, col_id, parent=None):
         self.db, self.col_id = db, col_id

--- a/src/calibre/gui2/device.py
+++ b/src/calibre/gui2/device.py
@@ -125,7 +125,7 @@ def device_name_for_plugboards(device_class):
     return device_class.__class__.__name__
 
 
-class BusyCursor(object):
+class BusyCursor:
 
     def __enter__(self):
         QApplication.setOverrideCursor(QCursor(Qt.CursorShape.WaitCursor))
@@ -890,7 +890,7 @@ device_signals = DeviceSignals()
 # }}}
 
 
-class DeviceMixin(object):  # {{{
+class DeviceMixin:  # {{{
 
     def __init__(self, *args, **kwargs):
         pass

--- a/src/calibre/gui2/dialogs/plugin_updater.py
+++ b/src/calibre/gui2/dialogs/plugin_updater.py
@@ -180,7 +180,7 @@ class PluginFilterComboBox(QComboBox):
         self.addItems(items)
 
 
-class DisplayPlugin(object):
+class DisplayPlugin:
 
     def __init__(self, plugin):
         self.name = plugin['index_name']

--- a/src/calibre/gui2/dialogs/tag_categories.py
+++ b/src/calibre/gui2/dialogs/tag_categories.py
@@ -14,7 +14,7 @@ from calibre.utils.icu import sort_key, strcmp, primary_contains
 from polyglot.builtins import iteritems, unicode_type
 
 
-class Item(object):
+class Item:
 
     def __init__(self, name, label, index, icon, exists):
         self.name = name

--- a/src/calibre/gui2/ebook_download.py
+++ b/src/calibre/gui2/ebook_download.py
@@ -76,7 +76,7 @@ def download_file(url, cookie_file=None, filename=None, create_browser=None):
     return dfilename
 
 
-class EbookDownload(object):
+class EbookDownload:
 
     def __call__(self, gui, cookie_file=None, url='', filename='', save_loc='', add_to_lib=True, tags=[], create_browser=None,
                  log=None, abort=None, notifications=None):
@@ -134,7 +134,7 @@ def start_ebook_download(callback, job_manager, gui, cookie_file=None, url='', f
     job_manager.run_threaded_job(job)
 
 
-class EbookDownloadMixin(object):
+class EbookDownloadMixin:
 
     def __init__(self, *args, **kwargs):
         pass

--- a/src/calibre/gui2/email.py
+++ b/src/calibre/gui2/email.py
@@ -51,7 +51,7 @@ class Worker(Thread):
             self.func = self.args = None
 
 
-class Sendmail(object):
+class Sendmail:
 
     MAX_RETRIES = 1
     TIMEOUT = 25 * 60  # seconds
@@ -303,7 +303,7 @@ def select_recipients(parent=None):
 # }}}
 
 
-class EmailMixin(object):  # {{{
+class EmailMixin:  # {{{
 
     def __init__(self, *args, **kwargs):
         pass

--- a/src/calibre/gui2/gestures.py
+++ b/src/calibre/gui2/gestures.py
@@ -27,7 +27,7 @@ Tap, TapAndHold, Flick = 'Tap', 'TapAndHold', 'Flick'
 Left, Right, Up, Down = 'Left', 'Right', 'Up', 'Down'
 
 
-class TouchPoint(object):
+class TouchPoint:
 
     def __init__(self, tp):
         self.creation_time = self.last_update_time = self.time_of_last_move = monotonic()

--- a/src/calibre/gui2/icon_theme.py
+++ b/src/calibre/gui2/icon_theme.py
@@ -73,14 +73,14 @@ def read_images_from_folder(path):
     return name_map
 
 
-class Theme(object):
+class Theme:
 
     def __init__(self, title='', author='', version=-1, description='', license='Unknown', url=None, cover=None):
         self.title, self.author, self.version, self.description = title, author, version, description
         self.license, self.cover, self.url = license, cover, url
 
 
-class Report(object):
+class Report:
 
     def __init__(self, path, name_map, extra, missing, theme):
         self.path, self.name_map, self.extra, self.missing, self.theme = path, name_map, extra, missing, theme

--- a/src/calibre/gui2/image_popup.py
+++ b/src/calibre/gui2/image_popup.py
@@ -283,7 +283,7 @@ class ImageView(QDialog):
             (self.zoom_out if d < 0 else self.zoom_in)()
 
 
-class ImagePopup(object):
+class ImagePopup:
 
     def __init__(self, parent):
         self.current_img = QPixmap()

--- a/src/calibre/gui2/init.py
+++ b/src/calibre/gui2/init.py
@@ -39,7 +39,7 @@ def partial(*args, **kwargs):
     return ans
 
 
-class LibraryViewMixin(object):  # {{{
+class LibraryViewMixin:  # {{{
 
     def __init__(self, *args, **kwargs):
         pass
@@ -555,7 +555,7 @@ class VLTabs(QTabBar):  # {{{
 # }}}
 
 
-class LayoutMixin(object):  # {{{
+class LayoutMixin:  # {{{
 
     def __init__(self, *args, **kwargs):
         pass

--- a/src/calibre/gui2/keyboard.py
+++ b/src/calibre/gui2/keyboard.py
@@ -168,7 +168,7 @@ class Manager(QObject):  # {{{
 # Model {{{
 
 
-class Node(object):
+class Node:
 
     def __init__(self, group_map, shortcut_map, name=None, shortcut=None):
         self.data = name if name is not None else shortcut

--- a/src/calibre/gui2/layout.py
+++ b/src/calibre/gui2/layout.py
@@ -324,7 +324,7 @@ class Spacer(QWidget):  # {{{
 # }}}
 
 
-class MainWindowMixin(object):  # {{{
+class MainWindowMixin:  # {{{
 
     def __init__(self, *args, **kwargs):
         pass

--- a/src/calibre/gui2/library/alternate_views.py
+++ b/src/calibre/gui2/library/alternate_views.py
@@ -288,7 +288,7 @@ def sync(func):
     return ans
 
 
-class AlternateViews(object):
+class AlternateViews:
 
     def __init__(self, main_view):
         self.views = {None:main_view}

--- a/src/calibre/gui2/library/annotations.py
+++ b/src/calibre/gui2/library/annotations.py
@@ -323,7 +323,7 @@ def current_db():
     return (getattr(current_db, 'ans', None) or get_gui().current_db).new_api
 
 
-class BusyCursor(object):
+class BusyCursor:
 
     def __enter__(self):
         QApplication.setOverrideCursor(QCursor(Qt.CursorShape.WaitCursor))

--- a/src/calibre/gui2/library/delegates.py
+++ b/src/calibre/gui2/library/delegates.py
@@ -30,7 +30,7 @@ from calibre.gui2.languages import LanguagesEdit
 from polyglot.builtins import unicode_type
 
 
-class UpdateEditorGeometry(object):
+class UpdateEditorGeometry:
 
     def updateEditorGeometry(self, editor, option, index):
         if editor is None:

--- a/src/calibre/gui2/library/models.py
+++ b/src/calibre/gui2/library/models.py
@@ -71,7 +71,7 @@ def group_numbers(numbers):
         yield first, last[1]
 
 
-class ColumnColor(object):  # {{{
+class ColumnColor:  # {{{
 
     def __init__(self, formatter):
         self.mi = None
@@ -100,7 +100,7 @@ class ColumnColor(object):  # {{{
 # }}}
 
 
-class ColumnIcon(object):  # {{{
+class ColumnIcon:  # {{{
 
     def __init__(self, formatter, model):
         self.mi = None
@@ -1316,7 +1316,7 @@ class OnDeviceSearch(SearchQueryParser):  # {{{
 # }}}
 
 
-class DeviceDBSortKeyGen(object):  # {{{
+class DeviceDBSortKeyGen:  # {{{
 
     def __init__(self, attr, keyfunc, db):
         self.attr = attr

--- a/src/calibre/gui2/library/views.py
+++ b/src/calibre/gui2/library/views.py
@@ -133,7 +133,7 @@ class HeaderView(QHeaderView):  # {{{
 # }}}
 
 
-class PreserveViewState(object):  # {{{
+class PreserveViewState:  # {{{
 
     '''
     Save the set of selected books at enter time. If at exit time there are no

--- a/src/calibre/gui2/lrf_renderer/document.py
+++ b/src/calibre/gui2/lrf_renderer/document.py
@@ -28,7 +28,7 @@ class Pen(QPen):
                       (Qt.PenStyle.SolidLine if width > 0 else Qt.PenStyle.NoPen))
 
 
-class ContentObject(object):
+class ContentObject:
 
     has_content = True
 
@@ -300,7 +300,7 @@ class Page(_Canvas):
         self.layout_block(block, 0, self.current_y)
 
 
-class Chapter(object):
+class Chapter:
 
     num_of_pages = property(fget=lambda self: len(self.pages))
 

--- a/src/calibre/gui2/lrf_renderer/text.py
+++ b/src/calibre/gui2/lrf_renderer/text.py
@@ -49,7 +49,7 @@ class Plot(PixmapItem):
         PixmapItem.__init__(self, data, encoding, x0, y0, x1, y1, xsize, ysize)
 
 
-class FontLoader(object):
+class FontLoader:
 
     font_map = {
                 'Swis721 BT Roman'     : 'Liberation Sans',
@@ -93,7 +93,7 @@ class FontLoader(object):
         return qfont
 
 
-class Style(object):
+class Style:
     map = collections.defaultdict(lambda : NULL)
 
     def __init__(self, style, dpi):
@@ -150,7 +150,7 @@ class BlockStyle(Style):
         )
 
 
-class ParSkip(object):
+class ParSkip:
 
     def __init__(self, parskip):
         self.height = parskip
@@ -159,7 +159,7 @@ class ParSkip(object):
         return 'Parskip: '+unicode_type(self.height)
 
 
-class TextBlock(object):
+class TextBlock:
 
     class HeightExceeded(Exception):
         pass
@@ -577,7 +577,7 @@ class Line(QGraphicsItem):
         return unicode_type(self).encode('utf-8')
 
 
-class Word(object):
+class Word:
 
     def __init__(self, string, width, height, ts, font, valign):
         self.string, self.width, self.height = string, width, height

--- a/src/calibre/gui2/main.py
+++ b/src/calibre/gui2/main.py
@@ -220,7 +220,7 @@ def windows_repair(library_path=None):
         app.quit()
 
 
-class EventAccumulator(object):
+class EventAccumulator:
 
     def __init__(self):
         self.events = []

--- a/src/calibre/gui2/main_window.py
+++ b/src/calibre/gui2/main_window.py
@@ -71,7 +71,7 @@ class GarbageCollector(QObject):
             print(obj, repr(obj), type(obj))
 
 
-class ExceptionHandler(object):
+class ExceptionHandler:
 
     def __init__(self, main_window):
         self.wref = weakref.ref(main_window)

--- a/src/calibre/gui2/metadata/basic_widgets.py
+++ b/src/calibre/gui2/metadata/basic_widgets.py
@@ -67,7 +67,7 @@ def clean_text(x):
 
 '''
 The interface common to all widgets used to set basic metadata
-class BasicMetadataWidget(object):
+class BasicMetadataWidget:
 
     LABEL = "label text"
 
@@ -87,7 +87,7 @@ class BasicMetadataWidget(object):
 '''
 
 
-class ToMetadataMixin(object):
+class ToMetadataMixin:
 
     FIELD_NAME = None
     allow_undo = False

--- a/src/calibre/gui2/metadata/bulk_download.py
+++ b/src/calibre/gui2/metadata/bulk_download.py
@@ -165,7 +165,7 @@ def get_job_details(job):
             all_failed, det_msg, lm_map)
 
 
-class HeartBeat(object):
+class HeartBeat:
     CHECK_INTERVAL = 300  # seconds
     ''' Check that the file count in tdir changes every five minutes '''
 

--- a/src/calibre/gui2/preferences/__init__.py
+++ b/src/calibre/gui2/preferences/__init__.py
@@ -27,7 +27,7 @@ class AbortInitialize(Exception):
     pass
 
 
-class ConfigWidgetInterface(object):
+class ConfigWidgetInterface:
 
     '''
     This class defines the interface that all widgets displayed in the
@@ -93,7 +93,7 @@ class ConfigWidgetInterface(object):
         pass
 
 
-class Setting(object):
+class Setting:
 
     CHOICES_SEARCH_FLAGS = Qt.MatchFlag.MatchExactly | Qt.MatchFlag.MatchCaseSensitive
 

--- a/src/calibre/gui2/preferences/look_feel.py
+++ b/src/calibre/gui2/preferences/look_feel.py
@@ -41,7 +41,7 @@ from calibre.utils.resources import set_data
 from polyglot.builtins import iteritems, unicode_type, map
 
 
-class BusyCursor(object):
+class BusyCursor:
 
     def __enter__(self):
         QApplication.setOverrideCursor(QCursor(Qt.CursorShape.WaitCursor))

--- a/src/calibre/gui2/preferences/toolbar.py
+++ b/src/calibre/gui2/preferences/toolbar.py
@@ -25,7 +25,7 @@ def sort_key_for_action(ac):
         return primary_sort_key('')
 
 
-class FakeAction(object):
+class FakeAction:
 
     def __init__(self, name, gui_name, icon, tooltip=None,
             dont_add_to=frozenset(), dont_remove_from=frozenset()):

--- a/src/calibre/gui2/preferences/tweaks.py
+++ b/src/calibre/gui2/preferences/tweaks.py
@@ -77,7 +77,7 @@ class Delegate(QStyledItemDelegate):  # {{{
 # }}}
 
 
-class Tweak(object):  # {{{
+class Tweak:  # {{{
 
     def __init__(self, name, doc, var_names, defaults, custom):
         translate = _

--- a/src/calibre/gui2/qt_file_dialogs.py
+++ b/src/calibre/gui2/qt_file_dialogs.py
@@ -23,7 +23,7 @@ def select_initial_dir(q):
     return os.path.expanduser(u'~')
 
 
-class Dummy(object):
+class Dummy:
 
     def __enter__(self):
         pass

--- a/src/calibre/gui2/search_box.py
+++ b/src/calibre/gui2/search_box.py
@@ -458,7 +458,7 @@ class SavedSearchBox(QComboBox):  # {{{
     # }}}
 
 
-class SearchBoxMixin(object):  # {{{
+class SearchBoxMixin:  # {{{
 
     def __init__(self, *args, **kwargs):
         pass
@@ -545,7 +545,7 @@ class SearchBoxMixin(object):  # {{{
     # }}}
 
 
-class SavedSearchBoxMixin(object):  # {{{
+class SavedSearchBoxMixin:  # {{{
 
     def __init__(self, *args, **kwargs):
         pass

--- a/src/calibre/gui2/search_restriction_mixin.py
+++ b/src/calibre/gui2/search_restriction_mixin.py
@@ -308,7 +308,7 @@ class CreateVirtualLibrary(QDialog):  # {{{
 # }}}
 
 
-class SearchRestrictionMixin(object):
+class SearchRestrictionMixin:
 
     no_restriction = '<' + _('None') + '>'
 

--- a/src/calibre/gui2/store/__init__.py
+++ b/src/calibre/gui2/store/__init__.py
@@ -8,7 +8,7 @@ __docformat__ = 'restructuredtext en'
 from calibre.utils.filenames import ascii_filename
 
 
-class StorePlugin(object):  # {{{
+class StorePlugin:  # {{{
 
     '''
     A plugin representing an online ebook repository (store). The store can

--- a/src/calibre/gui2/store/basic_config.py
+++ b/src/calibre/gui2/store/basic_config.py
@@ -28,7 +28,7 @@ class BasicStoreConfigWidget(QWidget, Ui_Form):
         self.tags.setText(config.get('tags', ''))
 
 
-class BasicStoreConfig(object):
+class BasicStoreConfig:
 
     def customization_help(self, gui=False):
         return 'Customize the behavior of this store.'

--- a/src/calibre/gui2/store/search/download_thread.py
+++ b/src/calibre/gui2/store/search/download_thread.py
@@ -17,7 +17,7 @@ from polyglot.queue import Queue
 from polyglot.binary import from_base64_bytes
 
 
-class GenericDownloadThreadPool(object):
+class GenericDownloadThreadPool:
     '''
     add_task must be implemented in a subclass and must
     GenericDownloadThreadPool.add_task must be called

--- a/src/calibre/gui2/store/search_result.py
+++ b/src/calibre/gui2/store/search_result.py
@@ -6,7 +6,7 @@ __copyright__ = '2011, John Schember <john@nachtimwald.com>'
 __docformat__ = 'restructuredtext en'
 
 
-class SearchResult(object):
+class SearchResult:
 
     DRM_LOCKED = 1
     DRM_UNLOCKED = 2

--- a/src/calibre/gui2/store/web_store_dialog.py
+++ b/src/calibre/gui2/store/web_store_dialog.py
@@ -10,7 +10,7 @@ from itertools import count
 counter = count()
 
 
-class WebStoreDialog(object):
+class WebStoreDialog:
 
     def __init__(
         self, gui, base_url, parent=None, detail_url=None, create_browser=None

--- a/src/calibre/gui2/tag_browser/model.py
+++ b/src/calibre/gui2/tag_browser/model.py
@@ -47,7 +47,7 @@ def bf():
     return _bf
 
 
-class TagTreeItem(object):  # {{{
+class TagTreeItem:  # {{{
 
     CATEGORY = 0
     TAG      = 1

--- a/src/calibre/gui2/tag_browser/ui.py
+++ b/src/calibre/gui2/tag_browser/ui.py
@@ -25,7 +25,7 @@ from calibre.gui2.dialogs.edit_authors_dialog import EditAuthorsDialog
 from polyglot.builtins import unicode_type, iteritems
 
 
-class TagBrowserMixin(object):  # {{{
+class TagBrowserMixin:  # {{{
 
     def __init__(self, *args, **kwargs):
         pass

--- a/src/calibre/gui2/tag_mapper.py
+++ b/src/calibre/gui2/tag_mapper.py
@@ -431,7 +431,7 @@ class Tester(Dialog):
         return ans
 
 
-class SaveLoadMixin(object):
+class SaveLoadMixin:
 
     def save_ruleset(self):
         if not self.rules:

--- a/src/calibre/gui2/tweak_book/diff/highlight.py
+++ b/src/calibre/gui2/tweak_book/diff/highlight.py
@@ -53,7 +53,7 @@ class QtHighlighter(QTextDocument):
                 block = block.next()
 
 
-class NullHighlighter(object):
+class NullHighlighter:
 
     def __init__(self, text):
         self.lines = text.splitlines()
@@ -79,7 +79,7 @@ def pygments_lexer(filename):
         return None
 
 
-class PygmentsHighlighter(object):
+class PygmentsHighlighter:
 
     def __init__(self, text, lexer):
         theme, cache = get_theme(tprefs['editor_theme']), {}

--- a/src/calibre/gui2/tweak_book/diff/main.py
+++ b/src/calibre/gui2/tweak_book/diff/main.py
@@ -57,7 +57,7 @@ class BusyWidget(QWidget):  # {{{
 # }}}
 
 
-class Cache(object):
+class Cache:
 
     def __init__(self):
         self._left, self._right = {}, {}

--- a/src/calibre/gui2/tweak_book/diff/view.py
+++ b/src/calibre/gui2/tweak_book/diff/view.py
@@ -33,7 +33,7 @@ from polyglot.builtins import as_bytes, iteritems, map, range, unicode_type, zip
 Change = namedtuple('Change', 'ltop lbot rtop rbot kind')
 
 
-class BusyCursor(object):
+class BusyCursor:
 
     def __enter__(self):
         QApplication.setOverrideCursor(QCursor(Qt.CursorShape.WaitCursor))

--- a/src/calibre/gui2/tweak_book/editor/__init__.py
+++ b/src/calibre/gui2/tweak_book/editor/__init__.py
@@ -57,7 +57,7 @@ def syntax_text_char_format(*args):
     return ans
 
 
-class StoreLocale(object):
+class StoreLocale:
 
     __slots__ = ('enabled',)
 

--- a/src/calibre/gui2/tweak_book/editor/canvas.py
+++ b/src/calibre/gui2/tweak_book/editor/canvas.py
@@ -37,7 +37,7 @@ def painter(func):
     return ans
 
 
-class SelectionState(object):
+class SelectionState:
 
     __slots__ = ('last_press_point', 'current_mode', 'rect', 'in_selection', 'drag_corner', 'dragging', 'last_drag_pos')
 

--- a/src/calibre/gui2/tweak_book/editor/help.py
+++ b/src/calibre/gui2/tweak_book/editor/help.py
@@ -15,7 +15,7 @@ from calibre.ebooks.oeb.polish.container import OEB_DOCS
 from calibre.ebooks.oeb.polish.utils import guess_type
 
 
-class URLMap(object):
+class URLMap:
 
     def __init__(self):
         self.cache = {}

--- a/src/calibre/gui2/tweak_book/editor/smarts/__init__.py
+++ b/src/calibre/gui2/tweak_book/editor/smarts/__init__.py
@@ -6,7 +6,7 @@ __license__ = 'GPL v3'
 __copyright__ = '2014, Kovid Goyal <kovid at kovidgoyal.net>'
 
 
-class NullSmarts(object):
+class NullSmarts:
 
     override_tab_stop_width = None
 

--- a/src/calibre/gui2/tweak_book/editor/smarts/html.py
+++ b/src/calibre/gui2/tweak_book/editor/smarts/html.py
@@ -34,7 +34,7 @@ PARAGRAPH_SEPARATOR = '\u2029'
 DEFAULT_LINK_TEMPLATE = '<a href="_TARGET_">_TEXT_</a>'
 
 
-class Tag(object):
+class Tag:
 
     def __init__(self, start_block, tag_start, end_block, tag_end, self_closing=False):
         self.start_block, self.end_block = start_block, end_block

--- a/src/calibre/gui2/tweak_book/editor/snippets.py
+++ b/src/calibre/gui2/tweak_book/editor/snippets.py
@@ -186,7 +186,7 @@ def snippets(refresh=False):
 # Editor integration {{{
 
 
-class EditorTabStop(object):
+class EditorTabStop:
 
     def __init__(self, left, tab_stops, editor):
         self.editor = weakref.ref(editor)

--- a/src/calibre/gui2/tweak_book/editor/syntax/base.py
+++ b/src/calibre/gui2/tweak_book/editor/syntax/base.py
@@ -38,7 +38,7 @@ def run_loop(user_data, state_map, formats, text):
             break
 
 
-class SimpleState(object):
+class SimpleState:
 
     __slots__ = ('parse',)
 
@@ -63,7 +63,7 @@ class SimpleUserData(QTextBlockUserData):
         self.doc_name = doc_name
 
 
-class SyntaxHighlighter(object):
+class SyntaxHighlighter:
 
     create_formats_func = lambda highlighter: {}
     spell_attributes = ()

--- a/src/calibre/gui2/tweak_book/editor/syntax/css.py
+++ b/src/calibre/gui2/tweak_book/editor/syntax/css.py
@@ -143,7 +143,7 @@ IN_CONTENT = 4
 IN_COMMENT_CONTENT = 5
 
 
-class CSSState(object):
+class CSSState:
 
     __slots__ = ('parse', 'blocks')
 

--- a/src/calibre/gui2/tweak_book/editor/syntax/pygments_highlighter.py
+++ b/src/calibre/gui2/tweak_book/editor/syntax/pygments_highlighter.py
@@ -100,7 +100,7 @@ def create_lexer(base_class):
     })
 
 
-class State(object):
+class State:
 
     __slots__ = ('parse', 'pygments_stack')
 

--- a/src/calibre/gui2/tweak_book/file_list.py
+++ b/src/calibre/gui2/tweak_book/file_list.py
@@ -190,7 +190,7 @@ class ItemDelegate(QStyledItemDelegate):  # {{{
 # }}}
 
 
-class OpenWithHandler(object):  # {{{
+class OpenWithHandler:  # {{{
 
     def add_open_with_actions(self, menu, file_name):
         from calibre.gui2.open_with import edit_programs, populate_menu

--- a/src/calibre/gui2/tweak_book/function_replace.py
+++ b/src/calibre/gui2/tweak_book/function_replace.py
@@ -45,7 +45,7 @@ def compile_code(src, name='<string>'):
     return namespace
 
 
-class Function(object):
+class Function:
 
     def __init__(self, name, source=None, func=None):
         self._source = source

--- a/src/calibre/gui2/tweak_book/live_css.py
+++ b/src/calibre/gui2/tweak_book/live_css.py
@@ -92,7 +92,7 @@ class Heading(QWidget):  # {{{
 # }}}
 
 
-class Cell(object):  # {{{
+class Cell:  # {{{
 
     __slots__ = ('rect', 'text', 'right_align', 'color_role', 'override_color', 'swatch', 'is_overriden')
 
@@ -362,7 +362,7 @@ class Box(QWidget):
         m.exec_(ev.globalPos())
 
 
-class Property(object):
+class Property:
 
     __slots__ = 'name', 'value', 'important', 'color', 'specificity', 'is_overriden'
 

--- a/src/calibre/gui2/tweak_book/main.py
+++ b/src/calibre/gui2/tweak_book/main.py
@@ -38,7 +38,7 @@ files inside the book which will be opened for editing automatically.
     return parser
 
 
-class EventAccumulator(object):
+class EventAccumulator:
 
     def __init__(self):
         self.events = []

--- a/src/calibre/gui2/tweak_book/plugin.py
+++ b/src/calibre/gui2/tweak_book/plugin.py
@@ -17,7 +17,7 @@ from calibre.gui2.tweak_book.boss import get_boss
 from polyglot.builtins import itervalues, unicode_type
 
 
-class Tool(object):
+class Tool:
 
     '''
     The base class for individual tools in an Edit Book plugin. Useful members include:

--- a/src/calibre/gui2/tweak_book/preview.py
+++ b/src/calibre/gui2/tweak_book/preview.py
@@ -63,7 +63,7 @@ def parse_html(raw):
     return ans
 
 
-class ParseItem(object):
+class ParseItem:
 
     __slots__ = ('name', 'length', 'fingerprint', 'parsing_done', 'parsed_data')
 

--- a/src/calibre/gui2/tweak_book/reports.py
+++ b/src/calibre/gui2/tweak_book/reports.py
@@ -350,7 +350,7 @@ def jump_to_location(loc):
             editor.find(regex.compile(regex.escape(loc.text_on_line)))
 
 
-class Jump(object):
+class Jump:
 
     def __init__(self):
         self.pos_map = defaultdict(lambda : -1)

--- a/src/calibre/gui2/tweak_book/undo.py
+++ b/src/calibre/gui2/tweak_book/undo.py
@@ -26,7 +26,7 @@ def cleanup(containers):
             pass
 
 
-class State(object):
+class State:
 
     def __init__(self, container):
         self.container = container

--- a/src/calibre/gui2/tweak_book/widgets.py
+++ b/src/calibre/gui2/tweak_book/widgets.py
@@ -32,7 +32,7 @@ ROOT = QModelIndex()
 ignore_me
 
 
-class BusyCursor(object):
+class BusyCursor:
 
     def __enter__(self):
         QApplication.setOverrideCursor(QCursor(Qt.CursorShape.WaitCursor))

--- a/src/calibre/gui2/update.py
+++ b/src/calibre/gui2/update.py
@@ -191,7 +191,7 @@ class UpdateNotification(QDialog):
         QDialog.accept(self)
 
 
-class UpdateMixin(object):
+class UpdateMixin:
 
     def __init__(self, *args, **kw):
         pass

--- a/src/calibre/gui2/viewer/search.py
+++ b/src/calibre/gui2/viewer/search.py
@@ -81,7 +81,7 @@ def text_to_regex(text):
     return ''.join(ans)
 
 
-class Search(object):
+class Search:
 
     def __init__(self, text, mode, case_sensitive, backwards):
         self.text, self.mode = text, mode
@@ -118,7 +118,7 @@ class Search(object):
         return str(namedtuple('Search', s)(*tuple(getattr(self, x) for x in s)))
 
 
-class SearchFinished(object):
+class SearchFinished:
 
     def __init__(self, search_query):
         self.search_query = search_query

--- a/src/calibre/gui2/viewer/toolbars.py
+++ b/src/calibre/gui2/viewer/toolbars.py
@@ -23,7 +23,7 @@ from calibre.utils.icu import primary_sort_key
 from polyglot.builtins import iteritems
 
 
-class Action(object):
+class Action:
 
     __slots__ = ('icon', 'text', 'shortcut_action')
 
@@ -31,7 +31,7 @@ class Action(object):
         self.icon, self.text, self.shortcut_action = QIcon(I(icon)), text, shortcut_action
 
 
-class Actions(object):
+class Actions:
 
     def __init__(self, a):
         self.__dict__.update(a)

--- a/src/calibre/gui2/widgets.py
+++ b/src/calibre/gui2/widgets.py
@@ -218,7 +218,7 @@ class FormatList(QListWidget):  # {{{
 # }}}
 
 
-class ImageDropMixin(object):  # {{{
+class ImageDropMixin:  # {{{
     '''
     Adds support for dropping images onto widgets and a context menu for
     copy/pasting images.
@@ -466,7 +466,7 @@ class BasicList(QListWidget):
 # }}}
 
 
-class LineEditECM(object):  # {{{
+class LineEditECM:  # {{{
 
     '''
     Extend the context menu of a QLineEdit to include more actions.

--- a/src/calibre/gui2/widgets2.py
+++ b/src/calibre/gui2/widgets2.py
@@ -23,7 +23,7 @@ from polyglot.builtins import unicode_type
 from polyglot.functools import lru_cache
 
 
-class HistoryMixin(object):
+class HistoryMixin:
 
     max_history_items = None
     min_history_entry_length = 3

--- a/src/calibre/gui_launch.py
+++ b/src/calibre/gui_launch.py
@@ -43,7 +43,7 @@ def register_with_default_programs():
         from calibre.gui2 import gprefs
         return Register(gprefs)
     else:
-        class Dummy(object):
+        class Dummy:
 
             def __enter__(self):
                 return self

--- a/src/calibre/library/add_to_library.py
+++ b/src/calibre/library/add_to_library.py
@@ -50,7 +50,7 @@ def find_folders_under(root, db, add_root=True,  # {{{
 # }}}
 
 
-class FormatCollection(object):  # {{{
+class FormatCollection:  # {{{
 
     def __init__(self, parent_folder, formats):
         self.path_map = {}

--- a/src/calibre/library/caches.py
+++ b/src/calibre/library/caches.py
@@ -1117,7 +1117,7 @@ class ResultCache(SearchQueryParser):  # {{{
             only_ids.sort(key=keyg)
 
 
-class SortKey(object):
+class SortKey:
 
     def __init__(self, orders, values):
         self.orders, self.values = orders, values
@@ -1148,7 +1148,7 @@ class SortKey(object):
         return self.compare_to_other(other) >= 0
 
 
-class SortKeyGenerator(object):
+class SortKeyGenerator:
 
     def __init__(self, fields, field_metadata, data, db_prefs):
         from calibre.utils.icu import sort_key

--- a/src/calibre/library/catalogs/epub_mobi_builder.py
+++ b/src/calibre/library/catalogs/epub_mobi_builder.py
@@ -70,7 +70,7 @@ class Formatter(TemplateFormatter):
         return self.book.format_field(key, series_with_index=False)[1]
 
 
-class CatalogBuilder(object):
+class CatalogBuilder:
     '''
     Generates catalog source files from calibre database
 

--- a/src/calibre/library/catalogs/utils.py
+++ b/src/calibre/library/catalogs/utils.py
@@ -12,7 +12,7 @@ from calibre import prints
 from calibre.utils.logging import default_log as log
 
 
-class NumberToText(object):  # {{{
+class NumberToText:  # {{{
     '''
     Converts numbers to text
     4.56    => four point fifty-six

--- a/src/calibre/library/check_library.py
+++ b/src/calibre/library/check_library.py
@@ -38,7 +38,7 @@ CHECKS = [('invalid_titles',    _('Invalid titles'), True, False),
       ]
 
 
-class CheckLibrary(object):
+class CheckLibrary:
 
     def __init__(self, library_path, db):
         if isbytestring(library_path):

--- a/src/calibre/library/coloring.py
+++ b/src/calibre/library/coloring.py
@@ -13,7 +13,7 @@ from polyglot.builtins import map
 color_row_key = '*row'
 
 
-class Rule(object):  # {{{
+class Rule:  # {{{
 
     SIGNATURE = '# BasicColorRule():'
 

--- a/src/calibre/library/custom_columns.py
+++ b/src/calibre/library/custom_columns.py
@@ -17,7 +17,7 @@ from calibre.utils.config import tweaks
 from polyglot.builtins import unicode_type, string_or_bytes
 
 
-class CustomColumns(object):
+class CustomColumns:
 
     CUSTOM_DATA_TYPES = frozenset(['rating', 'text', 'comments', 'datetime',
         'int', 'float', 'bool', 'series', 'composite', 'enumeration'])

--- a/src/calibre/library/database.py
+++ b/src/calibre/library/database.py
@@ -18,7 +18,7 @@ from calibre import isbytestring
 from polyglot.builtins import unicode_type, filter, map
 
 
-class Concatenate(object):
+class Concatenate:
     '''String concatenation aggregator for sqlite'''
 
     def __init__(self, sep=','):
@@ -72,7 +72,7 @@ def _connect(path):
     return conn
 
 
-class LibraryDatabase(object):
+class LibraryDatabase:
 
     @staticmethod
     def books_in_old_database(path):
@@ -1463,7 +1463,7 @@ ALTER TABLE books ADD COLUMN isbn TEXT DEFAULT "" COLLATE NOCASE;
         return self.conn.get('SELECT id FROM books where id=?', (id,), all=False) is not None
 
 
-class SearchToken(object):
+class SearchToken:
 
     FIELD_MAP = {'title'       : 1,
                   'author'      : 2,

--- a/src/calibre/library/database2.py
+++ b/src/calibre/library/database2.py
@@ -57,7 +57,7 @@ SPOOL_SIZE = 30*1024*1024
 ProxyMetadata = namedtuple('ProxyMetadata', 'book_size ondevice_col db_approx_formats')
 
 
-class DBPrefsWrapper(object):
+class DBPrefsWrapper:
 
     def __init__(self, db):
         self.db = db
@@ -1731,7 +1731,7 @@ class LibraryDatabase2(LibraryDatabase, SchemaUpgrade, CustomColumns):
     CATEGORY_SORTS = CATEGORY_SORTS
     MATCH_TYPE = ('any', 'all')
 
-    class TCat_Tag(object):
+    class TCat_Tag:
 
         def __init__(self, name, sort):
             self.n = name

--- a/src/calibre/library/field_metadata.py
+++ b/src/calibre/library/field_metadata.py
@@ -326,7 +326,7 @@ def _builtin_field_metadata():
 # }}}
 
 
-class FieldMetadata(object):
+class FieldMetadata:
     '''
     key: the key to the dictionary is:
     - for standard fields, the metadata field name.

--- a/src/calibre/library/schema_upgrades.py
+++ b/src/calibre/library/schema_upgrades.py
@@ -12,7 +12,7 @@ from calibre.utils.date import isoformat, DEFAULT_DATE
 from polyglot.builtins import itervalues, unicode_type
 
 
-class SchemaUpgrade(object):
+class SchemaUpgrade:
 
     def __init__(self):
         # Upgrade database

--- a/src/calibre/library/sqlite.py
+++ b/src/calibre/library/sqlite.py
@@ -91,7 +91,7 @@ sqlite.register_converter(native_string_type('bool'), convert_bool)
 sqlite.register_converter(native_string_type('BOOL'), convert_bool)
 
 
-class DynamicFilter(object):
+class DynamicFilter:
 
     def __init__(self, name):
         self.name = name
@@ -104,7 +104,7 @@ class DynamicFilter(object):
         self.ids = frozenset(ids)
 
 
-class Concatenate(object):
+class Concatenate:
     '''String concatenation aggregator for sqlite'''
 
     def __init__(self, sep=','):
@@ -126,7 +126,7 @@ class Concatenate(object):
             raise
 
 
-class SortedConcatenate(object):
+class SortedConcatenate:
     '''String concatenation aggregator for sqlite, sorted by supplied index'''
     sep = ','
 
@@ -156,7 +156,7 @@ class SortedConcatenateAmper(SortedConcatenate):
     sep = '&'
 
 
-class IdentifiersConcat(object):
+class IdentifiersConcat:
     '''String concatenation aggregator for the identifiers map'''
 
     def __init__(self):
@@ -174,7 +174,7 @@ class IdentifiersConcat(object):
             raise
 
 
-class AumSortedConcatenate(object):
+class AumSortedConcatenate:
     '''String concatenation aggregator for the author sort map'''
 
     def __init__(self):
@@ -368,7 +368,7 @@ def proxy(fn):
     return run
 
 
-class ConnectionProxy(object):
+class ConnectionProxy:
 
     def __init__(self, proxy):
         self.proxy = proxy

--- a/src/calibre/linux.py
+++ b/src/calibre/linux.py
@@ -54,7 +54,7 @@ def polyglot_write(stream):
     return write
 
 
-class PreserveMIMEDefaults(object):  # {{{
+class PreserveMIMEDefaults:  # {{{
 
     def __init__(self):
         self.initial_values = {}
@@ -235,7 +235,7 @@ CALIBRE_LINUX_INSTALLER_HEREDOC
 # Completion {{{
 
 
-class ZshCompleter(object):  # {{{
+class ZshCompleter:  # {{{
 
     def __init__(self, opts):
         self.opts = opts

--- a/src/calibre/ptempfile.py
+++ b/src/calibre/ptempfile.py
@@ -157,7 +157,7 @@ def _make_dir(suffix, prefix, base):
     return tempfile.mkdtemp(suffix, prefix, base)
 
 
-class PersistentTemporaryFile(object):
+class PersistentTemporaryFile:
 
     """
     A file-like object that is a temporary file that is available even after being closed on
@@ -208,7 +208,7 @@ def PersistentTemporaryDirectory(suffix='', prefix='', dir=None):
     return tdir
 
 
-class TemporaryDirectory(object):
+class TemporaryDirectory:
 
     '''
     A temporary directory to be used in a with statement.
@@ -232,7 +232,7 @@ class TemporaryDirectory(object):
             remove_dir(self.tdir)
 
 
-class TemporaryFile(object):
+class TemporaryFile:
 
     def __init__(self, suffix="", prefix="", dir=None, mode='w+b'):
         if prefix is None:

--- a/src/calibre/spell/dictionary.py
+++ b/src/calibre/spell/dictionary.py
@@ -30,7 +30,7 @@ dprefs.defaults['user_dictionaries'] = [{'name':_('Default'), 'is_active':True, 
 not_present = object()
 
 
-class UserDictionary(object):
+class UserDictionary:
 
     __slots__ = ('name', 'is_active', 'words')
 
@@ -178,7 +178,7 @@ def load_dictionary(dictionary):
     return LoadedDictionary(dictionary.primary_locale, dictionary.locales, obj, dictionary.builtin, dictionary.name, dictionary.id)
 
 
-class Dictionaries(object):
+class Dictionaries:
 
     def __init__(self):
         self.remove_hyphenation = re.compile('[\u2010-]+')

--- a/src/calibre/srv/auth.py
+++ b/src/calibre/srv/auth.py
@@ -22,7 +22,7 @@ MAX_AGE_SECONDS = 3600
 nonce_counter, nonce_counter_lock = 0, Lock()
 
 
-class BanList(object):
+class BanList:
 
     def __init__(self, ban_time_in_minutes=0, max_failures_before_ban=5):
         self.interval = max(0, ban_time_in_minutes) * 60
@@ -120,7 +120,7 @@ def is_nonce_stale(nonce, max_age_seconds=MAX_AGE_SECONDS):
     return True
 
 
-class DigestAuth(object):  # {{{
+class DigestAuth:  # {{{
 
     valid_algorithms = {'MD5', 'MD5-SESS'}
     valid_qops = {'auth', 'auth-int'}
@@ -213,7 +213,7 @@ class DigestAuth(object):  # {{{
 # }}}
 
 
-class AuthController(object):
+class AuthController:
 
     '''
     Implement Basic/Digest authentication for the Content server. Android browsers

--- a/src/calibre/srv/auto_reload.py
+++ b/src/calibre/srv/auto_reload.py
@@ -35,7 +35,7 @@ class NoAutoReload(EnvironmentError):
 # Filesystem watcher {{{
 
 
-class WatcherBase(object):
+class WatcherBase:
 
     EXTENSIONS_TO_WATCH = frozenset('py pyj svg'.split())
     BOUNCE_INTERVAL = 2  # seconds
@@ -237,7 +237,7 @@ def join_process(p, timeout=5):
     return p.poll()
 
 
-class Worker(object):
+class Worker:
 
     def __init__(self, cmd, log, server, timeout=5):
         self.cmd = cmd

--- a/src/calibre/srv/bonjour.py
+++ b/src/calibre/srv/bonjour.py
@@ -8,7 +8,7 @@ __copyright__ = '2015, Kovid Goyal <kovid at kovidgoyal.net>'
 from threading import Event
 
 
-class BonJour(object):  # {{{
+class BonJour:  # {{{
 
     def __init__(self, name='Books in calibre', service_type='_calibre._tcp', path='/opds', add_hostname=True, wait_for_stop=True):
         self.service_name = name

--- a/src/calibre/srv/changes.py
+++ b/src/calibre/srv/changes.py
@@ -6,7 +6,7 @@
 from polyglot.builtins import map
 
 
-class ChangeEvent(object):
+class ChangeEvent:
 
     def __init__(self):
         pass

--- a/src/calibre/srv/convert.py
+++ b/src/calibre/srv/convert.py
@@ -23,7 +23,7 @@ conversion_jobs = {}
 cache_lock = Lock()
 
 
-class JobStatus(object):
+class JobStatus:
 
     def __init__(self, job_id, book_id, tdir, library_id, pathtoebook, conversion_data):
         self.job_id = job_id

--- a/src/calibre/srv/embedded.py
+++ b/src/calibre/srv/embedded.py
@@ -49,7 +49,7 @@ custom_list_template.path = os.path.join(config_dir, 'server-custom-list-templat
 search_the_net_urls.path = os.path.join(config_dir, 'server-search-the-net.json')
 
 
-class Server(object):
+class Server:
 
     loop = current_thread = exception = None
     state_callback = start_failure_callback = None

--- a/src/calibre/srv/handler.py
+++ b/src/calibre/srv/handler.py
@@ -18,7 +18,7 @@ from calibre.utils.search_query_parser import ParseException
 from polyglot.builtins import itervalues, filter, unicode_type
 
 
-class Context(object):
+class Context:
 
     log = None
     url_for = None
@@ -186,7 +186,7 @@ class Context(object):
 SRV_MODULES = ('ajax', 'books', 'cdb', 'code', 'content', 'legacy', 'opds', 'users_api', 'convert')
 
 
-class Handler(object):
+class Handler:
 
     def __init__(self, libraries, opts, testing=False, notify_changes=None):
         ctx = Context(libraries, opts, testing=testing, notify_changes=notify_changes)

--- a/src/calibre/srv/http_request.py
+++ b/src/calibre/srv/http_request.py
@@ -125,7 +125,7 @@ def normalize_header_name(name):
     return '-'.join(parts)
 
 
-class HTTPHeaderParser(object):
+class HTTPHeaderParser:
 
     '''
     Parse HTTP headers. Use this class by repeatedly calling the created object

--- a/src/calibre/srv/http_response.py
+++ b/src/calibre/srv/http_response.py
@@ -209,7 +209,7 @@ def get_range_parts(ranges, content_type, content_length):  # {{{
 # }}}
 
 
-class ETaggedFile(object):  # {{{
+class ETaggedFile:  # {{{
 
     def __init__(self, output, etag):
         self.output, self.etag = output, etag
@@ -219,7 +219,7 @@ class ETaggedFile(object):  # {{{
 # }}}
 
 
-class RequestData(object):  # {{{
+class RequestData:  # {{{
 
     cookies = {}
     username = None
@@ -301,7 +301,7 @@ class RequestData(object):  # {{{
 # }}}
 
 
-class ReadableOutput(object):
+class ReadableOutput:
 
     def __init__(self, output, etag=None, content_length=None):
         self.src_file = output
@@ -345,7 +345,7 @@ def dynamic_output(output, outheaders, etag=None):
     return ans
 
 
-class ETaggedDynamicOutput(object):
+class ETaggedDynamicOutput:
 
     def __init__(self, func, etag):
         self.func, self.etag = func, etag
@@ -354,7 +354,7 @@ class ETaggedDynamicOutput(object):
         return self.func()
 
 
-class GeneratedOutput(object):
+class GeneratedOutput:
 
     def __init__(self, output, etag=None):
         self.output = output
@@ -363,7 +363,7 @@ class GeneratedOutput(object):
         self.accept_ranges = False
 
 
-class StaticOutput(object):
+class StaticOutput:
 
     def __init__(self, data):
         if isinstance(data, unicode_type):

--- a/src/calibre/srv/jobs.py
+++ b/src/calibre/srv/jobs.py
@@ -82,7 +82,7 @@ class Job(Thread):
         return ans
 
 
-class JobsManager(object):
+class JobsManager:
 
     def __init__(self, opts, log):
         mj = opts.max_jobs

--- a/src/calibre/srv/library_broker.py
+++ b/src/calibre/srv/library_broker.py
@@ -93,7 +93,7 @@ def db_matches(db, library_id, library_path):
     return samefile(dbpath, os.path.join(library_path, os.path.basename(dbpath)))
 
 
-class LibraryBroker(object):
+class LibraryBroker:
 
     def __init__(self, libraries):
         self.lock = Lock()

--- a/src/calibre/srv/loop.py
+++ b/src/calibre/srv/loop.py
@@ -38,7 +38,7 @@ WAKEUP, JOB_DONE = b'\0', b'\x01'
 IPPROTO_IPV6 = getattr(socket, "IPPROTO_IPV6", 41)
 
 
-class ReadBuffer(object):  # {{{
+class ReadBuffer:  # {{{
 
     ' A ring buffer used to speed up the readline() implementation by minimizing recv() calls '
 
@@ -153,7 +153,7 @@ def is_ip_trusted(remote_addr, trusted_ips):
     return False
 
 
-class Connection(object):  # {{{
+class Connection:  # {{{
 
     def __init__(self, socket, opts, ssl_context, tdir, addr, pool, log, access_log, wakeup):
         self.opts, self.pool, self.log, self.wakeup, self.access_log = opts, pool, log, wakeup, access_log
@@ -365,7 +365,7 @@ class Connection(object):  # {{{
 # }}}
 
 
-class ServerLoop(object):
+class ServerLoop:
 
     LISTENING_MSG = 'calibre server listening on'
 

--- a/src/calibre/srv/metadata.py
+++ b/src/calibre/srv/metadata.py
@@ -146,7 +146,7 @@ CategoriesSettings = namedtuple(
     ' template using_hierarchy grouped_search_terms hidden_categories hide_empty_categories')
 
 
-class GroupedSearchTerms(object):
+class GroupedSearchTerms:
 
     __slots__ = ('keys', 'vals', 'hash')
 

--- a/src/calibre/srv/opds.py
+++ b/src/calibre/srv/opds.py
@@ -244,7 +244,7 @@ def ACQUISITION_ENTRY(book_id, updated, request_context):
 default_feed_title = __appname__ + ' ' + _('Library')
 
 
-class Feed(object):  # {{{
+class Feed:  # {{{
 
     def __init__(self, id_, updated, request_context, subtitle=None,
             title=None,
@@ -352,7 +352,7 @@ class CategoryGroupFeed(NavFeed):
             self.root.append(CATALOG_GROUP_ENTRY(item, which, request_context, updated))
 
 
-class RequestContext(object):
+class RequestContext:
 
     def __init__(self, ctx, rd):
         self.db, self.library_id, self.library_map, self.default_library = get_library_data(ctx, rd)

--- a/src/calibre/srv/opts.py
+++ b/src/calibre/srv/opts.py
@@ -220,7 +220,7 @@ options = OrderedDict([(o.name, o) for o in sorted(options, key=attrgetter('name
 del raw_options
 
 
-class Options(object):
+class Options:
 
     __slots__ = tuple(name for name in options)
 

--- a/src/calibre/srv/pool.py
+++ b/src/calibre/srv/pool.py
@@ -48,7 +48,7 @@ class Worker(Thread):
         self.result_queue.put((job_id, False, sys.exc_info()))
 
 
-class ThreadPool(object):
+class ThreadPool:
 
     def __init__(self, log, notify_server, count=10, queue_size=1000):
         self.request_queue, self.result_queue = Queue(queue_size), Queue(queue_size)
@@ -86,7 +86,7 @@ class ThreadPool(object):
         return sum(int(not w.working) for w in self.workers)
 
 
-class PluginPool(object):
+class PluginPool:
 
     def __init__(self, loop, plugins):
         self.workers = []

--- a/src/calibre/srv/render_book.py
+++ b/src/calibre/srv/render_book.py
@@ -412,7 +412,7 @@ def transform_html(container, name, virtualize_resources, link_uid, link_to_map,
         f.write(shtml)
 
 
-class RenderManager(object):
+class RenderManager:
 
     def __init__(self, max_workers):
         self.max_workers = max_workers
@@ -824,7 +824,7 @@ def viewer_main():
     render_for_viewer(*args)
 
 
-class Profiler(object):
+class Profiler:
 
     def __init__(self):
         try:

--- a/src/calibre/srv/routes.py
+++ b/src/calibre/srv/routes.py
@@ -102,7 +102,7 @@ def endpoint(route,
     return annotate
 
 
-class Route(object):
+class Route:
 
     var_pat = None
 
@@ -217,7 +217,7 @@ class Route(object):
     __unicode__ = __repr__ = __str__
 
 
-class Router(object):
+class Router:
 
     def __init__(self, endpoints=None, ctx=None, url_prefix=None, auth_controller=None):
         self.routes = {}

--- a/src/calibre/srv/standalone.py
+++ b/src/calibre/srv/standalone.py
@@ -58,7 +58,7 @@ def daemonize():  # {{{
 # }}}
 
 
-class Server(object):
+class Server:
 
     def __init__(self, libraries, opts):
         log = access_log = None

--- a/src/calibre/srv/tests/auth.py
+++ b/src/calibre/srv/tests/auth.py
@@ -71,7 +71,7 @@ def digest(un, pw, nonce=None, uri=None, method='GET', nc=1, qop='auth', realm=R
     modify(da)
     pw = getattr(da, 'pw', pw)
 
-    class Data(object):
+    class Data:
 
         def __init__(self):
             self.method = method

--- a/src/calibre/srv/tests/loop.py
+++ b/src/calibre/srv/tests/loop.py
@@ -52,7 +52,7 @@ class LoopTest(BaseTest):
 
     def test_plugins(self):
         'Test plugin semantics'
-        class Plugin(object):
+        class Plugin:
 
             def __init__(self):
                 self.running = Event()
@@ -136,7 +136,7 @@ class LoopTest(BaseTest):
 
     def test_ring_buffer(self):
         'Test the ring buffer used for reads'
-        class FakeSocket(object):
+        class FakeSocket:
 
             def __init__(self, data):
                 self.data = data

--- a/src/calibre/srv/tests/web_sockets.py
+++ b/src/calibre/srv/tests/web_sockets.py
@@ -28,7 +28,7 @@ Sec-WebSocket-Version: 13\r
 Frame = namedtuple('Frame', 'fin opcode payload')
 
 
-class WSClient(object):
+class WSClient:
 
     def __init__(self, port, timeout=5):
         self.timeout = timeout

--- a/src/calibre/srv/users.py
+++ b/src/calibre/srv/users.py
@@ -86,7 +86,7 @@ def connect(path, exc_class=ValueError):
             raise exc_class('Failed to open userdb database at {} with error: {}'.format(path, as_unicode(e)))
 
 
-class UserManager(object):
+class UserManager:
 
     lock = RLock()
 

--- a/src/calibre/srv/utils.py
+++ b/src/calibre/srv/utils.py
@@ -271,7 +271,7 @@ class ServerLog(ThreadSafeLog):
     exception_traceback_level = ThreadSafeLog.WARN
 
 
-class RotatingStream(object):
+class RotatingStream:
 
     def __init__(self, filename, max_size=None, history=5):
         self.filename, self.history, self.max_size = filename, history, max_size
@@ -351,7 +351,7 @@ class RotatingLog(ServerLog):
 # }}}
 
 
-class HandleInterrupt(object):  # {{{
+class HandleInterrupt:  # {{{
 
     # On windows socket functions like accept(), recv(), send() are not
     # interrupted by a Ctrl-C in the console. So to make Ctrl-C work we have to
@@ -397,7 +397,7 @@ class HandleInterrupt(object):  # {{{
 # }}}
 
 
-class Accumulator(object):  # {{{
+class Accumulator:  # {{{
 
     'Optimized replacement for BytesIO when the usage pattern is many writes followed by a single getvalue()'
 
@@ -435,7 +435,7 @@ def get_library_data(ctx, rd, strict_library_id=False):
     return db, library_id, library_map, default_library
 
 
-class Offsets(object):
+class Offsets:
     'Calculate offsets for a paginated view'
 
     def __init__(self, offset, delta, total):

--- a/src/calibre/srv/web_socket.py
+++ b/src/calibre/srv/web_socket.py
@@ -56,7 +56,7 @@ UNEXPECTED_ERROR = 1011
 RESERVED_CLOSE_CODES = (1004,1005,1006,)
 
 
-class ReadFrame(object):  # {{{
+class ReadFrame:  # {{{
 
     def __init__(self):
         self.header_buf = bytearray(14)
@@ -203,7 +203,7 @@ def create_frame(fin, opcode, payload, mask=None, rsv=0):
     return memoryview(frame)
 
 
-class MessageWriter(object):
+class MessageWriter:
 
     def __init__(self, buf, mask=None, chunk_size=None):
         self.buf, self.data_type, self.mask = buf, BINARY, mask
@@ -238,7 +238,7 @@ class MessageWriter(object):
 conn_id = 0
 
 
-class UTF8Decoder(object):  # {{{
+class UTF8Decoder:  # {{{
 
     def __init__(self):
         self.reset()
@@ -512,7 +512,7 @@ class WebSocketConnection(HTTPConnection):
         self.websocket_handler.handle_websocket_data(self.websocket_connection_id, data, message_starting, message_finished)
 
 
-class DummyHandler(object):
+class DummyHandler:
 
     def handle_websocket_upgrade(self, connection_id, connection_ref, inheaders):
         conn = connection_ref()
@@ -533,7 +533,7 @@ class DummyHandler(object):
 # suite
 
 
-class EchoHandler(object):
+class EchoHandler:
 
     def __init__(self, *args, **kwargs):
         self.ws_connections = {}

--- a/src/calibre/utils/complete.py
+++ b/src/calibre/utils/complete.py
@@ -65,7 +65,7 @@ def send(ans):
         prints(x)
 
 
-class EbookConvert(object):
+class EbookConvert:
 
     def __init__(self, comp_line, pos):
         words = split(comp_line[:pos])

--- a/src/calibre/utils/config_base.py
+++ b/src/calibre/utils/config_base.py
@@ -119,7 +119,7 @@ def make_config_dir():
         os.makedirs(plugin_dir, mode=CONFIG_DIR_MODE)
 
 
-class Option(object):
+class Option:
 
     def __init__(self, name, switches=[], help='', type=None, choices=None,
                  check=None, group=None, default=None, action=None, metavar=None):
@@ -153,13 +153,13 @@ class Option(object):
         return repr(self)
 
 
-class OptionValues(object):
+class OptionValues:
 
     def copy(self):
         return deepcopy(self)
 
 
-class OptionSet(object):
+class OptionSet:
 
     OVERRIDE_PAT = re.compile(r'#{3,100} Override Options #{15}(.*?)#{3,100} End Override #{3,100}',
                               re.DOTALL|re.IGNORECASE)
@@ -323,7 +323,7 @@ class OptionSet(object):
         return json_dumps(data, ignore_unserializable=ignore_unserializable)
 
 
-class ConfigInterface(object):
+class ConfigInterface:
 
     def __init__(self, description):
         self.option_set       = OptionSet(description=description)
@@ -429,7 +429,7 @@ class StringConfig(ConfigInterface):
         self.set_src(self.option_set.serialize(opts))
 
 
-class ConfigProxy(object):
+class ConfigProxy:
     '''
     A Proxy to minimize file reads for widely used config settings
     '''
@@ -656,7 +656,7 @@ def reset_tweaks_to_default():
     tweaks.update(default_tweaks)
 
 
-class Tweak(object):
+class Tweak:
 
     def __init__(self, name, value):
         self.name, self.value = name, value

--- a/src/calibre/utils/exim.py
+++ b/src/calibre/utils/exim.py
@@ -28,7 +28,7 @@ def send_file(from_obj, to_obj, chunksize=1<<20):
     return unicode_type(m.hexdigest())
 
 
-class FileDest(object):
+class FileDest:
 
     def __init__(self, key, exporter, mtime=None):
         self.exporter, self.key = exporter, key
@@ -66,7 +66,7 @@ class FileDest(object):
         self.close()
 
 
-class Exporter(object):
+class Exporter:
 
     VERSION = 0
     TAIL_FMT = b'!II?'  # part_num, version, is_last
@@ -209,7 +209,7 @@ def export(destdir, library_paths=None, dbmap=None, progress1=None, progress2=No
 # Import {{{
 
 
-class FileSource(object):
+class FileSource:
 
     def __init__(self, f, size, digest, description, mtime, importer):
         self.f, self.size, self.digest, self.description = f, size, digest, description
@@ -235,7 +235,7 @@ class FileSource(object):
         self.hasher = self.f = None
 
 
-class Importer(object):
+class Importer:
 
     def __init__(self, path_to_export_dir):
         self.corrupted_files = []

--- a/src/calibre/utils/filenames.py
+++ b/src/calibre/utils/filenames.py
@@ -320,7 +320,7 @@ def windows_nlinks(path):
     return winutil.nlinks(path)
 
 
-class WindowsAtomicFolderMove(object):
+class WindowsAtomicFolderMove:
 
     '''
     Move all the files inside a specified folder in an atomic fashion,

--- a/src/calibre/utils/fonts/free_type.py
+++ b/src/calibre/utils/fonts/free_type.py
@@ -30,7 +30,7 @@ def same_thread(func):
     return check_thread
 
 
-class Face(object):
+class Face:
 
     def __init__(self, face):
         self.start_thread = threading.current_thread()
@@ -64,7 +64,7 @@ class Face(object):
             yield self.face.glyph_id(ord(char))
 
 
-class FreeType(object):
+class FreeType:
 
     def __init__(self):
         self.start_thread = threading.current_thread()

--- a/src/calibre/utils/fonts/metadata.py
+++ b/src/calibre/utils/fonts/metadata.py
@@ -24,7 +24,7 @@ FontNames = namedtuple('FontNames',
     'family_name, subfamily_name, full_name, preferred_family_name, preferred_subfamily_name, wws_family_name, wws_subfamily_name')
 
 
-class FontMetadata(object):
+class FontMetadata:
 
     def __init__(self, bytes_or_stream):
         if not hasattr(bytes_or_stream, 'read'):

--- a/src/calibre/utils/fonts/sfnt/__init__.py
+++ b/src/calibre/utils/fonts/sfnt/__init__.py
@@ -20,7 +20,7 @@ def align_block(raw, multiple=4, pad=b'\0'):
     return raw + pad*(multiple - extra)
 
 
-class UnknownTable(object):
+class UnknownTable:
 
     def __init__(self, raw):
         self.raw = raw
@@ -32,7 +32,7 @@ class UnknownTable(object):
         return len(self.raw)
 
 
-class DateTimeProperty(object):
+class DateTimeProperty:
 
     def __init__(self, name):
         self.name = name
@@ -46,7 +46,7 @@ class DateTimeProperty(object):
         setattr(obj, self.name, int(td.total_seconds()))
 
 
-class FixedProperty(object):
+class FixedProperty:
 
     def __init__(self, name):
         self.name = name

--- a/src/calibre/utils/fonts/sfnt/cff/table.py
+++ b/src/calibre/utils/fonts/sfnt/cff/table.py
@@ -21,7 +21,7 @@ from polyglot.builtins import iteritems, itervalues, range
 # http://www.adobe.com/content/dam/Adobe/en/devnet/font/pdfs/5177.Type2.pdf
 
 
-class CFF(object):
+class CFF:
 
     def __init__(self, raw):
         (self.major_version, self.minor_version, self.header_size,

--- a/src/calibre/utils/fonts/sfnt/cff/writer.py
+++ b/src/calibre/utils/fonts/sfnt/cff/writer.py
@@ -76,7 +76,7 @@ class Dict(Index):
         Index.compile(self)
 
 
-class PrivateDict(object):
+class PrivateDict:
 
     def __init__(self, src, subrs, strings):
         self.src, self.strings = src, strings
@@ -109,7 +109,7 @@ class Charsets(list):
         return ans
 
 
-class Subset(object):
+class Subset:
 
     def __init__(self, cff, keep_charnames):
         self.cff = cff

--- a/src/calibre/utils/fonts/sfnt/cmap.py
+++ b/src/calibre/utils/fonts/sfnt/cmap.py
@@ -120,7 +120,7 @@ def set_id_delta(id_delta):  # {{{
 # }}}
 
 
-class BMPTable(object):
+class BMPTable:
 
     def __init__(self, raw):
         self.raw = raw

--- a/src/calibre/utils/fonts/sfnt/common.py
+++ b/src/calibre/utils/fonts/sfnt/common.py
@@ -13,7 +13,7 @@ from calibre.utils.fonts.sfnt.errors import UnsupportedFont
 from polyglot.builtins import range, iteritems
 
 
-class Unpackable(object):
+class Unpackable:
 
     def __init__(self, raw, offset):
         self.raw, self.offset = raw, offset
@@ -171,7 +171,7 @@ def ExtensionSubstitution(raw, offset, subtable_map={}):
 CoverageRange = namedtuple('CoverageRange', 'start end start_coverage_index')
 
 
-class Coverage(object):
+class Coverage:
 
     def __init__(self, raw, offset, parent_table_name):
         data = Unpackable(raw, offset)
@@ -208,7 +208,7 @@ class Coverage(object):
         return ans
 
 
-class UnknownLookupSubTable(object):
+class UnknownLookupSubTable:
 
     formats = {}
 

--- a/src/calibre/utils/fonts/sfnt/container.py
+++ b/src/calibre/utils/fonts/sfnt/container.py
@@ -24,7 +24,7 @@ from calibre.utils.fonts.utils import checksum_of_block, get_tables, verify_chec
 # OpenType spec: http://www.microsoft.com/typography/otspec/otff.htm
 
 
-class Sfnt(object):
+class Sfnt:
 
     TABLE_MAP = {
         b'head' : HeadTable,

--- a/src/calibre/utils/fonts/sfnt/glyf.py
+++ b/src/calibre/utils/fonts/sfnt/glyf.py
@@ -27,7 +27,7 @@ SCALED_COMPONENT_OFFSET    = 0x0800  # composite designed to have the component 
 UNSCALED_COMPONENT_OFFSET  = 0x1000  # composite designed not to have the component offset scaled (designed for MS)
 
 
-class SimpleGlyph(object):
+class SimpleGlyph:
 
     def __init__(self, num_of_countours, raw):
         self.num_of_countours = num_of_countours

--- a/src/calibre/utils/fonts/sfnt/metrics.py
+++ b/src/calibre/utils/fonts/sfnt/metrics.py
@@ -11,7 +11,7 @@ from calibre.utils.fonts.utils import get_all_font_names
 from calibre.utils.fonts.sfnt.container import UnsupportedFont
 
 
-class FontMetrics(object):
+class FontMetrics:
 
     '''
     Get various metrics for the specified sfnt. All the metrics are returned in

--- a/src/calibre/utils/fonts/win_fonts.py
+++ b/src/calibre/utils/fonts/win_fonts.py
@@ -16,7 +16,7 @@ from calibre.utils.fonts.utils import (is_truetype_font, get_font_names,
 from polyglot.builtins import iteritems, unicode_type
 
 
-class WinFonts(object):
+class WinFonts:
 
     def __init__(self, winfonts):
         self.w = winfonts

--- a/src/calibre/utils/formatter.py
+++ b/src/calibre/utils/formatter.py
@@ -20,7 +20,7 @@ from calibre.utils.icu import strcmp
 from polyglot.builtins import unicode_type, error_message
 
 
-class Node(object):
+class Node:
     NODE_RVALUE = 1
     NODE_IF = 2
     NODE_ASSIGN = 3
@@ -255,7 +255,7 @@ class CharacterNode(Node):
         self.expression = expression
 
 
-class _Parser(object):
+class _Parser:
     LEX_OP = 1
     LEX_ID = 2
     LEX_CONST = 3
@@ -677,7 +677,7 @@ class StopException(Exception):
         super().__init__('Template evaluation stopped')
 
 
-class _Interpreter(object):
+class _Interpreter:
     def error(self, message, line_number):
         m = _('Interpreter: {0} - line number {1}').format(message, line_number)
         raise ValueError(m)

--- a/src/calibre/utils/formatter_functions.py
+++ b/src/calibre/utils/formatter_functions.py
@@ -28,7 +28,7 @@ from calibre.utils.localization import calibre_langcode_to_name, canonicalize_la
 from polyglot.builtins import iteritems, itervalues, unicode_type
 
 
-class FormatterFunctions(object):
+class FormatterFunctions:
 
     error_function_body = ('def evaluate(self, formatter, kwargs, mi, locals):\n'
                        '\treturn "' +
@@ -121,7 +121,7 @@ def formatter_functions():
     return _ff
 
 
-class FormatterFunction(object):
+class FormatterFunction:
 
     doc = _('No documentation provided')
     name = 'no name provided'

--- a/src/calibre/utils/img.py
+++ b/src/calibre/utils/img.py
@@ -304,7 +304,7 @@ def blend_on_canvas(img, width, height, bgcolor='#ffffff'):
     return canvas
 
 
-class Canvas(object):
+class Canvas:
 
     def __init__(self, width, height, bgcolor='#ffffff'):
         self.img = QImage(width, height, QImage.Format.Format_RGB32)

--- a/src/calibre/utils/inotify.py
+++ b/src/calibre/utils/inotify.py
@@ -71,7 +71,7 @@ def load_inotify():  # {{{
 # }}}
 
 
-class INotify(object):
+class INotify:
 
     # See <sys/inotify.h> for the flags defined below
 

--- a/src/calibre/utils/ipc/job.py
+++ b/src/calibre/utils/ipc/job.py
@@ -19,7 +19,7 @@ from polyglot.builtins import cmp
 job_counter = count()
 
 
-class BaseJob(object):
+class BaseJob:
 
     WAITING  = 0
     RUNNING  = 1

--- a/src/calibre/utils/ipc/pool.py
+++ b/src/calibre/utils/ipc/pool.py
@@ -89,7 +89,7 @@ class Failure(Exception):
         self.failure_message = tf.message
 
 
-class Worker(object):
+class Worker:
 
     def __init__(self, p, conn, events, name):
         self.process, self.conn = p, conn

--- a/src/calibre/utils/ipython.py
+++ b/src/calibre/utils/ipython.py
@@ -152,7 +152,7 @@ class Exit:
         raise SystemExit(0)
 
 
-class Helper(object):
+class Helper:
 
     def __repr__(self):
         return "Type help() for interactive help, " \

--- a/src/calibre/utils/localunzip.py
+++ b/src/calibre/utils/localunzip.py
@@ -257,7 +257,7 @@ def extractall(path_or_stream, path=None):
             f.close()
 
 
-class LocalZipFile(object):
+class LocalZipFile:
 
     def __init__(self, stream):
         self.file_info = OrderedDict()

--- a/src/calibre/utils/lock.py
+++ b/src/calibre/utils/lock.py
@@ -95,7 +95,7 @@ def lock_file(path, timeout=15, sleep_time=0.2):
     return f
 
 
-class ExclusiveFile(object):
+class ExclusiveFile:
 
     def __init__(self, path, timeout=15, sleep_time=0.2):
         if iswindows and isinstance(path, bytes):

--- a/src/calibre/utils/logging.py
+++ b/src/calibre/utils/logging.py
@@ -19,7 +19,7 @@ from calibre.prints import prints
 from polyglot.builtins import as_unicode
 
 
-class Stream(object):
+class Stream:
 
     def __init__(self, stream=None):
         if stream is None:
@@ -147,7 +147,7 @@ class UnicodeHTMLStream(HTMLStream):
         self.last_col = lc
 
 
-class Log(object):
+class Log:
 
     DEBUG = DEBUG
     INFO  = INFO

--- a/src/calibre/utils/magick/legacy.py
+++ b/src/calibre/utils/magick/legacy.py
@@ -16,13 +16,13 @@ from calibre.utils.img import (
 from calibre.utils.imghdr import identify
 
 
-class PixelWand(object):
+class PixelWand:
 
     def __init__(self):
         self.color = '#ffffff'
 
 
-class Image(object):
+class Image:
 
     def __init__(self):
         self.read_format = None

--- a/src/calibre/utils/matcher.py
+++ b/src/calibre/utils/matcher.py
@@ -79,7 +79,7 @@ def default_scorer(*args, **kwargs):
         return PyScorer(*args, **kwargs)
 
 
-class Matcher(object):
+class Matcher:
 
     def __init__(
         self,
@@ -220,7 +220,7 @@ def process_item(ctx, haystack, needle):
     return final_score, final_positions
 
 
-class PyScorer(object):
+class PyScorer:
     __slots__ = (
         'level1', 'level2', 'level3', 'max_score_per_char', 'items', 'memory'
     )
@@ -246,7 +246,7 @@ class PyScorer(object):
 # }}}
 
 
-class CScorer(object):
+class CScorer:
 
     def __init__(
         self,

--- a/src/calibre/utils/opensearch/description.py
+++ b/src/calibre/utils/opensearch/description.py
@@ -15,7 +15,7 @@ from calibre.utils.xml_parse import safe_xml_fromstring
 from calibre.utils.opensearch.url import URL
 
 
-class Description(object):
+class Description:
     '''
     A class for representing OpenSearch Description files.
     '''

--- a/src/calibre/utils/opensearch/query.py
+++ b/src/calibre/utils/opensearch/query.py
@@ -8,7 +8,7 @@ __docformat__ = 'restructuredtext en'
 from polyglot.urllib import parse_qs, urlencode, urlparse, urlunparse
 
 
-class Query(object):
+class Query:
     '''
     Represents an opensearch query Really this class is just a
     helper for substituting values into the macros in a format.

--- a/src/calibre/utils/opensearch/url.py
+++ b/src/calibre/utils/opensearch/url.py
@@ -6,7 +6,7 @@ __copyright__ = '2006, Ed Summers <ehs@pobox.com>'
 __docformat__ = 'restructuredtext en'
 
 
-class URL(object):
+class URL:
     '''
     Class for representing a URL in an opensearch v1.1 query
     '''

--- a/src/calibre/utils/resources.py
+++ b/src/calibre/utils/resources.py
@@ -16,7 +16,7 @@ from polyglot.builtins import builtins
 user_dir = os.path.join(config_dir, 'resources')
 
 
-class PathResolver(object):
+class PathResolver:
 
     def __init__(self):
         self.locations = [sys.resources_location]

--- a/src/calibre/utils/search_query_parser.py
+++ b/src/calibre/utils/search_query_parser.py
@@ -33,7 +33,7 @@ adding other fields, such as whether the search is a 'favorite'
 '''
 
 
-class SavedSearchQueries(object):
+class SavedSearchQueries:
     queries = {}
     opt_name = ''
 
@@ -139,7 +139,7 @@ base_token ::= a sequence of letters and colons, perhaps quoted
 '''
 
 
-class Parser(object):
+class Parser:
 
     def __init__(self):
         self.current_token = 0
@@ -286,7 +286,7 @@ class ParseException(Exception):
         return ""
 
 
-class SearchQueryParser(object):
+class SearchQueryParser:
     '''
     Parses a search query.
 

--- a/src/calibre/utils/short_uuid.py
+++ b/src/calibre/utils/short_uuid.py
@@ -30,7 +30,7 @@ def string_to_num(string, alphabet_map, alphabet_len):
     return ans
 
 
-class ShortUUID(object):
+class ShortUUID:
 
     def __init__(self, alphabet=None):
         # We do not include zero and one in the default alphabet as they can be

--- a/src/calibre/utils/terminal.py
+++ b/src/calibre/utils/terminal.py
@@ -102,7 +102,7 @@ def colored(text, fg=None, bg=None, bold=False):
     return prefix + text + suffix
 
 
-class Detect(object):
+class Detect:
 
     def __init__(self, stream):
         self.stream = stream or sys.stdout

--- a/src/calibre/utils/unrar.py
+++ b/src/calibre/utils/unrar.py
@@ -22,7 +22,7 @@ def as_unicode(x):
     return x
 
 
-class StreamAsPath(object):
+class StreamAsPath:
 
     def __init__(self, stream):
         self.stream = stream

--- a/src/calibre/utils/winreg/dde.py
+++ b/src/calibre/utils/winreg/dde.py
@@ -97,7 +97,7 @@ def default_errcheck(result, func, args):
 null = object()
 
 
-class a(object):
+class a:
 
     def __init__(self, name, typ, default=null, in_arg=True):
         self.typ=typ

--- a/src/calibre/utils/winreg/lib.py
+++ b/src/calibre/utils/winreg/lib.py
@@ -53,7 +53,7 @@ def default_errcheck(result, func, args):
 null = object()
 
 
-class a(object):
+class a:
 
     def __init__(self, name, typ, default=null, in_arg=True):
         self.typ = typ
@@ -211,7 +211,7 @@ def filetime_to_datettime(ft):
 # }}}
 
 
-class Key(object):
+class Key:
 
     def __init__(self, create_at=None, open_at=None, root=HKEY_CURRENT_USER, open_mode=KEY_READ):
         root = getattr(root, 'hkey', root)

--- a/src/calibre/utils/wmf/__init__.py
+++ b/src/calibre/utils/wmf/__init__.py
@@ -17,7 +17,7 @@ class NoRaster(Exception):
     pass
 
 
-class DIBHeader(object):
+class DIBHeader:
 
     '''
     See http://en.wikipedia.org/wiki/BMP_file_format

--- a/src/calibre/utils/wmf/emf.py
+++ b/src/calibre/utils/wmf/emf.py
@@ -36,7 +36,7 @@ StretchDiBits = namedtuple(
 # }}}
 
 
-class EMF(object):
+class EMF:
 
     def __init__(self, raw, verbose=0):
         self.pos = 0

--- a/src/calibre/utils/wmf/parse.py
+++ b/src/calibre/utils/wmf/parse.py
@@ -11,7 +11,7 @@ import sys, struct
 from calibre.utils.wmf import create_bmp_from_dib, to_png
 
 
-class WMFHeader(object):
+class WMFHeader:
 
     '''
     For header documentation, see
@@ -37,7 +37,7 @@ class WMFHeader(object):
         self.records_start_at = header_size * 2
 
 
-class WMF(object):
+class WMF:
 
     def __init__(self, log=None, verbose=0):
         if log is None:

--- a/src/calibre/utils/wordcount.py
+++ b/src/calibre/utils/wordcount.py
@@ -82,7 +82,7 @@ def get_wordcount(text):
 
 def dict2obj(dictionary):
     """Transform a dictionary into an object"""
-    class Obj(object):
+    class Obj:
 
         def __init__(self, dictionary):
             self.__dict__.update(dictionary)

--- a/src/calibre/utils/zipfile.py
+++ b/src/calibre/utils/zipfile.py
@@ -301,7 +301,7 @@ def _EndRecData(fpin):
     return
 
 
-class ZipInfo (object):
+class ZipInfo :
 
     """Class with attributes describing each file in the ZIP archive."""
 

--- a/src/calibre/web/__init__.py
+++ b/src/calibre/web/__init__.py
@@ -4,7 +4,7 @@ __license__   = 'GPL v3'
 __copyright__ = '2008, Kovid Goyal <kovid at kovidgoyal.net>'
 
 
-class Recipe(object):
+class Recipe:
     pass
 
 

--- a/src/calibre/web/feeds/__init__.py
+++ b/src/calibre/web/feeds/__init__.py
@@ -15,7 +15,7 @@ from calibre.utils.cleantext import clean_ascii_chars, clean_xml_chars
 from polyglot.builtins import unicode_type, string_or_bytes, map
 
 
-class Article(object):
+class Article:
 
     def __init__(self, id, title, url, author, summary, published, content):
         from lxml import html
@@ -107,7 +107,7 @@ Has content : %s
         return self.content == getattr(other_article, 'content', False)
 
 
-class Feed(object):
+class Feed:
 
     def __init__(self, get_article_url=lambda item: item.get('link', None),
             log=default_log):

--- a/src/calibre/web/feeds/recipes/collection.py
+++ b/src/calibre/web/feeds/recipes/collection.py
@@ -276,7 +276,7 @@ def get_builtin_recipe_by_id(id_, log=None, download_recipe=False):
             return get_builtin_recipe(urn)
 
 
-class SchedulerConfig(object):
+class SchedulerConfig:
 
     def __init__(self):
         from calibre.utils.config import config_dir

--- a/src/calibre/web/feeds/recipes/model.py
+++ b/src/calibre/web/feeds/recipes/model.py
@@ -25,7 +25,7 @@ from calibre.utils.search_query_parser import ParseException
 from polyglot.builtins import iteritems, unicode_type
 
 
-class NewsTreeItem(object):
+class NewsTreeItem:
 
     def __init__(self, builtin, custom, scheduler_config, parent=None):
         self.builtin, self.custom = builtin, custom

--- a/src/calibre/web/feeds/templates.py
+++ b/src/calibre/web/feeds/templates.py
@@ -27,7 +27,7 @@ def attrs(*args, **kw):
 # Regular templates
 
 
-class Template(object):
+class Template:
 
     IS_HTML = True
 

--- a/src/calibre/web/fetch/simple.py
+++ b/src/calibre/web/fetch/simple.py
@@ -45,7 +45,7 @@ class FetchError(Exception):
     pass
 
 
-class closing(object):
+class closing:
 
     'Context to automatically close something at the end of a block.'
 
@@ -125,7 +125,7 @@ def default_is_link_wanted(url, tag):
     raise NotImplementedError()
 
 
-class RecursiveFetcher(object):
+class RecursiveFetcher:
     LINK_FILTER = tuple(re.compile(i, re.IGNORECASE) for i in
                 ('.exe\\s*$', '.mp3\\s*$', '.ogg\\s*$', '^\\s*mailto:', '^\\s*$'))
     # ADBLOCK_FILTER = tuple(re.compile(i, re.IGNORECASE) for it in

--- a/src/css_selectors/parser.py
+++ b/src/css_selectors/parser.py
@@ -46,7 +46,7 @@ else:
 
 # Parsed objects
 
-class Selector(object):
+class Selector:
 
     """
     Represents a parsed selector.
@@ -101,7 +101,7 @@ class Selector(object):
         return a, b, c
 
 
-class Class(object):
+class Class:
 
     """
     Represents selector.class_name
@@ -120,7 +120,7 @@ class Class(object):
         return a, b, c
 
 
-class FunctionalPseudoElement(object):
+class FunctionalPseudoElement:
 
     """
     Represents selector::name(arguments)
@@ -156,7 +156,7 @@ class FunctionalPseudoElement(object):
         return a, b, c
 
 
-class Function(object):
+class Function:
 
     """
     Represents selector:name(expr)
@@ -194,7 +194,7 @@ class Function(object):
         return a, b, c
 
 
-class Pseudo(object):
+class Pseudo:
 
     """
     Represents selector:ident
@@ -213,7 +213,7 @@ class Pseudo(object):
         return a, b, c
 
 
-class Negation(object):
+class Negation:
 
     """
     Represents selector:not(subselector)
@@ -232,7 +232,7 @@ class Negation(object):
         return a1 + a2, b1 + b2, c1 + c2
 
 
-class Attrib(object):
+class Attrib:
 
     """
     Represents selector[namespace|attrib operator value]
@@ -263,7 +263,7 @@ class Attrib(object):
         return a, b, c
 
 
-class Element(object):
+class Element:
 
     """
     Represents namespace|element
@@ -288,7 +288,7 @@ class Element(object):
             return 0, 0, 0
 
 
-class Hash(object):
+class Hash:
 
     """
     Represents selector#id
@@ -307,7 +307,7 @@ class Hash(object):
         return a, b, c
 
 
-class CombinedSelector(object):
+class CombinedSelector:
 
     def __init__(self, selector, combinator, subselector):
         assert selector is not None
@@ -739,7 +739,7 @@ def tokenize(s):
     yield EOFToken(pos)
 
 
-class TokenStream(object):
+class TokenStream:
 
     def __init__(self, tokens, source=None):
         self.used = []

--- a/src/css_selectors/select.py
+++ b/src/css_selectors/select.py
@@ -47,7 +47,7 @@ def get_compiled_xpath(expr):
         return ans
 
 
-class AlwaysIn(object):
+class AlwaysIn:
 
     def __contains__(self, x):
         return True
@@ -91,7 +91,7 @@ INAPPROPRIATE_PSEUDO_CLASSES = frozenset((
     'active', 'after', 'disabled', 'visited', 'link', 'before', 'focus', 'first-letter', 'enabled', 'first-line', 'hover', 'checked', 'target'))
 
 
-class Select(object):
+class Select:
 
     '''
 

--- a/src/odf/odf2moinmoin.py
+++ b/src/odf/odf2moinmoin.py
@@ -145,7 +145,7 @@ class ListProperties:
         self.ordered = value
 
 
-class ODF2MoinMoin(object):
+class ODF2MoinMoin:
 
     def __init__(self, filepath):
         self.footnotes = []

--- a/src/odf/teletype.py
+++ b/src/odf/teletype.py
@@ -32,7 +32,7 @@ from .element import Node
 from .text import S,LineBreak,Tab
 
 
-class WhitespaceText(object):
+class WhitespaceText:
 
     def __init__(self):
         self.textBuffer = []

--- a/src/odf/userfield.py
+++ b/src/odf/userfield.py
@@ -44,7 +44,7 @@ VALUE_TYPES = {
     }
 
 
-class UserFields(object):
+class UserFields:
     """List, view and manipulate user fields."""
 
     # these attributes can be a filename or a file like object

--- a/src/polyglot/smtplib.py
+++ b/src/polyglot/smtplib.py
@@ -6,7 +6,7 @@ import sys
 from functools import partial
 
 
-class FilteredLog(object):
+class FilteredLog:
 
     ' Hide AUTH credentials from the log '
 

--- a/src/templite/__init__.py
+++ b/src/templite/__init__.py
@@ -29,7 +29,7 @@ import sys, re
 
 from polyglot.builtins import unicode_type
 
-class Templite(object):
+class Templite:
     auto_emit = re.compile('(^[\'\"])|(^[a-zA-Z0-9_\[\]\'\"]+$)')
 
     def __init__(self, template, start='${', end='}$'):

--- a/src/tinycss/css21.py
+++ b/src/tinycss/css21.py
@@ -38,7 +38,7 @@ from tinycss.parsing import (
 #  unused      : block | ATKEYWORD S* | ';' S* | CDO S* | CDC S*;
 
 
-class Stylesheet(object):
+class Stylesheet:
     """
     A parsed CSS stylesheet.
 
@@ -70,7 +70,7 @@ class Stylesheet(object):
             self, len(self.rules), len(self.errors))
 
 
-class AtRule(object):
+class AtRule:
     """
     An unparsed at-rule.
 
@@ -115,7 +115,7 @@ class AtRule(object):
                 .format(self))
 
 
-class RuleSet(object):
+class RuleSet:
     """A ruleset.
 
     .. attribute:: at_keyword
@@ -150,7 +150,7 @@ class RuleSet(object):
                 .format(self, self.selector.as_css()))
 
 
-class Declaration(object):
+class Declaration:
     """A property declaration.
 
     .. attribute:: name
@@ -191,7 +191,7 @@ class Declaration(object):
                     self, self.value.as_css(), priority))
 
 
-class PageRule(object):
+class PageRule:
     """A parsed CSS 2.1 @page rule.
 
     .. attribute:: at_keyword
@@ -237,7 +237,7 @@ class PageRule(object):
                 ' {0.selector}>'.format(self))
 
 
-class MediaRule(object):
+class MediaRule:
     """A parsed @media rule.
 
     .. attribute:: at_keyword
@@ -269,7 +269,7 @@ class MediaRule(object):
                 ' {0.media}>'.format(self))
 
 
-class ImportRule(object):
+class ImportRule:
     """A parsed @import rule.
 
     .. attribute:: at_keyword
@@ -323,7 +323,7 @@ def _remove_at_charset(tokens):
     return chain(header, tokens)
 
 
-class CSS21Parser(object):
+class CSS21Parser:
     """Parser for CSS 2.1
 
     This parser supports the core CSS syntax as well as @import, @media,

--- a/src/tinycss/decoding.py
+++ b/src/tinycss/decoding.py
@@ -100,7 +100,7 @@ def hex2re(hex_data):
     return re.escape(from_hex_bytes(hex_data.replace(' ', '').encode('ascii')))
 
 
-class Slicer(object):
+class Slicer:
     """Slice()[start:stop:end] == slice(start, stop, end)"""
     def __getitem__(self, slice_):
         return operator.itemgetter(slice_)

--- a/src/tinycss/fonts3.py
+++ b/src/tinycss/fonts3.py
@@ -186,7 +186,7 @@ def parse_font(css_string):
     return ans
 
 
-class FontFaceRule(object):
+class FontFaceRule:
 
     at_keyword = '@font-face'
     __slots__ = 'declarations', 'line', 'column'

--- a/src/tinycss/media3.py
+++ b/src/tinycss/media3.py
@@ -10,7 +10,7 @@ from tinycss.parsing import remove_whitespace, split_on_comma, ParseError
 from polyglot.builtins import error_message
 
 
-class MediaQuery(object):
+class MediaQuery:
 
     __slots__ = 'media_type', 'expressions', 'negated'
 

--- a/src/tinycss/page3.py
+++ b/src/tinycss/page3.py
@@ -16,7 +16,7 @@
 from .css21 import CSS21Parser, ParseError
 
 
-class MarginRule(object):
+class MarginRule:
     """A parsed at-rule for margin box.
 
     .. attribute:: at_keyword

--- a/src/tinycss/token_data.py
+++ b/src/tinycss/token_data.py
@@ -217,7 +217,7 @@ def FIND_NEWLINES(x):
     return list(re.compile(COMPILED_MACROS['nl']).finditer(x))
 
 
-class Token(object):
+class Token:
     r"""A single atomic token.
 
     .. attribute:: is_container
@@ -334,7 +334,7 @@ class Token(object):
                 .format(self, self.unit or ''))
 
 
-class ContainerToken(object):
+class ContainerToken:
     """A token that contains other (nested) tokens.
 
     .. attribute:: is_container


### PR DESCRIPTION
Python2 had old-style classes (no "(object)"), and new style classes (with
"object"). Under Py3 this is a noop, so let's drop it to make the code
a bit shorter.