### PR TITLE
Update Kobo database version for new firmware

### DIFF
--- a/src/calibre/devices/kobo/driver.py
+++ b/src/calibre/devices/kobo/driver.py
@@ -1384,7 +1384,7 @@ class KOBOTOUCH(KOBO):
         ' Based on the existing Kobo driver by %s.') % KOBO.author
 #    icon        = 'devices/kobotouch.jpg'
 
-    supported_dbversion             = 170
+    supported_dbversion             = 171
     min_supported_dbversion         = 53
     min_dbversion_series            = 65
     min_dbversion_externalid        = 65


### PR DESCRIPTION
For this firmware version, Kobo bumped the database version but for the firmware version, they only changed the build number.