### PR TITLE
Two independent commits

### DIFF
--- a/src/calibre/gui2/tag_browser/ui.py
+++ b/src/calibre/gui2/tag_browser/ui.py
@@ -556,7 +556,7 @@ class TagBrowserBar(QWidget):  # {{{
         ac = QAction(parent)
         parent.addAction(ac)
         parent.keyboard.register_shortcut('tag browser find box',
-                _('Find next match'), default_keys=(),
+                _('Find in the Tag browser'), default_keys=(),
                 action=ac, group=_('Tag browser'))
         ac.triggered.connect(self.set_focus_to_find_box)
 
@@ -568,7 +568,7 @@ class TagBrowserBar(QWidget):  # {{{
         ac = QAction(parent)
         parent.addAction(ac)
         parent.keyboard.register_shortcut('tag browser find button',
-                _('Find in the Tag browser'), default_keys=(),
+                _('Find next match'), default_keys=(),
                 action=ac, group=_('Tag browser'))
         ac.triggered.connect(self.search_button.click)
 

--- a/src/calibre/gui2/tag_browser/view.py
+++ b/src/calibre/gui2/tag_browser/view.py
@@ -331,13 +331,26 @@ class TagsView(QTreeView):  # {{{
     def keyPressEvent(self, event):
         # I don't see how current_index can ever be not valid, but ...
         if self.currentIndex().isValid():
-            if (gprefs['tag_browser_allow_keyboard_focus'] and
-                    event.key() == Qt.Key.Key_Return and self.state() != QAbstractItemView.State.EditingState):
-                self.toggle_current_index()
-                return
+            key = event.key()
+            if gprefs['tag_browser_allow_keyboard_focus']:
+                if key == Qt.Key.Key_Return and self.state() != QAbstractItemView.State.EditingState:
+                    self.toggle_current_index()
+                    return
+                # Check if we are moving the focus and we are at the beginning or the
+                # end of the list. The goal is to prevent moving focus away from the
+                # tag browser.
+                on_node = self.model().get_node(self.currentIndex())
+                if key == Qt.Key.Key_Tab:
+                    if on_node != self._model.root_item.children[-1]:
+                        QTreeView.keyPressEvent(self, event)
+                    return
+                if key == Qt.Key.Key_Backtab:
+                    if on_node != self._model.root_item.children[0]:
+                        QTreeView.keyPressEvent(self, event)
+                    return
             # If this is an edit request, mark the node to request whether to use VLs
             # As far as I can tell, F2 is used across all platforms
-            if event.key() == Qt.Key.Key_F2:
+            if key == Qt.Key.Key_F2:
                 node = self.model().get_node(self.currentIndex())
                 if node.type == TagTreeItem.TAG:
                     # Saved search nodes don't use the VL test/dialog


### PR DESCRIPTION
1) Fix labels being interchanged for two tag browser shortcuts

2) 
Ensure that once the tag browser has the focus, Tab and Backtab don't move the focus to another widget.