### PR TITLE
opf2.py's OPF tries to guess even when not given a basedir 

### DIFF
--- a/src/calibre/ebooks/metadata/opf2.py
+++ b/src/calibre/ebooks/metadata/opf2.py
@@ -587,8 +587,12 @@ class OPF:  # {{{
     author_link_map = MetadataField('author_link_map', is_dc=False,
                                 formatter=json.loads, renderer=dump_dict)
 
-    def __init__(self, stream, basedir=os.getcwd(), unquote_urls=True,
-            populate_spine=True, try_to_guess_cover=True, preparsed_opf=None, read_toc=True):
+    def __init__(self, stream, basedir=None, unquote_urls=True,
+            populate_spine=True, try_to_guess_cover=None, preparsed_opf=None, read_toc=True):
+        if try_to_guess_cover is None:
+            try_to_guess_cover = basedir is not None
+        if basedir is None:
+            basedir = os.getcwd()
         self.try_to_guess_cover = try_to_guess_cover
         self.basedir  = self.base_dir = basedir
         self.path_to_html_toc = self.html_toc_fragment = None


### PR DESCRIPTION
I noticed my strace was constantly being filled with output like the following:

```
13:44:07 access("/opt/calibre-book-box/B07BZBWSKN.jpg", R_OK) = -1 ENOENT (No such file or directory)
13:44:07 access("/opt/calibre-book-box/B07BZBWSKN.jpg", R_OK) = -1 ENOENT (No such file or directory)
13:44:07 access("/opt/calibre-book-box/B07BZBWSKN.jpeg", R_OK) = -1 ENOENT (No such file or directory)
13:44:07 access("/opt/calibre-book-box/B07BZBWSKN.jpeg", R_OK) = -1 ENOENT (No such file or directory)
13:44:07 access("/opt/calibre-book-box/B07BZBWSKN.gif", R_OK) = -1 ENOENT (No such file or directory)
13:44:07 access("/opt/calibre-book-box/B07BZBWSKN.gif", R_OK) = -1 ENOENT (No such file or directory)
13:44:07 access("/opt/calibre-book-box/B07BZBWSKN.png", R_OK) = -1 ENOENT (No such file or directory)
13:44:07 access("/opt/calibre-book-box/B07BZBWSKN.png", R_OK) = -1 ENOENT (No such file or directory)
13:44:07 access("/opt/calibre-book-box/B07BZBWSKN.bmp", R_OK) = -1 ENOENT (No such file or directory)
13:44:07 access("/opt/calibre-book-box/B07BZBWSKN.bmp", R_OK) = -1 ENOENT (No such file or directory)
```

where `/opt/calibre-book-box` is my current working directory. 

This doesn't seem intentional, as it doesn't make sense to guess around inside basedir when it's not provided?

(The doubling is an unrelated bug, see #1678 )