### PR TITLE
media-types: use image/x-xcf rather than application/x-xcf to match gimp.desktop

### DIFF
--- a/resources/mime.types
+++ b/resources/mime.types
@@ -875,7 +875,6 @@ application/x-ustar				ustar
 application/x-wais-source				src
 application/x-wingz				wz
 application/x-x509-ca-cert				crt der
-application/x-xcf				xcf
 application/x-xfig				fig
 application/x-xpinstall				xpi
 application/x400-bp
@@ -1146,6 +1145,7 @@ image/x-portable-graymap				pgm
 image/x-portable-pixmap				ppm
 image/x-rgb				rgb
 image/x-xbitmap				xbm
+image/x-xcf				xcf
 image/x-xpixmap				xpm
 image/x-xwindowdump				xwd
 message/cpim


### PR DESCRIPTION
Current XCF media type is `image/x-xcf` .

See also:
  Re: [Gimp-developer] Mime type application/x-xcf in /etc/mime.types vs image/x-xcf in gimp.desktop
  https://mail.gnome.org/archives/gimp-developer-list/2021-July/msg00001.html
