### PR TITLE
Two changes to edit metadata custom columns:

### DIFF
--- a/src/calibre/db/backend.py
+++ b/src/calibre/db/backend.py
@@ -564,6 +564,7 @@ class DB:
         defs['cover_browser_title_template'] = '{title}'
         defs['cover_browser_subtitle_field'] = 'rating'
         defs['styled_columns'] = {}
+        defs['edit_metadata_ignore_display_order'] = False
 
         # Migrate the bool tristate tweak
         defs['bools_are_tristate'] = \

--- a/src/calibre/gui2/custom_column_widgets.py
+++ b/src/calibre/gui2/custom_column_widgets.py
@@ -507,7 +507,7 @@ class Text(Base):
                 w.set_space_before_sep(True)
                 w.set_add_separator(tweaks['authors_completer_append_separator'])
             w.get_editor_button().clicked.connect(self.edit)
-            w.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Preferred)
+            w.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
             self.set_to_undefined = w.clear
         else:
             w = EditWithComplete(parent)
@@ -787,7 +787,7 @@ def populate_metadata_page(layout, db, book_id, bulk=False, two_column=False, pa
     fm = db.field_metadata
 
     # Get list of all non-composite custom fields. We must make widgets for these
-    cols = [k[0] for k in get_field_list(db) if k[1]]
+    cols = [k[0] for k in get_field_list(db, use_defaults=db.prefs['edit_metadata_ignore_display_order']) if k[1]]
     # This deals with the historical behavior where comments fields go to the
     # bottom, starting on the left hand side. If a comment field is moved to
     # somewhere else then it isn't moved to either side.

--- a/src/calibre/gui2/preferences/look_feel.py
+++ b/src/calibre/gui2/preferences/look_feel.py
@@ -538,6 +538,7 @@ class ConfigWidget(ConfigWidgetBase, Ui_Form):
         r('edit_metadata_single_layout', gprefs,
           choices=[(_('Default'), 'default'), (_('Compact Metadata'), 'alt1'),
                    (_('All on 1 tab'), 'alt2')])
+        r('edit_metadata_ignore_display_order', db.prefs)
 
         self.current_font = self.initial_font = None
         self.change_font_button.clicked.connect(self.change_font)

--- a/src/calibre/gui2/preferences/look_feel.ui
+++ b/src/calibre/gui2/preferences/look_feel.ui
@@ -994,6 +994,19 @@ A value of zero means calculate automatically.</string>
          </layout>
         </widget>
        </item>
+       <item row="8" column="0">
+        <widget class="QCheckBox" name="opt_edit_metadata_ignore_display_order">
+         <property name="text">
+          <string>Show all columns in default order when editing metadata</string>
+         </property>
+         <property name="toolTip">
+          <string>&lt;p&gt;Check this box to make the edit metadata dialogs ignore the
+above specifications, showing all the columns in the default order. This is
+useful for temporarily seeing all your columns in the dialogs without losing
+the display and order specifications.&lt;/p&gt;</string>
+         </property>
+        </widget>
+       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="tag_browser_tab">


### PR DESCRIPTION
1) Ensure the height of a widget doesn't grow in two column mode.
2) Add an option to ignore the column selection and order specifications.
See the tooltip for the option for the justification.