### PR TITLE
Fix a potential wrong operator bug

### DIFF
--- a/src/calibre/gui2/tweak_book/reports.py
+++ b/src/calibre/gui2/tweak_book/reports.py
@@ -954,7 +954,7 @@ class CSSRulesModel(QAbstractItemModel):
         if not index.isValid():
             return ROOT
         parent = index.internalPointer()
-        if parent is self.rules or parent is None:
+        if parent in self.rules or parent is None:
             return ROOT
         try:
             pidx, grand_parent = self.parent_map[parent]


### PR DESCRIPTION
Hi,

This pull request is a fix to a potential wrong operator bug at `src/calibre/gui2/tweak_book/reports.py`. Please check the changes.

`self.rules` seems a tuple so using `in` would be more reasonable.

Best,
Jingxuan