### PR TITLE
Fix highlighting to correctly highlight things like =='aa'. Given the…

### DIFF
--- a/src/calibre/gui2/dialogs/template_dialog.py
+++ b/src/calibre/gui2/dialogs/template_dialog.py
@@ -82,7 +82,7 @@ class TemplateHighlighter(QSyntaxHighlighter):
             r"|\b[+-]?[0-9]+(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?\b",
             "number")
 
-        a(r"""(?:[^:]'[^']*'|"[^"]*")""", "string")
+        a(r"""(?<!:)'[^']*'|"[^"]*\"""", "string")
 
         a(r'\(', "lparen")
         a(r'\)', "rparen")


### PR DESCRIPTION
… way highlighting works, this change will break highlighting for statements like
  for a in $tags:'aa' rof.
I think that strings following operators are far more common than strings following the colon in a for statement.