### PR TITLE
opf2.py's OPF.guess_cover doesn't return the path

### DIFF
--- a/src/calibre/ebooks/metadata/opf2.py
+++ b/src/calibre/ebooks/metadata/opf2.py
@@ -1174,8 +1174,8 @@ class OPF:  # {{{
                 if item.text:
                     prefix = item.text.replace('-', '')
                     for suffix in ['.jpg', '.jpeg', '.gif', '.png', '.bmp']:
-                        cpath = os.access(os.path.join(self.base_dir, prefix+suffix), os.R_OK)
-                        if os.access(os.path.join(self.base_dir, prefix+suffix), os.R_OK):
+                        cpath = os.path.join(self.base_dir, prefix + suffix)
+                        if os.access(cpath, os.R_OK):
                             return cpath
 
     @property


### PR DESCRIPTION
While trying to investigate a bottleneck with calibredb I noticed that the same file was being accessed twice:

```
13:44:07 access("/opt/calibre-book-box/B07BZBWSKN.jpg", R_OK) = -1 ENOENT (No such file or directory)
13:44:07 access("/opt/calibre-book-box/B07BZBWSKN.jpg", R_OK) = -1 ENOENT (No such file or directory)
```

It seems a bug in guess_cover was causing it to return os.access(path) instead of just the path.