### PR TITLE
Remove some repeated links to other articles

### DIFF
--- a/recipes/economist.recipe
+++ b/recipes/economist.recipe
@@ -161,6 +161,11 @@ class Economist(BasicNewsRecipe):
     keep_only_tags = [dict(name='article', id=lambda x: not x)]
     no_stylesheets = True
     remove_attributes = ['data-reactid', 'width', 'height']
+    preprocess_regexps = [
+        (re.compile(r'<span data-ornament="ufinish">■</span></p>.*</body>', re.DOTALL|re.IGNORECASE),
+        lambda match: '<span data-ornament="ufinish">■</span></p></body>'
+        )
+    ]
     # economist.com has started throttling after about 60% of the total has
     # downloaded with connection reset by peer (104) errors.
     delay = 1

--- a/recipes/economist_free.recipe
+++ b/recipes/economist_free.recipe
@@ -161,6 +161,11 @@ class Economist(BasicNewsRecipe):
     keep_only_tags = [dict(name='article', id=lambda x: not x)]
     no_stylesheets = True
     remove_attributes = ['data-reactid', 'width', 'height']
+    preprocess_regexps = [
+        (re.compile(r'<span data-ornament="ufinish">■</span></p>.*</body>', re.DOTALL|re.IGNORECASE),
+        lambda match: '<span data-ornament="ufinish">■</span></p></body>'
+        )
+    ]
     # economist.com has started throttling after about 60% of the total has
     # downloaded with connection reset by peer (104) errors.
     delay = 1


### PR DESCRIPTION
On the web, under some articles, there are links to other articles or sections. These links are not present in the print edition, are repetetive and annoying. For example, soething like this: "For exclusive insight and reading recommendations from our correspondents in America, sign up to Checks and Balance, our weekly newsletter."

This commit removes them, as the ■ symbol marks end of the article.

The only downside is that applying the ■ symbol is not consistent - some articles do not end by it. One could target specific texts to remove as they are repetetive (like the one quoted above that appears under articles in the US sections).