### PR TITLE
Migrate the remaining edit metadata tweaks to gprefs.

### DIFF
--- a/resources/default_tweaks.py
+++ b/resources/default_tweaks.py
@@ -428,26 +428,6 @@ vertical_scrolling_per_row = False
 # Example: locale_for_sorting = 'nb' -- sort using Norwegian rules.
 locale_for_sorting =  ''
 
-#: Number of columns for custom metadata in the edit metadata dialog
-# Set whether to use one or two columns for custom metadata when editing
-# metadata  one book at a time. If True, then the fields are laid out using two
-# columns. If False, one column is used.
-metadata_single_use_2_cols_for_custom_fields = True
-
-#: Edit metadata custom column label width and elision point
-# Set the width of custom column labels shown in the edit metadata dialogs.
-# If metadata_edit_elide_labels is True then labels wider than the width
-# will be elided, otherwise they will be word wrapped. The maximum width is
-# computed by multiplying the average width of characters in the font by the
-# appropriate number.
-# Set the elision point to 'middle' to put the ellipsis (…) in the middle of
-# the label, 'right' to put it at the right end of the label, and 'left' to
-# put it at the left end.
-metadata_edit_elide_labels = True
-metadata_edit_bulk_cc_label_length = 25
-metadata_edit_single_cc_label_length = 12
-metadata_edit_elision_point = 'right'
-
 #: The number of seconds to wait before sending emails
 # The number of seconds to wait before sending emails when using a
 # public email server like GMX/Hotmail/Gmail. Default is: 5 minutes

--- a/src/calibre/gui2/__init__.py
+++ b/src/calibre/gui2/__init__.py
@@ -31,6 +31,7 @@ from calibre.gui2.linux_file_dialogs import (
 )
 from calibre.gui2.qt_file_dialogs import FileDialog
 from calibre.ptempfile import base_dir
+from calibre.utils.config_base import tweaks
 from calibre.utils.config import Config, ConfigProxy, JSONConfig, dynamic
 from calibre.utils.date import UNDEFINED_DATE
 from calibre.utils.file_type_icons import EXT_MAP
@@ -204,6 +205,28 @@ def create_defs():
     defs['browse_annots_use_stemmer'] = True
     defs['annots_export_format'] = 'txt'
     defs['books_autoscroll_time'] = 2.0
+    defs['edit_metadata_single_use_2_cols_for_custom_fields'] = True
+    defs['edit_metadata_elide_labels'] = True
+    defs['edit_metadata_elision_point'] = "right"
+    defs['edit_metadata_bulk_cc_label_length'] = 25
+    defs['edit_metadata_single_cc_label_length'] = 12
+
+    def migrate_tweak(tweak_name, pref_name):
+        # If the tweak has been changed then leave the tweak in the file so
+        # that the user can bounce between versions with and without the
+        # migration. For versions before the migration the tweak wins. For
+        # versions after the migration any changes win.
+        v = tweaks.get(tweak_name, None)
+        migrated_tweak_name = pref_name + '_tweak_migrated'
+        m = gprefs.get(migrated_tweak_name, None)
+        if m is None and v is not None:
+            gprefs[pref_name] = v
+            gprefs[migrated_tweak_name] = True
+    migrate_tweak('metadata_edit_elide_labels', 'edit_metadata_elide_labels')
+    migrate_tweak('metadata_edit_elision_point', 'edit_metadata_elision_point')
+    migrate_tweak('metadata_edit_bulk_cc_label_length', 'edit_metadata_bulk_cc_label_length')
+    migrate_tweak('metadata_edit_single_cc_label_length', 'edit_metadata_single_cc_label_length')
+    migrate_tweak('metadata_single_use_2_cols_for_custom_fields', 'edit_metadata_single_use_2_cols_for_custom_fields')
 
 
 create_defs()

--- a/src/calibre/gui2/custom_column_widgets.py
+++ b/src/calibre/gui2/custom_column_widgets.py
@@ -17,7 +17,7 @@ from qt.core import (Qt, QComboBox, QLabel, QSpinBox, QDoubleSpinBox,
 from calibre.utils.date import qt_to_dt, now, as_local_time, as_utc, internal_iso_format_string
 from calibre.gui2.complete2 import EditWithComplete as EWC
 from calibre.gui2.comments_editor import Editor as CommentsEditor
-from calibre.gui2 import UNDEFINED_QDATETIME, error_dialog, elided_text
+from calibre.gui2 import UNDEFINED_QDATETIME, error_dialog, elided_text, gprefs
 from calibre.gui2.dialogs.tag_editor import TagEditor
 from calibre.utils.config import tweaks
 from calibre.utils.icu import sort_key
@@ -809,8 +809,8 @@ def populate_metadata_page(layout, db, book_id, bulk=False, two_column=False, pa
     ans = []
     column = row = base_row = max_row = 0
     label_width = 0
-    do_elision = tweaks['metadata_edit_elide_labels']
-    elide_pos = tweaks['metadata_edit_elision_point']
+    do_elision = gprefs['edit_metadata_elide_labels']
+    elide_pos = gprefs['edit_metadata_elision_point']
     elide_pos = elide_pos if elide_pos in {'left', 'middle', 'right'} else 'right'
     # make room on the right side for the scrollbar
     sb_width = QApplication.instance().style().pixelMetric(QStyle.PixelMetric.PM_ScrollBarExtent)
@@ -857,10 +857,10 @@ def populate_metadata_page(layout, db, book_id, bulk=False, two_column=False, pa
                     colon_width = font_metrics.width(':')
                     if bulk:
                         label_width = (font_metrics.averageCharWidth() *
-                               tweaks['metadata_edit_bulk_cc_label_length']) - colon_width
+                               gprefs['edit_metadata_bulk_cc_label_length']) - colon_width
                     else:
                         label_width = (font_metrics.averageCharWidth() *
-                               tweaks['metadata_edit_single_cc_label_length']) - colon_width
+                               gprefs['edit_metadata_single_cc_label_length']) - colon_width
                 wij.setMaximumWidth(label_width)
                 if c == 0:
                     wij.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred)

--- a/src/calibre/gui2/metadata/single.py
+++ b/src/calibre/gui2/metadata/single.py
@@ -56,7 +56,6 @@ class MetadataSingleDialogBase(QDialog):
 
     view_format = pyqtSignal(object, object)
     edit_format = pyqtSignal(object, object)
-    cc_two_column = tweaks['metadata_single_use_2_cols_for_custom_fields']
     one_line_comments_toolbar = False
     use_toolbutton_for_config_metadata = True
 
@@ -309,13 +308,16 @@ class MetadataSingleDialogBase(QDialog):
             gprefs['paste_isbn_prefixes'] = list(filter(None, (x.strip() for x in prefixes.splitlines()))) or gprefs.defaults['paste_isbn_prefixes']
             self.update_paste_identifiers_menu()
 
+    def use_two_columns_for_custom_metadata(self):
+        raise NotImplementedError
+
     def create_custom_metadata_widgets(self):  # {{{
         self.custom_metadata_widgets_parent = w = QWidget(self)
         layout = QGridLayout()
         w.setLayout(layout)
         self.custom_metadata_widgets, self.__cc_spacers = \
             populate_metadata_page(layout, self.db, None, parent=w, bulk=False,
-                two_column=self.cc_two_column)
+                two_column=self.use_two_columns_for_custom_metadata())
         self.__custom_col_layouts = [layout]
         for widget in self.custom_metadata_widgets:
             widget.connect_data_changed(self.data_changed)
@@ -745,6 +747,9 @@ class Splitter(QSplitter):
 
 class MetadataSingleDialog(MetadataSingleDialogBase):  # {{{
 
+    def use_two_columns_for_custom_metadata(self):
+        return gprefs['edit_metadata_single_use_2_cols_for_custom_fields']
+
     def do_layout(self):
         if len(self.db.custom_column_label_map) == 0:
             self.central_widget.tabBar().setVisible(False)
@@ -896,14 +901,15 @@ class DragTrackingWidget(QWidget):  # {{{
 
 class MetadataSingleDialogAlt1(MetadataSingleDialogBase):  # {{{
 
-    cc_two_column = False
     one_line_comments_toolbar = True
     use_toolbutton_for_config_metadata = False
-
     on_drag_enter = pyqtSignal()
 
     def handle_drag_enter(self):
         self.central_widget.setCurrentIndex(1)
+
+    def use_two_columns_for_custom_metadata(self):
+        return False
 
     def do_layout(self):
         self.central_widget.clear()
@@ -1051,9 +1057,11 @@ class MetadataSingleDialogAlt1(MetadataSingleDialogBase):  # {{{
 
 class MetadataSingleDialogAlt2(MetadataSingleDialogBase):  # {{{
 
-    cc_two_column = False
     one_line_comments_toolbar = True
     use_toolbutton_for_config_metadata = False
+
+    def use_two_columns_for_custom_metadata(self):
+        return False
 
     def do_layout(self):
         self.central_widget.clear()

--- a/src/calibre/gui2/preferences/look_feel.py
+++ b/src/calibre/gui2/preferences/look_feel.py
@@ -539,6 +539,13 @@ class ConfigWidget(ConfigWidgetBase, Ui_Form):
           choices=[(_('Default'), 'default'), (_('Compact Metadata'), 'alt1'),
                    (_('All on 1 tab'), 'alt2')])
         r('edit_metadata_ignore_display_order', db.prefs)
+        r('edit_metadata_elision_point', gprefs,
+          choices=[(_('Left'), 'left'), (_('Middle'), 'middle'),
+                   (_('Right'), 'right')])
+        r('edit_metadata_elide_labels', gprefs)
+        r('edit_metadata_single_use_2_cols_for_custom_fields', gprefs)
+        r('edit_metadata_bulk_cc_label_length', gprefs)
+        r('edit_metadata_single_cc_label_length', gprefs)
 
         self.current_font = self.initial_font = None
         self.change_font_button.clicked.connect(self.change_font)

--- a/src/calibre/gui2/preferences/look_feel.ui
+++ b/src/calibre/gui2/preferences/look_feel.ui
@@ -908,10 +908,10 @@ A value of zero means calculate automatically.</string>
       <attribute name="title">
        <string>Edit &amp;metadata</string>
       </attribute>
-      <layout class="QGridLayout" name="gridLayout_61">
-       <item row="1" column="0">
-        <layout class="QHBoxLayout" name="horizontalLayout1">
-         <item>
+      <layout class="QVBoxLayout" name="vbox_layout_61">
+       <item>
+        <layout class="QFormLayout">
+         <item row="0" column="0">
           <widget class="QLabel" name="edit_metadata_single_label">
            <property name="text">
             <string>Edit metadata (single) &amp;layout:</string>
@@ -921,29 +921,16 @@ A value of zero means calculate automatically.</string>
            </property>
           </widget>
          </item>
-         <item>
+         <item row="0" column="1">
           <widget class="QComboBox" name="opt_edit_metadata_single_layout">
            <property name="toolTip">
             <string>Choose a different layout for the Edit metadata dialog. The compact metadata layout favors editing custom metadata over changing covers and formats.</string>
            </property>
           </widget>
          </item>
-         <item>
-          <spacer name="verticalSpacer_5">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>40</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
         </layout>
        </item>
-       <item row="6" column="0">
+       <item>
         <widget class="QGroupBox" name="groupBox">
          <property name="title">
           <string>Select the custom columns (for this library) to display in the edit metadata dialogs and their order</string>
@@ -994,18 +981,103 @@ A value of zero means calculate automatically.</string>
          </layout>
         </widget>
        </item>
-       <item row="8" column="0">
-        <widget class="QCheckBox" name="opt_edit_metadata_ignore_display_order">
-         <property name="text">
-          <string>Show all columns in default order when editing metadata</string>
-         </property>
-         <property name="toolTip">
-          <string>&lt;p&gt;Check this box to make the edit metadata dialogs ignore the
+       <item>
+        <layout class="QHBoxLayout">
+         <item>
+          <layout class="QFormLayout">
+           <item row="0" column="0" colspan="2">
+            <widget class="QCheckBox" name="opt_edit_metadata_ignore_display_order">
+             <property name="text">
+              <string>Show all columns in default order when editing metadata</string>
+             </property>
+             <property name="toolTip">
+              <string>&lt;p&gt;Check this box to make the edit metadata dialogs ignore the
 above specifications, showing all the columns in the default order. This is
 useful for temporarily seeing all your columns in the dialogs without losing
 the display and order specifications.&lt;/p&gt;</string>
-         </property>
-        </widget>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0" colspan="2">
+            <widget class="QCheckBox" name="opt_edit_metadata_elide_labels">
+             <property name="text">
+              <string>Elide labels when editing custom columns</string>
+             </property>
+             <property name="toolTip">
+              <string>If checked then labels wider than the label width
+will be elided, otherwise they will be word wrapped.</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="label_102">
+             <property name="text">
+              <string>Elision point</string>
+               </property>
+             <property name="buddy">
+              <cstring>opt_edit_metadata_elision_point</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QComboBox" name="opt_edit_metadata_elision_point">
+             <property name="toolTip">
+              <string>Choose where in the label to put the ...</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <layout class="QFormLayout">
+           <item row="0" column="0" colspan="2">
+            <widget class="QCheckBox" name="opt_edit_metadata_single_use_2_cols_for_custom_fields">
+             <property name="text">
+              <string>Use two columns for custom columns in the Default layout</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="label_102">
+             <property name="text">
+              <string>Bulk edit custom column label length</string>
+             </property>
+             <property name="buddy">
+              <cstring>opt_edit_metadata_bulk_cc_label_length</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QSpinBox" name="opt_edit_metadata_bulk_cc_label_length">
+             <property name="toolTip">
+              <string>The maximum width of a custom column label in bulk metadata
+edit. It is computed by multiplying the average width of characters
+in the font by this number.</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="label_1022">
+             <property name="text">
+              <string>Single edit Custom column label length</string>
+             </property>
+             <property name="buddy">
+              <cstring>opt_edit_metadata_single_cc_label_length</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QSpinBox" name="opt_edit_metadata_single_cc_label_length">
+             <property name="toolTip">
+              <string>The maximum width of a custom column label in single
+metadata edit. It is computed by multiplying the average width of characters
+in the font by this number.</string>
+             </property>
+           </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
        </item>
       </layout>
      </widget>


### PR DESCRIPTION
They are:
- 2 column mode in the default single edit
- The 4 tweaks for eliding custom column labels