### PR TITLE
Reduce image compression in equestria_daily recipe

### DIFF
--- a/recipes/equestria_daily.recipe
+++ b/recipes/equestria_daily.recipe
@@ -17,6 +17,7 @@ class AdvancedUserRecipe1639926896(BasicNewsRecipe):
     max_articles_per_feed = 30
 
     compress_news_images = True
+    compress_news_images_auto_size = 4
     no_stylesheets = True
     keep_only_tags = [{'name': 'div', 'class_': ['post', 'hentry']}]
     remove_tags = [{'name': 'div', 'class_': 'post-footer'}]


### PR DESCRIPTION
The website https://www.equestriadaily.com/ often uses images in its articles, and from what I have seen the images get compressed so much that text is basically unreadable on them.
This fix mitigates this issue by reducing the compression factor from 16 to 4, which slightly increases the size of the newspaper but makes it more enjoyable and readable.