### PR TITLE
Create custom column dialog: Fix exception if the library has no …

### DIFF
--- a/src/calibre/gui2/preferences/columns.py
+++ b/src/calibre/gui2/preferences/columns.py
@@ -28,7 +28,9 @@ class ConfigWidget(ConfigWidgetBase, Ui_Form):
         self.custcols = copy.deepcopy(db.field_metadata.custom_field_metadata())
         for k, cc in self.custcols.items():
             cc['original_key'] = k
-        self.initial_created_count = max(x['colnum'] for x in self.custcols.values()) + 1
+        # Using max() in this way requires python 3.4+
+        self.initial_created_count = max((x['colnum'] for x in self.custcols.values()),
+                                         default=0) + 1
         self.created_count = self.initial_created_count
 
         self.column_up.clicked.connect(self.up_column)

--- a/src/calibre/gui2/preferences/create_custom_column.py
+++ b/src/calibre/gui2/preferences/create_custom_column.py
@@ -787,7 +787,8 @@ class CreateNewCustomColumn(object):
         self.custcols = copy.deepcopy(db.field_metadata.custom_field_metadata())
         # Get the largest internal column number so we can be sure that we can
         # detect duplicates.
-        self.created_count = max(x['colnum'] for x in self.custcols.values()) + 1
+        self.created_count = max((x['colnum'] for x in self.custcols.values()),
+                                         default=0) + 1
 
     def create_column(self, lookup_name, column_heading, datatype, is_multiple,
                       display={}, generate_unused_lookup_name=False, freeze_lookup_name=True):


### PR DESCRIPTION
…custom columns.

Note that the fix works only with python 3.4+. If that is a problem I can do an alternate fix.