### PR TITLE
Fix potential crash in ebook-edit due to type mismatch.

### DIFF
--- a/src/calibre/gui2/tweak_book/editor/insert_resource.py
+++ b/src/calibre/gui2/tweak_book/editor/insert_resource.py
@@ -97,7 +97,7 @@ class ImageDelegate(QStyledItemDelegate):
         f = self.parent().font()
         sz = f.pixelSize()
         if sz < 5:
-            sz = f.pointSize() * self.parent().logicalDpiY() / 72.0
+            sz = f.pointSize() * self.parent().logicalDpiY() // 72
         self.title_height = max(25, sz + 10)
         self.item_size = self.cover_size + QSize(2 * self.MARGIN, (2 * self.MARGIN) + self.title_height)
         self.calculate_spacing()


### PR DESCRIPTION
If the ImageDelegate's font has a pixelSize of less than 5, it will calculate a floating point value, from its pointSize. QSize can only take an int, due to its dispatching to a C++ method.

I've changed some graphics settings recently, but am not sure what change caused ebook-edit to crash. It may make more sense to round() the result, but I used flooring division to keep consistent with the few other calculated QSize arguments, which are simply converted to int (by flooring) if they are not already.