### PR TITLE
Use proper date in recipes

### DIFF
--- a/src/calibre/web/feeds/news.py
+++ b/src/calibre/web/feeds/news.py
@@ -1462,7 +1462,7 @@ class BasicNewsRecipe(Recipe):
             dir = self.output_dir
         title = self.short_title()
         if self.output_profile.periodical_date_in_title:
-            title += strftime(self.timefmt)
+            title += strftime(self.timefmt,self.publication_date())
         mi = MetaInformation(title, [__appname__])
         mi.publisher = __appname__
         mi.author_sort = __appname__


### PR DESCRIPTION
As discussed here: #1642 (comment), this makes the title in a recipe use the date when a given publication was issued (if set by a recipe) instead of current time.