### PR TITLE
One difference: using the new run_test() I see all the debug output …

### DIFF
--- a/src/calibre/utils/formatter.py
+++ b/src/calibre/utils/formatter.py
@@ -13,7 +13,7 @@ from functools import partial
 from math import modf
 
 from calibre import prints
-from calibre.constants import DEBUG
+from calibre.constants import is_debugging
 from calibre.ebooks.metadata.book.base import field_metadata
 from calibre.utils.formatter_functions import formatter_functions
 from calibre.utils.icu import strcmp
@@ -1390,7 +1390,7 @@ class _Interpreter:
         except (ValueError, ExecutionBase, StopException) as e:
             raise e
         except Exception as e:
-            if (DEBUG):
+            if is_debugging():
                 traceback.print_exc()
             self.error(_("Internal error evaluating an expression: '{0}'").format(str(e)),
                        prog.line_number)
@@ -1451,7 +1451,7 @@ class TemplateFormatter(string.Formatter):
                 return fmt, '', ''
             return matches.groups()
         except:
-            if DEBUG:
+            if is_debugging():
                 traceback.print_exc()
             return fmt, '', ''
 
@@ -1697,7 +1697,7 @@ class TemplateFormatter(string.Formatter):
             except StopException as e:
                 ans = error_message(e)
             except Exception as e:
-                if DEBUG:  # and getattr(e, 'is_locking_error', False):
+                if is_debugging():  # and getattr(e, 'is_locking_error', False):
                     traceback.print_exc()
                     if column_name:
                         prints('Error evaluating column named:', column_name)

--- a/src/calibre/utils/run_tests.py
+++ b/src/calibre/utils/run_tests.py
@@ -306,6 +306,9 @@ def run_test(test_name, verbosity=4):
     tests = filter_tests_by_name(tests, test_name)
     if not tests._tests:
         raise SystemExit(f'No test named {test_name} found')
+    # Turn off DEBUG to stop random printing and exception traces
+    from calibre.constants import debug
+    debug(False)
     run_cli(tests, verbosity, buffer=False)
 
 


### PR DESCRIPTION
…where before I didn't, for example exception stack traces in the formatter. Not a big deal, but it does make reading the output more difficult with the extraneous traces. This push fixes that.

NB: I just discovered the hard way that when I do a
    from calibre.constants import DEBUG
I don't see changes to DEBUG caused by calls to calibre.constants.debug(False). Instead I must
    from calibre.constants import is_debugging()
and use that. 