### PR TITLE
Assume shared-mime-info 1.8

### DIFF
--- a/resources/calibre-mimetypes.xml
+++ b/resources/calibre-mimetypes.xml
@@ -4,10 +4,6 @@
         <comment>SONY E-book compiled format</comment>
         <glob pattern="*.lrf"/>
     </mime-type>
-    <mime-type type="application/epub+zip">
-        <comment>EPUB ebook format</comment>
-        <glob pattern="*.epub"/>
-    </mime-type>
     <mime-type type="text/lrs">
         <comment>SONY E-book source format</comment>
         <glob pattern="*.lrs"/>


### PR DESCRIPTION
Assume the required version of shared-mime-info is 1.8, which seems to
be a good low-enough baseline according to:
https://repology.org/metapackage/shared-mime-info/versions
(e.g. CentOS 7, Debian 9)

This makes it possible to drop the definition of `application/epub+zip`,
provided by newer versions of shared-mime-info (and with more details
than this removed definition).