### PR TITLE
Fix leaving bits of the background selection sometimes visible when e…

### DIFF
--- a/src/calibre/gui2/dialogs/edit_authors_dialog.py
+++ b/src/calibre/gui2/dialogs/edit_authors_dialog.py
@@ -55,11 +55,9 @@ class EditColumnDelegate(QItemDelegate):
                 editor = EditWithComplete(parent)
                 editor.set_separator(None)
                 editor.update_items_cache(self.completion_data)
-            else:
-                from calibre.gui2.widgets import EnLineEdit
-                editor = EnLineEdit(parent)
-            return editor
-        return QItemDelegate.createEditor(self, parent, option, index)
+                return editor
+        from calibre.gui2.widgets import EnLineEdit
+        return EnLineEdit(parent)
 
 
 class EditAuthorsDialog(QDialog, Ui_EditAuthorsDialog):


### PR DESCRIPTION
…diting sort and link columns. This change makes the editor widget fill the underlying cell.

As an aside, shouldn't EnLineEdit do setClearButtonEnabled(True) to be like other widgets? If no, then perhaps I should add it in this delegate. The EditWithComplete widgets in the authors column have it.