### PR TITLE
The calibre editor "Check" complains when rules are empty, saying …

### DIFF
--- a/src/calibre/ebooks/oeb/transforms/jacket.py
+++ b/src/calibre/ebooks/oeb/transforms/jacket.py
@@ -287,6 +287,7 @@ def render_jacket(mi, output_profile,
 
     template = re.sub(r'<!--.*?-->', '', template, flags=re.DOTALL)
     css = re.sub(r'/\*.*?\*/', '', css, flags=re.DOTALL)
+    css = re.sub(r'table.cbj_header [^:}].*?}', '', css, flags=re.DOTALL)
 
     try:
         title_str = alt_title if mi.is_null('title') else mi.title


### PR DESCRIPTION
…"Rules without any properties specified should be removed". Using Polish to make a jacket can produce these empty rules. This PR removes rules in the jacket css that have no properties (don't contain any colons).

There may be a better way to do this than using a regular expression.