### PR TITLE
Add vision 6 to tolino driver

### DIFF
--- a/src/calibre/devices/eb600/driver.py
+++ b/src/calibre/devices/eb600/driver.py
@@ -58,10 +58,18 @@ class TOLINO(EB600):
     gui_name = 'tolino shine'
     description    = _('Communicate with the tolino shine and vision readers')
     FORMATS = ['epub', 'pdf', 'txt']
-    PRODUCT_ID  = EB600.PRODUCT_ID + [0x6033, 0x6052, 0x6053]
+
+    EPOS_PRODUCT_ID         = [0x6053]
+    VISION6_PRODUCT_ID      = [0x8000]
+    OTHER_TOLINO_PRODUCT_ID = [0x6033, 0x6052]
+    PRODUCT_ID = EB600.PRODUCT_ID + OTHER_TOLINO_PRODUCT_ID + EPOS_PRODUCT_ID + VISION6_PRODUCT_ID
+
+    KOBO_VENDOR_ID = [0x4173]   # Some newer Tolino devices have the Kobo Vendor ID. But, they still use different software.
+    VENDOR_ID   = EB600.VENDOR_ID + KOBO_VENDOR_ID
     BCD         = [0x226, 0x9999]
     VENDOR_NAME      = ['DEUTSCHE', 'LINUX']
     WINDOWS_MAIN_MEM = WINDOWS_CARD_A_MEM = ['_TELEKOMTOLINO', 'FILE-CD_GADGET']
+    EBOOK_DIR_MAIN = ''
 
     EXTRA_CUSTOMIZATION_MESSAGE = [
         _('Swap main and card A') +
@@ -75,6 +83,10 @@ class TOLINO(EB600):
     ]
 
     OPT_SWAP_MEMORY = 0
+
+    def get_device_information(self, end_session=True):
+        self.set_device_name()
+        return super(TOLINO, self).get_device_information(end_session)
 
     # There are apparently two versions of this device, one with swapped
     # drives and one without, see https://bugs.launchpad.net/bugs/1240504
@@ -122,6 +134,21 @@ class TOLINO(EB600):
         if for_upload:
             return getattr(self, 'ebook_dir_for_upload', self.EBOOK_DIR_MAIN)
         return self.EBOOK_DIR_MAIN
+
+    def isEpos(self):
+        return self.detected_device.idProduct in self.EPOS_PRODUCT_ID
+
+    def isVision6(self):
+        return self.detected_device.idProduct in self.VISION6_PRODUCT_ID
+
+    def set_device_name(self):
+        device_name = self.gui_name
+        if self.isEpos():
+            device_name = 'tolino epos'
+        elif self.isVision6():
+            device_name = 'tolino vision 6'
+        self.__class__.gui_name = device_name
+        return device_name
 
 
 class COOL_ER(EB600):


### PR DESCRIPTION
The new device uses Kobo vendor id. Also, show the names for this and the epos.