### PR TITLE
Use proper date in recipes

### DIFF
--- a/recipes/economist.recipe
+++ b/recipes/economist.recipe
@@ -270,7 +270,8 @@ class Economist(BasicNewsRecipe):
     def publication_date(self):
         if edition_date:
             return parse_only_date(edition_date, as_utc=False)
-        return BasicNewsRecipe.publication_date(self)
+        url = self.browser.open("https://www.economist.com/printedition").geturl()
+        return parse_only_date(url.split("/")[-1], as_utc=False)
 
     def parse_index(self):
         # return [('Articles', [{'title':'test',

--- a/recipes/economist_free.recipe
+++ b/recipes/economist_free.recipe
@@ -270,7 +270,8 @@ class Economist(BasicNewsRecipe):
     def publication_date(self):
         if edition_date:
             return parse_only_date(edition_date, as_utc=False)
-        return BasicNewsRecipe.publication_date(self)
+        url = self.browser.open("https://www.economist.com/printedition").geturl()
+        return parse_only_date(url.split("/")[-1], as_utc=False)
 
     def parse_index(self):
         # return [('Articles', [{'title':'test',

--- a/src/calibre/web/feeds/news.py
+++ b/src/calibre/web/feeds/news.py
@@ -1462,7 +1462,7 @@ class BasicNewsRecipe(Recipe):
             dir = self.output_dir
         title = self.short_title()
         if self.output_profile.periodical_date_in_title:
-            title += strftime(self.timefmt)
+            title += strftime(self.timefmt,self.publication_date())
         mi = MetaInformation(title, [__appname__])
         mi.publisher = __appname__
         mi.author_sort = __appname__


### PR DESCRIPTION
As discussed here: https://github.com/kovidgoyal/calibre/pull/1642#issuecomment-1127100400, this makes the title in a recipe use the date when a given publication was issued (if set by a recipe) instead of current time. As a proof of concept, this is implemented for the Economist recipe.