### PR TITLE
Change db.cache.virtual_libraries_for_books() to raise an exception …

### DIFF
--- a/src/calibre/utils/formatter_functions.py
+++ b/src/calibre/utils/formatter_functions.py
@@ -1756,9 +1756,12 @@ class BuiltinVirtualLibraries(BuiltinFormatterFunction):
 
     def evaluate(self, formatter, kwargs, mi, locals_):
         with suppress(Exception):
-            from calibre.gui2.ui import get_gui
-            a = get_gui().current_db.data.get_virtual_libraries_for_books((mi.id,))
-            return ', '.join(a[mi.id])
+            try:
+                from calibre.gui2.ui import get_gui
+                a = get_gui().current_db.data.get_virtual_libraries_for_books((mi.id,))
+                return ', '.join(a[mi.id])
+            except ValueError as v:
+                return str(v)
         return _('This function can be used only in the GUI')
 
 


### PR DESCRIPTION
…when recursion is detected instead of returning an empty list. Using an exception gives a better chance of telling the user that the VL expression is wrong.