### PR TITLE
Pass variable args to back compat method exec_()

### DIFF
--- a/src/calibre/gui2/pyqt6_compat.py
+++ b/src/calibre/gui2/pyqt6_compat.py
@@ -33,8 +33,8 @@ QHoverEvent.posF = lambda self: self.position()
 
 # Restore the removed exec_ method
 
-def exec_(self):
-    return self.exec()
+def exec_(self, *args, **kwargs):
+    return self.exec(*args, **kwargs)
 
 
 QDialog.exec_ = exec_


### PR DESCRIPTION
My EpubSplit plugin uses `menu.exec_(self.mapToGlobal(event.pos()))` which starting throwing:
```
TypeError: exec_() takes 1 positional argument but 2 were given
```

 `pyqt6_compat.py` restored `exec_()` (thanks for that) but not with arguments.  This change allows for arguments.