### PR TITLE
Update New Statesman RSS feed URL

### DIFF
--- a/recipes/new_statesman.recipe
+++ b/recipes/new_statesman.recipe
@@ -40,4 +40,4 @@ class NewStatesman(BasicNewsRecipe):
         'language': language
     }
 
-    feeds = [(u'Articles', u'https://www.newstatesman.com/feeds/site_feed.rss')]
+    feeds = [(u'Articles', u'https://www.newstatesman.com/feed')]


### PR DESCRIPTION
Updates the URL for the New Statesman RSS feed found at https://www.newstatesman.com/rss-feed