### PR TITLE
Improve build support for NetBSD

### DIFF
--- a/setup/build.py
+++ b/setup/build.py
@@ -7,7 +7,7 @@ __docformat__ = 'restructuredtext en'
 import textwrap, os, shlex, subprocess, glob, shutil, sys, json, errno, sysconfig
 from collections import namedtuple
 
-from setup import Command, islinux, isbsd, isfreebsd, ismacos, ishaiku, SRC, iswindows
+from setup import Command, islinux, isbsd, isfreebsd, ismacos, ishaiku, SRC, iswindows, isnetbsd
 isunix = islinux or ismacos or isbsd or ishaiku
 
 py_lib = os.path.join(sys.prefix, 'libs', 'python%d%d.lib' % sys.version_info[:2])
@@ -115,7 +115,7 @@ def is_ext_allowed(ext):
     only = ext.get('only', '')
     if only:
         only = set(only.split())
-        q = set(filter(lambda x: globals()["is" + x], ["bsd", "freebsd", "haiku", "linux", "macos", "windows"]))
+        q = set(filter(lambda x: globals()["is" + x], ["bsd", "freebsd", "netbsd", "haiku", "linux", "macos", "windows"]))
         return len(q.intersection(only)) > 0
     return True
 
@@ -136,6 +136,8 @@ def parse_extension(ext):
             ans = ext.pop('bsd_' + k, ans)
         elif isfreebsd:
             ans = ext.pop('freebsd_' + k, ans)
+        elif isnetbsd:
+            ans = ext.pop('netbsd_' + k, ans)
         elif ishaiku:
             ans = ext.pop('haiku_' + k, ans)
         else:

--- a/setup/extensions.json
+++ b/setup/extensions.json
@@ -198,7 +198,7 @@
     },
     {
         "name": "libusb",
-        "only": "macos linux haiku",
+        "only": "macos linux netbsd haiku",
         "sources": "calibre/devices/libusb/libusb.c",
         "libraries": "usb-1.0"
     },
@@ -210,7 +210,7 @@
     },
     {
         "name": "libmtp",
-        "only": "freebsd macos linux haiku",
+        "only": "freebsd netbsd macos linux haiku",
         "sources": "calibre/devices/mtp/unix/devices.c calibre/devices/mtp/unix/libmtp.c",
         "headers": "calibre/devices/mtp/unix/devices.h calibre/devices/mtp/unix/upstream/music-players.h calibre/devices/mtp/unix/upstream/device-flags.h",
         "libraries": "mtp"

--- a/src/calibre/constants.py
+++ b/src/calibre/constants.py
@@ -255,7 +255,7 @@ class ExtensionsImporter:
             extra = ('winutil', 'wpd', 'winfonts', 'winsapi')
         elif ismacos:
             extra = ('usbobserver', 'cocoa', 'libusb', 'libmtp')
-        elif isfreebsd or ishaiku or islinux:
+        elif isfreebsd or isnetbsd or ishaiku or islinux:
             extra = ('libusb', 'libmtp')
         else:
             extra = ()


### PR DESCRIPTION
by adding it to some conditionals.

Hi! Here is a small improvement for building Calibre on NetBSD. It is far from complete but it's a small step. In [pkgsrc](https://github.com/NetBSD/pkgsrc/tree/trunk/misc/calibre) I have created more patches, but not all of them may be appropriate to upstream.

In particular I'm trying to find out why libusb isn't properly scanning usb devices, so if you're open to it, I can possibly supply more patches in the future.