### PR TITLE
Fix leftover typos

### DIFF
--- a/format_docs/pdb/ereader.txt
+++ b/format_docs/pdb/ereader.txt
@@ -10,7 +10,7 @@ than Dropbook. Dropbook is a GUI application that only runs on Windows and
 Apple’s OS X.
 
 
-PDB Identiy
+PDB Identity
 -------
 
 PNRdPPrs
@@ -29,7 +29,7 @@ Record 0, eReader header (202)
 ------------------
 
 Note all values are in 2 byte increments. Like values are condensed into a
-range. The range can be borken into 2 byte sections which represent the actual
+range. The range can be broken into 2 byte sections which represent the actual
 stored values.
 
 bytes       content             comments
@@ -48,7 +48,7 @@ bytes       content             comments
 114-116     Garbage
 116-202     Unknown
 
-* Garbage: Intentially random values.
+* Garbage: Intentionally random values.
 
 
 Text Records (202)
@@ -98,7 +98,7 @@ bytes   content                     comments
                                     contained in the file
 20-22   Number of images            The number of images contained in the file
 22-24   Number of links             The number of links contained in the file
-24-26   Metadata avaliable          Is there a metadata record in the file?
+24-26   Metadata available          Is there a metadata record in the file?
                                     0 = None, 1 = There is a metadata record
 26-28   Unknown                     Value of 0 is used
 28-30   Number of Footnotes         The number of footnote records in the file
@@ -286,7 +286,7 @@ E.G.
 
 Gibraltar Earth\x00Michael McCollum\x001999\x00Sci Fi Arizona\x001929381255\x00
 
-The metdata record is always followed by a record which contains 'MeTaInFo\x00'
+The metadata record is always followed by a record which contains 'MeTaInFo\x00'
 
 Note: Starting with DropBook 1.5.2 'MeTaInFo\x00' is not following Metadata
 Record. It is a separate record that ends the file and there are some more

--- a/format_docs/pdb/mbp.txt
+++ b/format_docs/pdb/mbp.txt
@@ -1,10 +1,10 @@
-// BEGINING OF FILE
+// BEGINNING OF FILE
 //   NOTES:
 //   1* Numeric data stored as big endian, 32 bits.
 //   2* Data padded to 16 bits limits. (Sometimes to 32 bits limits?)
 //   3* Text stored seems to be an 8 bit encoding padded to 16 bits
 //    (may be "ISO-8859-1"?, or may be just a local machine character set?)
-//   4* I initially used the term "MARK" where I should have used "HIGHLIGTH", 
+//   4* I initially used the term "MARK" where I should have used "HIGHLIGHT", 
 //     bear that in mind (it was a bad name election when I started reversing)
 
 <0x 31 bytes = book_title_PAR + 0x00 PAD if (book_title_PAR < 31) >
@@ -31,7 +31,7 @@ MOBI
 // Order of Indexes: from the beginning of this MBP file, 
 // forward to the end of the file.
 // Nevertheless, see these comments for order relative to: 
-//   "BEGINING OF USER DATA": order of Data marks.
+//   "BEGINNING OF USER DATA": order of Data marks.
 //   "FINAL GROUP OF MARKS": order of final marks.
 [for each {NOTE,MARK,CORRECTION,DRAWING,BOOKMARK,
 		AUTHOR,TITLE,CATEGORY,GENRE,ABSTRACT,COVER,PUBLISHER,
@@ -95,10 +95,10 @@ BPAR
 <0x FF FF FF FF>
 [fi]
 
-// BEGINING OF USER DATA:
+// BEGINNING OF USER DATA:
 // Order of {NOTE,MARK,CORRECTION,DRAWING} : 
 // starts with user data at the end of the file, 
-// going backwards to the begining of the file:
+// going backwards to the beginning of the file:
 //--------------------------------------------------------------------
 [for each {NOTE,MARK,CORRECTION,DRAWING}]
 //-------------------------------
@@ -193,7 +193,7 @@ DATA
 DATA
 <0x 4 bytes = size of raw data>
 ADQM
-	// NOTE: bakground color is stored in corresponding BKMK.
+	// NOTE: background color is stored in corresponding BKMK.
 	[begin DRAWING format]
 		...4 = <0x 00 00 00 01> ???
 		<0x 4 bytes = X POSITION OF UPPER LEFT CORNER??? > 
@@ -339,7 +339,7 @@ PUBL
 
 // FINAL GROUP OF MARKS
 // Order of {NOTE,MARK,CORRECTION} : 
-// starts with user data at the begining of the file, 
+// starts with user data at the beginning of the file, 
 // going forwards to the end:
 //--------------------------------------------------------------------
 [for each {NOTE,MARK,CORRECTION,DRAWING,BOOKMARK}]

--- a/format_docs/pdb/mobi.txt
+++ b/format_docs/pdb/mobi.txt
@@ -145,7 +145,7 @@ The following records are only present if the mobi header is long enough.
 174     4       DRM Size                Number of bytes in DRM info.
 176     4       DRM Flags               Some flags concerning the DRM info.
 180     6       ?
-186     2       Last Image record       Possible vaule with the last image
+186     2       Last Image record       Possible value with the last image
                                         record. If there are no images in the
                                         book this will be 0xffff.
 188     4       ?

--- a/format_docs/pdb/pdb_format.txt
+++ b/format_docs/pdb/pdb_format.txt
@@ -1,10 +1,10 @@
 Format
 ------
 
-A PDB file can be borken into multiple parts. The header, record 0 and data.
+A PDB file can be broken into multiple parts. The header, record 0 and data.
 values stored within the various parts are big-endian byte order. The data
 part is is broken down into multiple sections. The section count and offsets
-are referened in the PDB header. Sections can be no more than 65505 bytes in
+are referenced in the PDB header. Sections can be no more than 65505 bytes in
 length.
 
 
@@ -17,7 +17,7 @@ contained format specific iformation followed by data.
     DB Header
 0   Record 0
 .
-.   Data (borken down into sections)
+.   Data (broken down into sections)
 .
 
 

--- a/format_docs/pdb/pml.txt
+++ b/format_docs/pdb/pml.txt
@@ -86,7 +86,7 @@ they do.
                                 code is decimal XXX. See the PML character
                                 table for details.
 \UXXXX                          Insert non-ASCII character whose Unicode code
-                                is hexidecimal XXXX. See the Extended PML
+                                is hexadecimal XXXX. See the Extended PML
                                 character table for details.
 \m="imagename.png"              Insert the named image. See the section on
                                 Images below.
@@ -590,7 +590,7 @@ In addition to the special characters supported by earlier versions of eReader
 (which can be accessed using the \a### tag), all versions of eReader Pro and
 eReader version 2.4 and later include support for additional special characters
 and symbols. These symbols can be accessed using the \U#### tag, where #### are
-four hexidecimal digits giving the Unicode encoding of the special character.
+four hexadecimal digits giving the Unicode encoding of the special character.
 
 Only the limited subset of Unicode characters given in the table below are
 supported. In addition, some of the characters that are included in the table
@@ -700,30 +700,30 @@ Spacing Modifier Letters
 ˘   &#728;     \U02D8     BREVE
 ˙   &#729;     \U02D9     DOT ABOVE
 Greek and Coptic
-Α     &#913;     \U0391     GREEK CAPTIAL LETTER ALPHA
-Β     &#914;     \U0392     GREEK CAPTIAL LETTER BETA
-Γ     &#915;     \U0393     GREEK CAPTIAL LETTER GAMMA
-Δ     &#917;     \U0394     GREEK CAPTIAL LETTER DELTA
-Ε     &#917;     \U0395     GREEK CAPTIAL LETTER EPSILON
-Ζ     &#918;     \U0396     GREEK CAPTIAL LETTER ZETA
-Η     &#919;     \U0397     GREEK CAPTIAL LETTER ETA
-Θ     &#920;     \U0398     GREEK CAPTIAL LETTER THETA
-Ι     &#921;     \U0399     GREEK CAPTIAL LETTER IOTA
-Κ     &#922;     \U039A     GREEK CAPTIAL LETTER KAPPA
-Λ     &#923;     \U039B     GREEK CAPTIAL LETTER LAMBDA
-Μ     &#924;     \U039C     GREEK CAPTIAL LETTER MU
-Ν     &#925;     \U039D     GREEK CAPTIAL LETTER NU
-Ξ     &#926;     \U039E     GREEK CAPTIAL LETTER XI
-Ο     &#927;     \U039F     GREEK CAPTIAL LETTER OMICRON
-Π     &#928;     \U03A0     GREEK CAPTIAL LETTER PI
-Ρ     &#929;     \U03A1     GREEK CAPTIAL LETTER RHO
-Σ     &#931;     \U03A3     GREEK CAPTIAL LETTER SIGMA
-Τ     &#932;     \U03A4     GREEK CAPTIAL LETTER TAU
-Υ     &#933;     \U03A5     GREEK CAPTIAL LETTER UPSILON
-Φ     &#934;     \U03A6     GREEK CAPTIAL LETTER PHI
-Χ     &#935;     \U03A7     GREEK CAPTIAL LETTER CHI
-Ψ     &#936;     \U03A8     GREEK CAPTIAL LETTER PSI
-Ω     &#937;     \U03A9     GREEK CAPTIAL LETTER OMEGA
+Α     &#913;     \U0391     GREEK CAPITAL LETTER ALPHA
+Β     &#914;     \U0392     GREEK CAPITAL LETTER BETA
+Γ     &#915;     \U0393     GREEK CAPITAL LETTER GAMMA
+Δ     &#917;     \U0394     GREEK CAPITAL LETTER DELTA
+Ε     &#917;     \U0395     GREEK CAPITAL LETTER EPSILON
+Ζ     &#918;     \U0396     GREEK CAPITAL LETTER ZETA
+Η     &#919;     \U0397     GREEK CAPITAL LETTER ETA
+Θ     &#920;     \U0398     GREEK CAPITAL LETTER THETA
+Ι     &#921;     \U0399     GREEK CAPITAL LETTER IOTA
+Κ     &#922;     \U039A     GREEK CAPITAL LETTER KAPPA
+Λ     &#923;     \U039B     GREEK CAPITAL LETTER LAMBDA
+Μ     &#924;     \U039C     GREEK CAPITAL LETTER MU
+Ν     &#925;     \U039D     GREEK CAPITAL LETTER NU
+Ξ     &#926;     \U039E     GREEK CAPITAL LETTER XI
+Ο     &#927;     \U039F     GREEK CAPITAL LETTER OMICRON
+Π     &#928;     \U03A0     GREEK CAPITAL LETTER PI
+Ρ     &#929;     \U03A1     GREEK CAPITAL LETTER RHO
+Σ     &#931;     \U03A3     GREEK CAPITAL LETTER SIGMA
+Τ     &#932;     \U03A4     GREEK CAPITAL LETTER TAU
+Υ     &#933;     \U03A5     GREEK CAPITAL LETTER UPSILON
+Φ     &#934;     \U03A6     GREEK CAPITAL LETTER PHI
+Χ     &#935;     \U03A7     GREEK CAPITAL LETTER CHI
+Ψ     &#936;     \U03A8     GREEK CAPITAL LETTER PSI
+Ω     &#937;     \U03A9     GREEK CAPITAL LETTER OMEGA
 α     &#945;     \U03B1     GREEK SMALL LETTER ALPHA
 β     &#946;     \U03B2     GREEK SMALL LETTER BETA
 γ     &#947;     \U03B3     GREEK SMALL LETTER GAMMA
@@ -877,13 +877,13 @@ Private Use Area
     -     \UE019     LATIN SMALL LETTER M WITH MACRON
     -     \UE01A     LATIN SMALL LETTER M WITH TILDE
     -     \UE01B     LATIN SMALL LETTER O WITH CEDILLA
-    -     \UE01C     LATIN SMALL LETTER O WITH MACRON AND CIRUMFLEX
+    -     \UE01C     LATIN SMALL LETTER O WITH MACRON AND CIRCUMFLEX
     -     \UE01E     LATIN SMALL LIGATURE OI
     -     \UE01F     LATIN SMALL LIGATURE OO
     -     \UE020     LATIN SMALL LIGATURE OO WITH MACRON
     -     \UE021     LATIN SMALL LIGATURE OU
     -     \UE022     LATIN SMALL LETTER OPEN O WITH ACUTE
-    -     \UE023     LATIN SMALL LETTER R WITH DIARESIS
+    -     \UE023     LATIN SMALL LETTER R WITH DIAERESIS
     -     \UE024     LATIN SMALL LETTER R WITH CIRCUMFLEX
     -     \UE025     LATIN SMALL LETTER R WITH RING BELOW
     -     \UE026     LATIN SMALL LETTER S WITH VERTICAL LINE ABOVE

--- a/format_docs/pdb/ztxt.txt
+++ b/format_docs/pdb/ztxt.txt
@@ -123,7 +123,7 @@ UInt16        recordSize;
 recordSize is the size in bytes of a text record. This field is important, as
 the size of text and decompression buffers is based on this value. It is used
 by Weasel to navigate though the text so it can map absolute offsets to record
-numberss. 8192 is the default. With compression mode 1, this is the amount of
+numbers. 8192 is the default. With compression mode 1, this is the amount of
 data inside each compressed record (except maybe the last one), but the actual
 compressed records will likely have varying sizes. In mode 2, both compressed
 records and the resulting text records are all of this size (except, again, the

--- a/format_docs/rb.txt
+++ b/format_docs/rb.txt
@@ -23,7 +23,7 @@ Details
 -------
 
 The first 4 bytes of the file seem to be a magic number (in hex): B0 0C
-B0 0C. I like to think of this as a hexidecimal pun on the word "book"
+B0 0C. I like to think of this as a hexadecimal pun on the word "book"
 (repeated). [Matt Greenwood has reported seeing a magic number of "B0 0C
 F0 0D" in another type of ReB-related file -- i.e. "book food".]
 

--- a/src/calibre/ebooks/rtf2xml/char_set.py
+++ b/src/calibre/ebooks/rtf2xml/char_set.py
@@ -15242,7 +15242,7 @@ UPWARDS DOUBLE ARROW:'DD:8657:&#x21D1;
 RIGHTWARDS DOUBLE ARROW:'DE:8658:&#x21D2;
 DOWNWARDS DOUBLE ARROW:'DF:8659:&#x21D3;
 BETWEEN:'E0:8812:&#x226C;
-MATHMATICAL LEFT ANGELBRACKET:'E1:10216:&#x27E8;
+MATHEMATICAL LEFT ANGELBRACKET:'E1:10216:&#x27E8;
 REGISTERED SIGN:'E2:174:&#x00AE;
 COPYRIGHT:'E3:169:&#x00A9;
 TRADEMARK SYMBOL:'E4:8482:&#x2122;
@@ -15257,7 +15257,7 @@ LARGE LEFT BRACKET PART1:'EC:0:<udef_symbol num="0xEC" description="right_bracke
 LARGE LEFT BRACKET PART2:'ED:0:<udef_symbol num="0xED" description="right_bracke tpart 2"/>
 LARGE LEFT BRACKET PART3:'EE:0:<udef_symbol num="0xEE" description="right_bracket part 3"/>
 DIVIDES:'EF:8739:&#x2223;
-MATHMATICAL RIGHT ANGLE BRACKET:'F1:10217:&#x27E9;
+MATHEMATICAL RIGHT ANGLE BRACKET:'F1:10217:&#x27E9;
 INTEGRAL:'F2:8747:&#x222B;
 LARGE INTEGRAL PART 1:'F3:0:<udef_symbol num="0xF3" description="integral part 1"/>
 LARGE INTEGRAL PART 2:'F4:0:<udef_symbol num="0xF4" description="integral part 2"/>
@@ -15265,7 +15265,7 @@ LARGE INTEGRAL PART 3:'F5:0:<udef_symbol num="0xF5" description="integral part 3
 LARGE RIGHT PARENTHESIS PART1:'F6:0:<udef_symbol num="0xF6" description="right_parenthesis part 1"/>
 LARGE RIGHT PARENTHESIS PART2:'F7:0:<udef_symbol num="0xF7" description="right_parenthesis part 2"/>
 LARGE RIGHT PARENTHESIS PART3:'F8:0:<udef_symbol num="0xF8" description="right_parenthesis part 3"/>
-LARGE RIGHT SQAURE BRACKET PART1:'F9:0:<udef_symbol num="0xF9" description="right_square_bracket part 1"/>
+LARGE RIGHT SQUARE BRACKET PART1:'F9:0:<udef_symbol num="0xF9" description="right_square_bracket part 1"/>
 LARGE RIGHT SQUARE BRACKET PART2:'FA:0:<udef_symbol num="0xFA" description="right_square_bracket part 2"/>
 LARGE RIGHT SQUARE BRACKETPART3:'FB:0:<udef_symbol num="0xFB" description="right_square_bracket part 3"/>
 LARGE RIGHT BRACKET PART1:'FC:0:<udef_symbol num="0xFC" description="right_bracket part 1"/>
@@ -16140,7 +16140,7 @@ SNOWFLAKE:T:10052:&#x2744;
 SHADOWED WHITE LATIN CROSS:U:10014:&#x271E;
 SHADOWED WHITE LATIN CROSS:V:10014:&#x271E;
 MY CELTIC CROSS:W:0:<celtic_cross/>
-MALTESE CORSS:X:10016:&#x2720;
+MALTESE CROSS:X:10016:&#x2720;
 STAR OF DAVID:Y:10017:&#x2721;
 STAR AND CRESCENT:Z:9770:&#x262A;
 MY FOLDER:0:0:<folder/>
@@ -16334,7 +16334,7 @@ UPWARDS DOUBLE ARROW:221:8657:&#x21D1;
 RIGHTWARDS DOUBLE ARROW:222:8658:&#x21D2;
 DOWNWARDS DOUBLE ARROW:223:8659:&#x21D3;
 BETWEEN:224:8812:&#x226C;
-MATHMATICAL LEFT ANGELBRACKET:225:10216:&#x27E8;
+MATHEMATICAL LEFT ANGELBRACKET:225:10216:&#x27E8;
 REGISTERED SIGN:226:174:&#x00AE;
 COPYRIGHT:227:169:&#x00A9;
 TRADEMARK SYMBOL:228:8482:&#x2122;
@@ -16349,7 +16349,7 @@ LARGE LEFT BRACKET PART1:236:0:<udef_symbol num="0x236" description="right_brack
 LARGE LEFT BRACKET PART2:237:0:<udef_symbol num="0x237" description="right_bracket part 2"/>
 LARGE LEFT BRACKET PART3:238:0:<udef_symbol num="0x238" description="right_bracket part 3"/>
 DIVIDES:239:8739:&#x2223;
-MATHMATICAL RIGHT ANGLE BRACKET:241:10217:&#x27E9;
+MATHEMATICAL RIGHT ANGLE BRACKET:241:10217:&#x27E9;
 INTEGRAL:242:8747:&#x222B;
 LARGE INTEGRAL PART 1:243:0:<udef_symbol num="0x243" description="integral part 1"/>
 LARGE INTEGRAL PART 2:244:0:<udef_symbol num="0x244" description="integral part 2"/>
@@ -16357,7 +16357,7 @@ LARGE INTEGRAL PART 3:245:0:<udef_symbol num="0x245" description="integral part 
 LARGE RIGHT PARENTHESIS PART1:246:0:<udef_symbol num="0x246" description="right_parenthesis part 1"/>
 LARGE RIGHT PARENTHESIS PART2:247:0:<udef_symbol num="0x247" description="right_parenthesis part 2"/>
 LARGE RIGHT PARENTHESIS PART3:248:0:<udef_symbol num="0x248" description="right_parenthesis part 3"/>
-LARGE RIGHT SQAURE BRACKET PART1:249:0:<udef_symbol num="0x249" description="right_square_bracket part 1"/>
+LARGE RIGHT SQUARE BRACKET PART1:249:0:<udef_symbol num="0x249" description="right_square_bracket part 1"/>
 LARGE RIGHT SQUARE BRACKET PART2:250:0:<udef_symbol num="0x250" description="right_square_bracket part 2"/>
 LARGE RIGHT SQUARE BRACKETPART3:251:0:<udef_symbol num="0x251" description="right_square_bracket part 3"/>
 LARGE RIGHT BRACKET PART1:252:0:<udef_symbol num="0x252" description="right_bracket part 1"/>
@@ -16519,7 +16519,7 @@ UPWARDS DOUBLE ARROW:221:unknown:&#x21D1;
 RIGHTWARDS DOUBLE ARROW:222:unknown:&#x21D2;
 DOWNWARDS DOUBLE ARROW:223:unknown:&#x21D3;
 BETWEEN:224:unknown:&#x226C;
-MATHMATICAL LEFT ANGELBRACKET:225:unknown:&#x27E8;
+MATHEMATICAL LEFT ANGELBRACKET:225:unknown:&#x27E8;
 REGISTERED SIGN:226:unknown:&#x00AE;
 COPYRIGHT:227:unknown:&#x00A9;
 N-ARY SUMMATION:229:8721:&#x2211;
@@ -16533,7 +16533,7 @@ LARGE LEFT BRACKET PART1:236:unknown:<udef_symbol num="0x236" description="right
 LARGE LEFT BRACKET PART2:237:unknown:<udef_symbol num="0x237" description="right_bracket part 2"/>
 LARGE LEFT BRACKET PART3:238:unknown:<udef_symbol num="0x238" description="right_bracket part 3"/>
 DIVIDES:239:8739:&#x2223;
-MATHMATICAL RIGHT ANGLE BRACKET:241:unknown:27E9
+MATHEMATICAL RIGHT ANGLE BRACKET:241:unknown:27E9
 INTEGRAL:242:unknown:&#x222B;
 LARGE INTEGRAL PART 1:243:unknown:<integral part="1"/>
 LARGE INTEGRAL PART 2:244:unknown:<integral part="2"/>
@@ -16541,7 +16541,7 @@ LARGE INTEGRAL PART 3:245:unknown:<integral part="3"/>
 LARGE RIGHT PARENTHESIS PART1:246:unknown:<right_parenthesis part="1"/>
 LARGE RIGHT PARENTHESIS PART2:247:unknown:<right_parenthesis part="2"/>
 LARGE RIGHT PARENTHESIS PART3:248:unknown:<right_parenthesis part="3"/>
-LARGE RIGHT SQAURE BRACKET PART1:249:unknown:<right_square_bracket part="1"/>
+LARGE RIGHT SQUARE BRACKET PART1:249:unknown:<right_square_bracket part="1"/>
 LARGE RIGHT SQUARE BRACKET PART2:250:unknown:<right_square_bracket part="2"/>
 LARGE RIGHT SQUARE BRACKETPART3:251:unknown:<right_square_bracket part="3"/>
 LARGE RIGHT BRACKET PART1:252:unknown:<right_bracket part="1"/>

--- a/src/calibre/ebooks/rtf2xml/field_strings.py
+++ b/src/calibre/ebooks/rtf2xml/field_strings.py
@@ -139,7 +139,7 @@ class FieldStrings:
             'Ordinal'       :   'ordinal',
             'CardText'      :   'cardinal-text',
             'OrdText'       :   'ordinal-text',
-            'Hex'           :   'hexidecimal',
+            'Hex'           :   'hexadecimal',
             'DollarText'    :   'dollar-text',
             'Upper'         :   'upper-case',
             'Lower'         :   'lower-case',


### PR DESCRIPTION
Typos in format_docs/ and src/calibre/ebooks/rtf2xml