### PR TITLE
Three changes to the template system.

### DIFF
--- a/src/calibre/gui2/dialogs/template_dialog.py
+++ b/src/calibre/gui2/dialogs/template_dialog.py
@@ -276,6 +276,7 @@ class TemplateDialog(QDialog, Ui_TemplateDialog):
             self.colored_field.setCurrentIndex(self.colored_field.findData(color_field))
         elif self.iconing or self.embleming:
             self.icon_layout.setVisible(True)
+            self.icon_select_layout.setContentsMargins(0, 0, 0, 0)
             if self.embleming:
                 self.icon_kind_label.setVisible(False)
                 self.icon_kind.setVisible(False)

--- a/src/calibre/gui2/dialogs/template_dialog.ui
+++ b/src/calibre/gui2/dialogs/template_dialog.ui
@@ -76,7 +76,7 @@
         <widget class="QWidget" name="icon_layout">
          <layout class="QGridLayout">
           <item row="0" column="0" colspan="2">
-           <layout class="QHBoxLayout">
+           <layout class="QHBoxLayout" name="icon_kind_layout">
             <item>
              <widget class="QLabel" name="icon_kind_label">
               <property name="text">
@@ -110,15 +110,21 @@
              <string>Copy an icon file name to the clipboard:</string>
             </property>
             <property name="buddy">
-             <cstring>color_name</cstring>
+             <cstring>icon_files</cstring>
             </property>
            </widget>
           </item>
           <item row="2" column="1">
            <widget class="QWidget">
-            <layout class="QHBoxLayout">
+            <layout class="QHBoxLayout" name="icon_select_layout">
              <item>
               <widget class="QComboBox" name="icon_files">
+               <property name="toolTip">
+                <string>&lt;p&gt;The template must return the name of the icon file
+                to display. If you wish to display multiple icons, separate the
+                individual icon file names with a ':' (colon). They will all be
+                displayed on the column&lt;/p&gt;</string>
+               </property>
               </widget>
              </item>
              <item>

--- a/src/calibre/utils/formatter_functions.py
+++ b/src/calibre/utils/formatter_functions.py
@@ -611,7 +611,7 @@ class BuiltinSwitch(BuiltinFormatterFunction):
 
     def evaluate(self, formatter, kwargs, mi, locals, val, *args):
         if (len(args) % 2) != 1:
-            raise ValueError(_('switch requires an odd number of arguments'))
+            raise ValueError(_('switch requires an even number of arguments'))
         i = 0
         while i < len(args):
             if i + 1 >= len(args):


### PR DESCRIPTION
1) Correct an error message.
2) Inline the switch() function for performance.
3) Add a tooltip explaining that an advanced template can create a compound icon by separating the file names with colons
