### PR TITLE
Don't exclude slashes when parsing URLs for identifier rules

### DIFF
--- a/src/calibre/gui2/metadata/basic_widgets.py
+++ b/src/calibre/gui2/metadata/basic_widgets.py
@@ -1710,7 +1710,7 @@ class IdentifiersEdit(QLineEdit, ToMetadataMixin):
         rules = msprefs['id_link_rules']
         if rules:
             formatter = EvalFormatter()
-            vals = {'id' : '(?P<new_id>[^/]+)'}
+            vals = {'id' : '(?P<new_id>.+)'}
             for key in rules.keys():
                 rule = rules[key]
                 for name, template in rule:


### PR DESCRIPTION
Not sure why I had excluded the slash as a valid character in the identifier. There are a few sites that do this.