### PR TITLE
close Connection socket after server disconnect

### DIFF
--- a/src/calibre/srv/loop.py
+++ b/src/calibre/srv/loop.py
@@ -328,6 +328,9 @@ class Connection:  # {{{
         self.handle_event = None  # prevent reference cycles
         try:
             self.socket.shutdown(socket.SHUT_WR)
+        except OSError:
+            pass
+        try:
             self.socket.close()
         except OSError:
             pass


### PR DESCRIPTION
This is similar to: https://github.com/redis/redis-py/pull/1797

Currently, calibre/srv/loop.py's `Connection.close()` won't continue to close the socket if it encounters an `OSError` on `socket.shutdown`. An `OSError` can happen on `socket.shutdown` if the other side of the connection disconnected already. Not running `socket.close` prevents garbage collection from cleaning up the socket and will use more memory than necessary (maybe even causing a leak?).

This PR puts a separate try/except around `socket.close` and `socket.shutdown` to allow the socket to be closed after a failed shutdown.