### PR TITLE
Fix recipe for nature.com

### DIFF
--- a/recipes/nature.recipe
+++ b/recipes/nature.recipe
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from collections import defaultdict
-from calibre.web.feeds.news import BasicNewsRecipe
+from calibre.web.feeds.news import BasicNewsRecipe, classes
 
 BASE = 'https://www.nature.com'
 
@@ -39,11 +39,15 @@ class Nature(BasicNewsRecipe):
     no_javascript = True
     no_stylesheets = True
 
-    keep_only_tags = [
-        dict(name='div', attrs={'data-component': check_words('article-container')})
-    ]
+    keep_only_tags = [dict(name="article")]
 
-    remove_tags = [dict(attrs={'class': check_words('hide-print')})]
+    remove_tags = [
+        classes(
+            "u-hide-print hide-print c-latest-content__item c-context-bar "
+            "c-pdf-button__container u-js-hide"
+        ),
+        dict(name="img", attrs={"class": ["visually-hidden"]}),
+    ]
 
     def parse_index(self):
         soup = self.index_to_soup(BASE + '/nature/current-issue')
@@ -51,17 +55,15 @@ class Nature(BasicNewsRecipe):
             'img', attrs={'data-test': check_words('issue-cover-image')}
         )['src']
         try:
-            self.cover_url = self.cover_url.replace("w200","w500")  # enlarge cover size resolution
+            self.cover_url = self.cover_url.replace("w200", "w500")  # enlarge cover size resolution
         except:
             """
             failed, img src might have changed, use default width 200
             """
             pass
-        section_tags = soup.find(
-            'div', {'data-container-type': check_words('issue-section-list')}
-        )
-        section_tags = section_tags.findAll(
-            'div', {'class': check_words('article-section')}
+
+        section_tags = soup.find_all(
+            "section", attrs={"data-container-type": "issue-section-list"}
         )
 
         sections = defaultdict(list)


### PR DESCRIPTION
The recipe was returning the error below. Also improved the article extraction with changes to `keep_only_tags`/`remove_tags`.

```
Traceback (most recent call last):
  File "runpy.py", line 194, in _run_module_as_main
  File "runpy.py", line 87, in _run_code
  File "site.py", line 39, in <module>
  File "site.py", line 35, in main
  File "calibre/ebooks/conversion/cli.py", line 419, in main
  File "calibre/ebooks/conversion/plumber.py", line 1108, in run
  File "calibre/customize/conversion.py", line 242, in __call__
  File "calibre/ebooks/conversion/plugins/recipe_input.py", line 137, in convert
  File "calibre/web/feeds/news.py", line 1056, in download
  File "calibre/web/feeds/news.py", line 1225, in build_index
  File "<string>", line 68, in parse_index
AttributeError: 'NoneType' object has no attribute 'findAll'
```
