### PR TITLE
py310 support: explicit cast to int

### DIFF
--- a/src/calibre/gui2/proceed.py
+++ b/src/calibre/gui2/proceed.py
@@ -388,7 +388,7 @@ class ProceedQuestion(QWidget):
 
     def animated_paint(self, painter):
         top = (1 - self._show_fraction) * self.height()
-        painter.drawPixmap(0, top, self.rendered_pixmap)
+        painter.drawPixmap(0, int(top), self.rendered_pixmap)
 
     def paint_background(self, painter):
         br = 12  # border_radius


### PR DESCRIPTION
In the same vein as https://github.com/kovidgoyal/calibre/pull/1461/, need to explicitly cast to int before the value is passed in to Qt to prevent a TypeError with py310.

Addresses https://bugs.launchpad.net/calibre/+bug/1954708