### PR TITLE
Allows you to default to exclude some file types when adding books

### DIFF
--- a/resources/default_tweaks.py
+++ b/resources/default_tweaks.py
@@ -585,3 +585,10 @@ template_editor_tab_stop_width = 4
 #   value_for_undefined_numbers_when_sorting = 'minimum'
 #   value_for_undefined_numbers_when_sorting = 'maximum'
 value_for_undefined_numbers_when_sorting = 0
+
+#: File Specs to exclude by default when adding a new book
+# Allows you to exclude certain file formats from the default selection
+# of the Add Book dialog
+#  Example:
+# file_specs_to_exclude_by_default_when_adding_a_new_book = ['rar', 'zip' ]
+file_specs_to_exclude_by_default_when_adding_a_new_book = []

--- a/src/calibre/gui2/actions/add.py
+++ b/src/calibre/gui2/actions/add.py
@@ -30,7 +30,7 @@ from polyglot.builtins import iteritems, string_or_bytes
 
 
 def get_filters():
-    return [
+    filters = [
             (_('Books'), BOOK_EXTENSIONS),
             (_('EPUB books'), ['epub', 'kepub']),
             (_('Kindle books'), ['mobi', 'prc', 'azw', 'azw3', 'kfx', 'tpz', 'azw1', 'azw4']),
@@ -42,6 +42,14 @@ def get_filters():
             (_('Archives'), ['zip', 'rar']),
             (_('Wordprocessor files'), ['odt', 'doc', 'docx']),
     ]
+
+    excludeByDefault = tweaks['file_specs_to_exclude_by_default_when_adding_a_new_book']
+    
+    if len(excludeByDefault) != 0:
+        myBooks = [x for x in BOOK_EXTENSIONS if x not in excludeByDefault]
+        filters.insert(0,  (_('My Books'), myBooks))
+
+    return filters;
 
 
 class AddAction(InterfaceAction):


### PR DESCRIPTION
Added tweak that allows you to exclude some file types from the default select file dialog when adding books.

Motivation

Several times I have accidently added a zip file using the "Add books from single folder" rather than the "Add multiple books from Archive". So I would like the option to exclude archives by default, to make this mistake hard for me to make again

If this tweak is not set, everything should behave as normal.
If this tweak is set, then it adds another entry to the Select Books file dialog.