### PR TITLE
Set per issue title

### DIFF
--- a/recipes/economist.recipe
+++ b/recipes/economist.recipe
@@ -249,6 +249,7 @@ class Economist(BasicNewsRecipe):
             self.timefmt = ' [' + edition_date + ']'
         else:
             url = 'https://www.economist.com/printedition'
+        self.title = self.title + " from " + self.browser.open(url).geturl().split("/")[-1]
         raw = self.index_to_soup(url, raw=True)
         # with open('/t/raw.html', 'wb') as f:
         #     f.write(raw)

--- a/recipes/economist_free.recipe
+++ b/recipes/economist_free.recipe
@@ -249,6 +249,7 @@ class Economist(BasicNewsRecipe):
             self.timefmt = ' [' + edition_date + ']'
         else:
             url = 'https://www.economist.com/printedition'
+        self.title = self.title + " from " + self.browser.open(url).geturl().split("/")[-1]
         raw = self.index_to_soup(url, raw=True)
         # with open('/t/raw.html', 'wb') as f:
         #     f.write(raw)


### PR DESCRIPTION
This modifies the title of the downloaded e-book for the economist with the date. It is useful for telling appart different issues in calibre, in the filesystem (the filename is taken from the titile) and it also makes life easier for some e-readers, like this:
https://www.mobileread.com/forums/showthread.php?t=346484

I am sure, python-wise, this can be more elegant but this seems to work. The title of the downloaded magazine is then "The Economist from 2022-05-14" or something like that.