### PR TITLE
Bug #1955732: Hierarchical entries in user category may not merge …

### DIFF
--- a/src/calibre/db/categories.py
+++ b/src/calibre/db/categories.py
@@ -44,7 +44,8 @@ class Tag:
 
     @property
     def string_representation(self):
-        return '%s:%s:%s:%s:%s'%(self.name, self.count, self.id, self.state, self.category)
+        return '%s:%s:%s:%s:%s:%s'%(self.name, self.count, self.id, self.state,
+                                    self.category, self.original_categories)
 
     def __str__(self):
         return self.string_representation
@@ -207,10 +208,11 @@ def get_categories(dbcache, sort='name', book_ids=None, first_letter_sort=False)
     for c in gst:
         if c not in muc:
             continue
-        user_categories[c] = []
+        uc = []
         for sc in gst[c]:
             for t in categories.get(sc, ()):
-                user_categories[c].append([t.name, sc, 0])
+                uc.append([t.name, sc, 0])
+        user_categories[c] = uc
 
     if user_categories:
         # We want to use same node in the user category as in the source


### PR DESCRIPTION
…correctly in tag browser

Note that this fix works with grouped search terms. 'Real' user categories will never be merged because the source category is part of the 'name'