### PR TITLE
Update fonts MIME following IANA recommendation

### DIFF
--- a/resources/mime.types
+++ b/resources/mime.types
@@ -1378,10 +1378,11 @@ application/x-cbc                          cbc
 application/x-koboreader-ebook             kobo
 image/wmf                                  wmf
 application/ereader                        pdb
-# See http://idpf.org/epub/30/spec/epub30-publications.html#sec-core-media-types
-application/vnd.ms-opentype                otf
-application/font-woff                      woff
-application/x-font-truetype                ttf
+# See https://www.w3.org/publishing/epub3/epub-spec.html#sec-core-media-types
+font/otf                                   otf
+font/woff                                  woff
+font/woff2                                 woff2
+font/ttf                                   ttf
 text/xml                                   plist
 text/x-markdown                            md markdown
 application/x-ibooks+zip                   ibook ibooks

--- a/src/calibre/ebooks/oeb/polish/container.py
+++ b/src/calibre/ebooks/oeb/polish/container.py
@@ -54,7 +54,8 @@ from polyglot.urllib import urlparse
 
 exists, join, relpath = os.path.exists, os.path.join, os.path.relpath
 
-OEB_FONTS = {guess_type('a.ttf'), guess_type('b.otf'), guess_type('a.woff'), 'application/x-font-ttf', 'application/x-font-otf', 'application/font-sfnt'}
+OEB_FONTS = {guess_type('a.ttf'), guess_type('b.otf'), guess_type('a.woff'),
+             guess_type('.woff2'), 'application/font-woff', 'application/font-sfnt', 'application/vnd.ms-opentype'}
 OPF_NAMESPACES = {'opf':OPF2_NS, 'dc':DC11_NS}
 null = object()
 
@@ -146,14 +147,6 @@ class ContainerBase:  # {{{
         ans = guess_type(name)
         if ans == 'text/html':
             ans = 'application/xhtml+xml'
-        if ans in {'application/x-font-truetype', 'application/vnd.ms-opentype'}:
-            opfversion = self.opf_version_parsed[:2]
-            if opfversion > (3, 0):
-                return 'application/font-sfnt'
-            if opfversion >= (3, 0):
-                # bloody epubcheck has recently decided it likes this mimetype
-                # for ttf files
-                return 'application/vnd.ms-opentype'
         return ans
 
     def decode(self, data, normalize_to_nfc=True):


### PR DESCRIPTION
Hello.

MIME types for fonts are outdated.

According to https://www.iana.org/assignments/media-types/media-types.xhtml#font, MIME for ttf, otf and woff fonts should be respectively **font/ttf**, **font/otf**, **font/woff**.

These MIME are supported by EPUB 3 (https://www.w3.org/publishing/epub3/epub-spec.html#sec-core-media-types)

This PR changes MIME types accordingly.