### PR TITLE
Remove duplicated section "news" from tutorials

### DIFF
--- a/manual/tutorials.rst
+++ b/manual/tutorials.rst
@@ -8,7 +8,6 @@ Here you will find tutorials to get you started using calibre's more advanced fe
 .. toctree::
    :maxdepth: 1
 
-   news
    sub_groups
    xpath
    template_lang


### PR DESCRIPTION
Remove the "Adding your favorite news website to calibre" section from the tutorials as it's already present in the main index.

**Note:** this is my first contribution to calibre, this looks all right to me but I'm not knowledgeable about the build process of the manual and the consequences of this change on it.