### PR TITLE
Add ability to turn off completion in the EditWIthComplete widget via…

### DIFF
--- a/src/calibre/gui2/dialogs/metadata_bulk.py
+++ b/src/calibre/gui2/dialogs/metadata_bulk.py
@@ -492,6 +492,14 @@ class MetadataBulkDialog(QDialog, Ui_MetadataBulkDialog):
     def __init__(self, window, rows, model, tab, refresh_books):
         QDialog.__init__(self, window)
         self.setupUi(self)
+
+        self.publisher.set_disable_completion_pref('EMB_PublisherEdit')
+        self.tags.set_disable_completion_pref('EMB_TagsEdit')
+        self.remove_tags.set_disable_completion_pref('EMB_RemoveTagsEdit')
+        self.series.set_disable_completion_pref('EMB_SeriesEdit')
+        self.authors.set_disable_completion_pref('EMB_AuthorsEdit')
+        self.languages.set_disable_completion_pref('EMB_LanguagesEdit')
+
         self.model = model
         self.db = model.db
         self.refresh_book_list.setChecked(gprefs['refresh_book_list_on_bulk_edit'])

--- a/src/calibre/gui2/languages.py
+++ b/src/calibre/gui2/languages.py
@@ -15,10 +15,11 @@ from polyglot.builtins import iteritems, itervalues
 
 class LanguagesEdit(EditWithComplete):
 
-    def __init__(self, parent=None, db=None, prefs=None):
+    def __init__(self, parent=None, db=None, prefs=None, disable_completion_pref=None):
         self.prefs = prefs or gui_prefs()
         self.refresh_recently_used()
-        EditWithComplete.__init__(self, parent, sort_func=self.sort_language_items_key)
+        EditWithComplete.__init__(self, parent,sort_func=self.sort_language_items_key,
+                                  disable_completion_pref=disable_completion_pref)
 
         self.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToMinimumContentsLengthWithIcon)
         self.setMinimumContentsLength(20)

--- a/src/calibre/gui2/metadata/basic_widgets.py
+++ b/src/calibre/gui2/metadata/basic_widgets.py
@@ -349,7 +349,7 @@ class AuthorsEdit(EditWithComplete, ToMetadataMixin):
     def __init__(self, parent, manage_authors):
         self.dialog = parent
         self.books_to_refresh = set()
-        EditWithComplete.__init__(self, parent)
+        EditWithComplete.__init__(self, parent, disable_completion_pref='EMS_AuthorsEdit')
         self.set_clear_button_enabled(False)
         self.setToolTip(self.TOOLTIP)
         self.setWhatsThis(self.TOOLTIP)
@@ -611,7 +611,7 @@ class SeriesEdit(EditWithComplete, ToMetadataMixin):
     data_changed = pyqtSignal()
 
     def __init__(self, parent):
-        EditWithComplete.__init__(self, parent)
+        EditWithComplete.__init__(self, parent, disable_completion_pref='EMS_SeriesEdit')
         self.set_clear_button_enabled(False)
         self.set_separator(None)
         self.dialog = parent
@@ -1399,7 +1399,7 @@ class TagsEdit(EditWithComplete, ToMetadataMixin):  # {{{
     tag_editor_requested = pyqtSignal()
 
     def __init__(self, parent):
-        EditWithComplete.__init__(self, parent)
+        EditWithComplete.__init__(self, parent, disable_completion_pref='EMS_TagsEdit')
         self.set_clear_button_enabled(False)
         self.set_elide_mode(Qt.TextElideMode.ElideMiddle)
         self.currentTextChanged.connect(self.data_changed)
@@ -1484,7 +1484,7 @@ class LanguagesEdit(LE, ToMetadataMixin):  # {{{
     data_changed = pyqtSignal()
 
     def __init__(self, *args, **kwargs):
-        LE.__init__(self, *args, **kwargs)
+        LE.__init__(self, *args, disable_completion_pref='EMS_LanguagesEdit', **kwargs)
         self.set_clear_button_enabled(False)
         self.textChanged.connect(self.data_changed)
         self.setToolTip(self.TOOLTIP)
@@ -1805,7 +1805,7 @@ class PublisherEdit(EditWithComplete, ToMetadataMixin):  # {{{
     data_changed = pyqtSignal()
 
     def __init__(self, parent):
-        EditWithComplete.__init__(self, parent)
+        EditWithComplete.__init__(self, parent, disable_completion_pref='EMS_PublisherEdit')
         self.set_clear_button_enabled(False)
         self.currentTextChanged.connect(self.data_changed)
         self.set_separator(None)

--- a/src/calibre/gui2/widgets.py
+++ b/src/calibre/gui2/widgets.py
@@ -486,11 +486,14 @@ class LineEditECM:  # {{{
         menu.addMenu(case_menu)
         return case_menu
 
-    def contextMenuEvent(self, event):
+    def build_context_menu(self):
         menu = self.createStandardContextMenu()
         menu.addSeparator()
         self.create_change_case_menu(menu)
-        menu.exec(event.globalPos())
+        return menu
+
+    def contextMenuEvent(self, event):
+        self.build_context_menu().exec(event.globalPos())
 
     def upper_case(self):
         from calibre.utils.icu import upper
@@ -635,6 +638,9 @@ class EnComboBox(QComboBox):  # {{{
         self.setLineEdit(EnLineEdit(self))
         self.completer().setCaseSensitivity(Qt.CaseSensitivity.CaseInsensitive)
         self.setMinimumContentsLength(20)
+
+    def build_context_menu(self):
+        return self.lineEdit().build_context_menu()
 
     def text(self):
         return str(self.currentText())


### PR DESCRIPTION
… a context menu item. Use that ability in edit metadata single & bulk.

In the end I thought it would be easier for you to evaluate this stuff if you could see it.