### PR TITLE
Fix python site-package libdir creation in FreeBSD

### DIFF
--- a/setup/install.py
+++ b/setup/install.py
@@ -15,7 +15,7 @@ import time
 
 from setup import (
     Command, __appname__, __version__, basenames, functions,
-    isbsd, ishaiku, islinux, modules
+    isbsd, isfreebsd, ishaiku, islinux, modules
 )
 
 HEADER = '''\
@@ -156,9 +156,12 @@ class Develop(Command):
 
     def install_env_module(self):
         import sysconfig
+        python_ver_prefix = ''
+        if isfreebsd:
+            python_ver_prefix = 'python'
         libdir = os.path.join(
             self.opts.staging_root, sysconfig.get_config_var('PLATLIBDIR') or 'lib',
-            sysconfig.get_python_version(), 'site-packages')
+            python_ver_prefix + sysconfig.get_python_version(), 'site-packages')
         try:
             if not os.path.exists(libdir):
                 os.makedirs(libdir)


### PR DESCRIPTION
Changes in commit 7632beb8e05126fb3fa3a4a9d45c70d92233b40f cause calibre to install files in the wrong path on FreeBSD where site-package path looks like `/usr/local/lib/python3.8/site-packages`.

My patch adds the 'python' prefix there to fix installation only on FreeBSD.