### PR TITLE
Enhancement: add a tweak to provide the sort value for undefined …

### DIFF
--- a/resources/default_tweaks.py
+++ b/resources/default_tweaks.py
@@ -594,3 +594,16 @@ skip_network_check = False
 # Sets the width of the tab stop in the template editor in "average characters".
 # For example, a value of 1 results in a space with the width of one average character.
 template_editor_tab_stop_width = 4
+
+#: Value for undefined numbers when sorting
+# Sets the value to use for undefined numbers when sorting.
+# For example, the value -10 sorts undefined numbers as if they were set to -10.
+# Use 'maximum' for the largest possible number. Use 'minimum' for the smallest
+# possible number. Quotes are optional if entering a number.
+# Examples:
+#   value_for_undefined_numbers_when_sorting = -100
+#   value_for_undefined_numbers_when_sorting = '2'
+#   value_for_undefined_numbers_when_sorting = -0.01
+#   value_for_undefined_numbers_when_sorting = 'minimum'
+#   value_for_undefined_numbers_when_sorting = 'maximum'
+value_for_undefined_numbers_when_sorting = 0

--- a/src/calibre/db/fields.py
+++ b/src/calibre/db/fields.py
@@ -25,7 +25,7 @@ def bool_sort_key(bools_are_tristate):
     return (lambda x:{True: 1, False: 2, None: 3}.get(x, 3)) if bools_are_tristate else lambda x:{True: 1, False: 2, None: 2}.get(x, 2)
 
 
-def _get_sort_value_for_undefined_numbers():
+def sort_value_for_undefined_numbers():
     t = tweaks['value_for_undefined_numbers_when_sorting']
     try:
         if t == 'minimum':
@@ -38,13 +38,10 @@ def _get_sort_value_for_undefined_numbers():
         return 0
 
 
-sort_value_for_undefined_numbers = _get_sort_value_for_undefined_numbers()
-
-
 def numeric_sort_key(x):
     # It isn't clear whether this function can ever be called with a non-numeric
     # argument, but we check just in case
-    return x if type(x) in (int, float) else sort_value_for_undefined_numbers
+    return x if type(x) in (int, float) else sort_value_for_undefined_numbers()
 
 
 IDENTITY = lambda x: x
@@ -77,7 +74,7 @@ class Field:
         self._default_sort_key = b''
 
         if dt in {'int', 'float', 'rating'}:
-            self._default_sort_key = sort_value_for_undefined_numbers
+            self._default_sort_key = sort_value_for_undefined_numbers()
             self._sort_key = numeric_sort_key
         elif dt == 'bool':
             self._default_sort_key = None
@@ -280,7 +277,7 @@ class CompositeField(OneToOneField):
                 val = val[:(-2 if p > 1 else -1)].strip()
             val = atof(val) * p
         except (TypeError, AttributeError, ValueError, KeyError):
-            val = sort_value_for_undefined_numbers
+            val = sort_value_for_undefined_numbers()
         return val
 
     def date_sort_key(self, val):

--- a/src/calibre/db/fields.py
+++ b/src/calibre/db/fields.py
@@ -25,8 +25,26 @@ def bool_sort_key(bools_are_tristate):
     return (lambda x:{True: 1, False: 2, None: 3}.get(x, 3)) if bools_are_tristate else lambda x:{True: 1, False: 2, None: 2}.get(x, 2)
 
 
+def _get_sort_value_for_undefined_numbers():
+    t = tweaks['value_for_undefined_numbers_when_sorting']
+    try:
+        if t == 'minimum':
+            return float('-inf')
+        if t == 'maximum':
+            return float('inf')
+        return float(t)
+    except:
+        print('***** Bad value in undefined sort number tweak', t)
+        return 0
+
+
+sort_value_for_undefined_numbers = _get_sort_value_for_undefined_numbers()
+
+
 def numeric_sort_key(x):
-    return x or 0
+    # It isn't clear whether this function can ever be called with a non-numeric
+    # argument, but we check just in case
+    return x if type(x) in (int, float) else sort_value_for_undefined_numbers
 
 
 IDENTITY = lambda x: x
@@ -59,7 +77,7 @@ class Field:
         self._default_sort_key = b''
 
         if dt in {'int', 'float', 'rating'}:
-            self._default_sort_key = 0
+            self._default_sort_key = sort_value_for_undefined_numbers
             self._sort_key = numeric_sort_key
         elif dt == 'bool':
             self._default_sort_key = None
@@ -262,7 +280,7 @@ class CompositeField(OneToOneField):
                 val = val[:(-2 if p > 1 else -1)].strip()
             val = atof(val) * p
         except (TypeError, AttributeError, ValueError, KeyError):
-            val = 0.0
+            val = sort_value_for_undefined_numbers
         return val
 
     def date_sort_key(self, val):

--- a/src/calibre/gui2/preferences/tweaks.py
+++ b/src/calibre/gui2/preferences/tweaks.py
@@ -6,13 +6,14 @@
 import textwrap
 from collections import OrderedDict
 from functools import partial
+from math import ceil, floor
 from operator import attrgetter
 
 from qt.core import (
     QAbstractListModel, QApplication, QDialog, QDialogButtonBox, QFont, QGridLayout,
     QGroupBox, QIcon, QLabel, QListView, QMenu, QModelIndex, QPlainTextEdit, QComboBox,
     QPushButton, QSizePolicy, QSplitter, QStyle, QStyledItemDelegate, QAbstractItemView, QItemSelectionModel,
-    QStyleOptionViewItem, Qt, QVBoxLayout, QWidget, pyqtSignal
+    QStyleOptionViewItem, Qt, QVBoxLayout, QWidget, pyqtSignal, QTextDocument
 )
 
 from calibre import isbytestring
@@ -139,6 +140,11 @@ class Tweak:  # {{{
 # }}}
 
 
+# This is the width of the tweaks list view. Add the vertical scrollbar and
+# the margins to it.
+tweaks_list_minimum_width = 280
+
+
 class Tweaks(QAbstractListModel, AdaptSQP):  # {{{
 
     def __init__(self, parent=None):
@@ -156,7 +162,17 @@ class Tweaks(QAbstractListModel, AdaptSQP):  # {{{
         except:
             return None
         if role == Qt.ItemDataRole.DisplayRole:
-            return textwrap.fill(tweak.name, 40)
+            # Compute the display length of the string then word wrap it so it
+            # fits in minimum_width. This seems much harder than it should be.
+            d = QTextDocument()
+            d.setDocumentMargin(0)
+            if tweak.is_customized:
+                d.setHtml('<b>' + tweak.name + '</b')
+            else:
+                d.setHtml(tweak.name)
+            avg_char_width = ceil(d.size().width()/len(tweak.name))
+            num_chars_per_line = int(floor(tweaks_list_minimum_width/avg_char_width))
+            return textwrap.fill(tweak.name, num_chars_per_line)
         if role == Qt.ItemDataRole.FontRole and tweak.is_customized:
             ans = QFont()
             ans.setBold(True)
@@ -374,10 +390,12 @@ class TweaksView(QListView):
         self.setAlternatingRowColors(True)
         self.setSpacing(5)
         self.setVerticalScrollMode(QAbstractItemView.ScrollMode.ScrollPerPixel)
-        # On windows (at least) the automatic scroll bar appearing hides part
-        # of the last line in the list view. Force it always on.
-        self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOn)
-        self.setMinimumWidth(300)
+        # Compute the size of the display area. Tweak strings are wrapped so that
+        # they fit in tweaks_list_minimum_width, so we need to add the size of
+        # the scrollbar and a heuristic for margins
+        min_width = (tweaks_list_minimum_width + 20 +
+                     QApplication.instance().style().pixelMetric(QStyle.PixelMetric.PM_ScrollBarExtent))
+        self.setMinimumWidth(min_width)
 
     def currentChanged(self, cur, prev):
         QListView.currentChanged(self, cur, prev)

--- a/src/calibre/gui2/preferences/tweaks.py
+++ b/src/calibre/gui2/preferences/tweaks.py
@@ -374,6 +374,9 @@ class TweaksView(QListView):
         self.setAlternatingRowColors(True)
         self.setSpacing(5)
         self.setVerticalScrollMode(QAbstractItemView.ScrollMode.ScrollPerPixel)
+        # On windows (at least) the automatic scroll bar appearing hides part
+        # of the last line in the list view. Force it always on.
+        self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOn)
         self.setMinimumWidth(300)
 
     def currentChanged(self, cur, prev):


### PR DESCRIPTION
…numbers.

I couldn't find a case where numeric_sort_key() was called with a non-number but I decided to add the test anyway.

The change to tweaks.py fixes something that has annoyed me for a long time. I don't know if the problem exists on other platforms. If it doesn't then perhaps it could be conditioned with an 'if windows' test.