### PR TITLE
FIx typos

### DIFF
--- a/manual/gui.rst
+++ b/manual/gui.rst
@@ -421,7 +421,7 @@ A `search expression` is a sequence of `search terms` optionally separated by th
   * ``not tag:foo`` finds all books that don't contain the tag ``foo``
   * ``not (author:Asimov or author:Weber)`` finds all books not written by either Asimov or Weber.
 
-The above examples show examples of `search terms`. A basic `search term` is a sequence of characters not including spaces, quotes (``"``), backslashes (``\``), or parentheses (``( )``). It can be optionally preceeded by a column name specifier: the `lookup name` of a column followed by a colon (``:``), for example ``author:Asimov``. If a search term must contain a space then the entire term must be enclosed in quotes, as in ``title:"The Ring"``. If the search term must contain quotes then they must be `escaped` with backslashes. For example, to search for a series named `The "Ball" and The "Chain"`, use::
+The above examples show examples of `search terms`. A basic `search term` is a sequence of characters not including spaces, quotes (``"``), backslashes (``\``), or parentheses (``( )``). It can be optionally preceded by a column name specifier: the `lookup name` of a column followed by a colon (``:``), for example ``author:Asimov``. If a search term must contain a space then the entire term must be enclosed in quotes, as in ``title:"The Ring"``. If the search term must contain quotes then they must be `escaped` with backslashes. For example, to search for a series named `The "Ball" and The "Chain"`, use::
 
   series:"The \"Ball\" and The \"Chain\"
 

--- a/src/calibre/constants.py
+++ b/src/calibre/constants.py
@@ -481,7 +481,7 @@ def get_umask():
     return mask
 
 
-# call this at startup as it changed process global state, which doesnt work
+# call this at startup as it changed process global state, which doesn't work
 # with multi-threading. It's absurd there is no way to safely read the current
 # umask of a process.
 get_umask()

--- a/src/calibre/db/tests/fts_api.py
+++ b/src/calibre/db/tests/fts_api.py
@@ -102,7 +102,7 @@ class FTSAPITest(BaseTest):
         fts = cache.enable_fts()
         self.wait_for_fts_to_finish(fts)
         check(id=1, book=1, format='TXTZ', searchable_text='a test text')
-        # check changing the format but not the text doesnt cause a rescan
+        # check changing the format but not the text doesn't cause a rescan
         cache.add_format(1, 'TXTZ', self.make_txtz(b'a test text', extra='xxx'))
         self.wait_for_fts_to_finish(fts)
         check(id=1, book=1, format='TXTZ', searchable_text='a test text')

--- a/src/calibre/devices/mtp/unix/upstream/music-players.h
+++ b/src/calibre/devices/mtp/unix/upstream/music-players.h
@@ -662,7 +662,7 @@
 
   /*
    * SanDisk
-   * several devices (c150 for sure) are definately dual-mode and must
+   * several devices (c150 for sure) are definitely dual-mode and must
    * have the USB mass storage driver that hooks them unloaded first.
    * They all have problematic dual-mode making the device unload effect
    * uncertain on these devices.
@@ -2504,7 +2504,7 @@
   /*
    * Motorola Xoom (Wingray) variants
    *
-   * These devices seem to use these product IDs simulatenously
+   * These devices seem to use these product IDs simultaneously
    * https://code.google.com/p/android-source-browsing/source/browse/init.stingray.usb.rc?repo=device--moto--wingray
    *
    * 0x70a3 - Factory test - reported as early MTP ID
@@ -3311,7 +3311,7 @@
 #if 1
   /* after some review I commented it back in. There was apparently
    * only one or two devices misbehaving (having this ID in mass storage mode),
-   * but more seem to use it regulary as MTP devices. Marcus 20150401 */
+   * but more seem to use it regularly as MTP devices. Marcus 20150401 */
   /*
    * This had to be commented out - the same VID+PID is used also for
    * other modes than MTP, so we need to let mtp-probe do its job on this
@@ -3406,7 +3406,7 @@
 #if 1
   /* after some review I commented it back in. There was apparently
    * only one or two devices misbehaving (having this ID in mass storage mode),
-   * but more seem to use it regulary as MTP devices. Marcus 20150401 */
+   * but more seem to use it regularly as MTP devices. Marcus 20150401 */
   /*
    * This had to be commented out - the same VID+PID is used also for
    * other modes than MTP, so we need to let mtp-probe do its job on this
@@ -3848,7 +3848,7 @@
       DEVICE_FLAGS_ANDROID_BUGS },
 
   /* In update 4 the order of devices was changed for
-     better OS X / Windows suport and another device-id
+     better OS X / Windows support and another device-id
      got assigned for the MTP */
   { "Jolla", 0x2931, "Sailfish (ID2)", 0x0a05,
       DEVICE_FLAGS_ANDROID_BUGS },

--- a/src/calibre/devices/smart_device_app/driver.py
+++ b/src/calibre/devices/smart_device_app/driver.py
@@ -318,7 +318,7 @@ class SMART_DEVICE_APP(DeviceConfig, DevicePlugin):
         _('Use this IP address') + ':::<p>' +
         _('Use this option if you want to force the driver to listen on a '
               'particular IP address. The driver will listen only on the '
-              'entered address, and this address will be the one advertized '
+              'entered address, and this address will be the one advertised '
               'over mDNS (BonJour).') + '</p>',
         _('Replace books with same calibre ID') + ':::<p>' +
         _('Use this option to overwrite a book on the device if that book '

--- a/src/calibre/ebooks/rtf2xml/add_brackets.py
+++ b/src/calibre/ebooks/rtf2xml/add_brackets.py
@@ -132,7 +132,7 @@ class AddBrackets:
     def __after_control_word_func(self, line):
         """
         After a cw either add next allowed cw to temporary list or
-        change groupe and write it.
+        change group and write it.
         If the token leading to an exit is an open bracket go to
         ignore otherwise goto in body
         """

--- a/src/calibre/ebooks/rtf2xml/sections.py
+++ b/src/calibre/ebooks/rtf2xml/sections.py
@@ -41,7 +41,7 @@ class Sections:
     should be nested inside one section tag. After the index is complete, a new
     section should begin.
     In order to write the sections outside of the field blocks, I have to store
-    all of the field block as a string. When I ecounter the \\sect tag, add one to
+    all of the field block as a string. When I encounter the \\sect tag, add one to
     the section counter, but store this number in a list. Likewise, store the
     information describing the section in another list.
     When I reach the end of the field block, choose the first item from the

--- a/src/calibre/gui2/dialogs/smartdevice.ui
+++ b/src/calibre/gui2/dialogs/smartdevice.ui
@@ -51,7 +51,7 @@
    <item row="1" column="1">
     <widget class="QLabel" name="ip_addresses">
      <property name="text">
-      <string>Possibe IP addresses:</string>
+      <string>Possible IP addresses:</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>

--- a/src/css_selectors/parser.py
+++ b/src/css_selectors/parser.py
@@ -73,7 +73,7 @@ class Selector:
         #: +-------------------------+----------------+--------------------------------+
         #: | Invalid pseudo-class    | ``li:marker``  | ``None``                       |
         #: +-------------------------+----------------+--------------------------------+
-        #: | Functinal               | ``a::foo(2)``  | ``FunctionalPseudoElement(…)`` |
+        #: | Functional              | ``a::foo(2)``  | ``FunctionalPseudoElement(…)`` |
         #: +-------------------------+----------------+--------------------------------+
         #:
         # : .. _Lists3: http://www.w3.org/TR/2011/WD-css3-lists-20110524/#marker-pseudoelement

--- a/src/pyj/read_book/cfi.pyj
+++ b/src/pyj/read_book/cfi.pyj
@@ -650,7 +650,7 @@ def decoded_range_to_document_position(decoded):
     # character, which would be in the inline direction.
     #  Unless the flag is set to use the end of the range:
     #  (because ranges indices may not exceed the range,
-    #   but CFI offets are allowed to be one past the end.)
+    #   but CFI offsets are allowed to be one past the end.)
     if decoded.use_range_end_pos:
         inline_vs_pos = scroll_viewport.rect_inline_end(rect)
     else:

--- a/src/pyj/read_book/paged_mode.pyj
+++ b/src/pyj/read_book/paged_mode.pyj
@@ -515,7 +515,7 @@ def jump_to_anchor(name):
 
 def scrollable_element(elem):
     # bounding rect calculation for an inline element containing a block
-    # element that spans multiple columns is incorrect. Detet the common case
+    # element that spans multiple columns is incorrect. Detect the common case
     # of this and avoid it. See https://bugs.launchpad.net/calibre/+bug/1918437
     # for a test case.
     if not in_paged_mode() or window.getComputedStyle(elem).display.indexOf('inline') < 0 or not elem.firstElementChild:


### PR DESCRIPTION
Found via `codespell -q 3 -S./Changelog.*,./resources/dictionaries  -L alo,ans,pard,ro`