### PR TITLE
Fix 308 error that started appearing today

### DIFF
--- a/recipes/respekt_magazine.recipe
+++ b/recipes/respekt_magazine.recipe
@@ -12,14 +12,13 @@ from calibre.ebooks.BeautifulSoup import BeautifulSoup
 # This imports the version bundled with Calibre
 import lxml
 from lxml.builder import E
-respekt_url = 'http://www.respekt.cz'
-
+respekt_url = 'https://www.respekt.cz'
 
 class respektRecipe(BasicNewsRecipe):
     __author__  = 'Tomáš Hnyk'
     publisher = u'Respekt Publishing a. s.'
     description = u'Articles from the print edition'
-    title = u'Respekt Magazine – Print'
+    title = u'Respekt Magazine — Print'
     encoding = 'utf-8'
     language = 'cs'
     delay = 0.001
@@ -74,10 +73,10 @@ class respektRecipe(BasicNewsRecipe):
         return raw_html
 
     def parse_index(self):
-        raw1 = self.index_to_soup('http://www.respekt.cz/tydenik/', raw=True)
+        raw1 = self.index_to_soup('https://www.respekt.cz/tydenik/', raw=True)
         root1 = lxml.html.fromstring(raw1)
         current_edition_url = root1.xpath("//div[@class='heroissue']/a")[0].items()[0][1]
-        raw2 = self.index_to_soup('http://www.respekt.cz/' + current_edition_url, raw=True)
+        raw2 = self.index_to_soup('https://www.respekt.cz/' + current_edition_url, raw=True)
         root2 = lxml.html.fromstring(raw2)
         self.cover_url = root2.xpath("//i[contains(@class, 'heroissue-cover')]")[0].get("data-src")
         # Fetch date


### PR DESCRIPTION
I tried to run the recipe today and I would get this error 

```
calibre, version 5.35.0 (linux, embedded-python: True)
Conversion error: Failed: Fetch news from Respekt Magazine – Print

Fetch news from Respekt Magazine – Print
Conversion options changed from defaults:
  verbose: 2
  output_profile: 'kindle'
Resolved conversion options
calibre version: 5.35.0
{'asciiize': False,
 'author_sort': None,
 'authors': None,
 'base_font_size': 0,
 'book_producer': None,
 'change_justification': 'original',
 'chapter': None,
 'chapter_mark': 'pagebreak',
 'comments': None,
 'cover': None,
 'debug_pipeline': None,
 'dehyphenate': True,
 'delete_blank_paragraphs': True,
 'disable_font_rescaling': False,
 'dont_compress': False,
 'dont_download_recipe': False,
 'duplicate_links_in_toc': False,
 'embed_all_fonts': False,
 'embed_font_family': None,
 'enable_heuristics': False,
 'expand_css': False,
 'extra_css': None,
 'extract_to': None,
 'filter_css': None,
 'fix_indents': True,
 'font_size_mapping': None,
 'format_scene_breaks': True,
 'html_unwrap_factor': 0.4,
 'input_encoding': None,
 'input_profile': <calibre.customize.profiles.InputProfile object at 0x7f4f2bcecbb0>,
 'insert_blank_line': False,
 'insert_blank_line_size': 0.5,
 'insert_metadata': False,
 'isbn': None,
 'italicize_common_cases': True,
 'keep_ligatures': False,
 'language': None,
 'level1_toc': None,
 'level2_toc': None,
 'level3_toc': None,
 'line_height': 0,
 'linearize_tables': False,
 'lrf': False,
 'margin_bottom': 5.0,
 'margin_left': 5.0,
 'margin_right': 5.0,
 'margin_top': 5.0,
 'markup_chapter_headings': True,
 'max_toc_links': 50,
 'minimum_line_height': 120.0,
 'mobi_file_type': 'old',
 'mobi_ignore_margins': False,
 'mobi_keep_original_images': False,
 'mobi_toc_at_start': False,
 'no_chapters_in_toc': False,
 'no_inline_navbars': True,
 'no_inline_toc': False,
 'output_profile': <calibre.customize.profiles.KindleOutput object at 0x7f4f2bcfc100>,
 'page_breaks_before': None,
 'personal_doc': '[PDOC]',
 'prefer_author_sort': False,
 'prefer_metadata_cover': False,
 'pretty_print': False,
 'pubdate': None,
 'publisher': None,
 'rating': None,
 'read_metadata_from_opf': None,
 'remove_fake_margins': True,
 'remove_first_image': False,
 'remove_paragraph_spacing': False,
 'remove_paragraph_spacing_indent_size': 1.5,
 'renumber_headings': True,
 'replace_scene_breaks': '',
 'search_replace': None,
 'series': None,
 'series_index': None,
 'share_not_sync': False,
 'smarten_punctuation': False,
 'sr1_replace': '',
 'sr1_search': '',
 'sr2_replace': '',
 'sr2_search': '',
 'sr3_replace': '',
 'sr3_search': '',
 'start_reading_at': None,
 'subset_embedded_fonts': False,
 'tags': None,
 'test': False,
 'timestamp': None,
 'title': None,
 'title_sort': None,
 'toc_filter': None,
 'toc_threshold': 6,
 'toc_title': None,
 'transform_css_rules': None,
 'transform_html_rules': None,
 'unsmarten_punctuation': False,
 'unwrap_lines': True,
 'use_auto_toc': False,
 'verbose': 2}
Failed to initialize plugin: '/home/drew/.config/calibre/plugins/DeDRM.zip'
InputFormatPlugin: Recipe Input running
Downloading recipe urn: builtin:respekt_magazine
Trying to get latest version of recipe: respekt_magazine
Using user agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36
Traceback (most recent call last):
  File "runpy.py", line 194, in _run_module_as_main
  File "runpy.py", line 87, in _run_code
  File "site.py", line 45, in <module>
  File "site.py", line 41, in main
  File "calibre/utils/ipc/worker.py", line 215, in main
  File "calibre/gui2/convert/gui_conversion.py", line 31, in gui_convert_recipe
  File "calibre/gui2/convert/gui_conversion.py", line 25, in gui_convert
  File "calibre/ebooks/conversion/plumber.py", line 1108, in run
  File "calibre/customize/conversion.py", line 242, in __call__
  File "calibre/ebooks/conversion/plugins/recipe_input.py", line 137, in convert
  File "calibre/web/feeds/news.py", line 1056, in download
  File "calibre/web/feeds/news.py", line 1225, in build_index
  File "<string>", line 77, in parse_index
  File "calibre/web/feeds/news.py", line 706, in index_to_soup
  File "mechanize/_mechanize.py", line 241, in open_novisit
  File "mechanize/_mechanize.py", line 313, in _mech_open
mechanize._response.httperror_seek_wrapper: HTTP Error 308: Permanent Redirect
```

changind the urls to https instead of https fixes this.

Otherwise, it is more proper to use a dash and not a hyphen in a name.