### PR TITLE
fix a potention bug of unexpected type 'float'

### DIFF
--- a/src/calibre/ebooks/oeb/transforms/rasterize.py
+++ b/src/calibre/ebooks/oeb/transforms/rasterize.py
@@ -34,8 +34,8 @@ def rasterize_svg(data=TEST_SVG, sizes=(), width=0, height=0, print=None, fmt='P
     svg = QSvgRenderer(QByteArray(data))
     size = svg.defaultSize()
     if size.width() == 100 and size.height() == 100 and sizes:
-        size.setWidth(sizes[0])
-        size.setHeight(sizes[1])
+        size.setWidth(int(sizes[0]))
+        size.setHeight(int(sizes[1]))
     if width or height:
         size.scale(int(width), int(height), Qt.AspectRatioMode.KeepAspectRatio)
     if print is not None:


### PR DESCRIPTION
I ran into this problem when converting an epub book into mobi, the error messages are as attached

```
Convert book 1 of 1 (经济学原理(第7版)微观经济学分册)
Conversion options changed from defaults:
  read_metadata_from_opf: '/var/folders/fl/bh95gz354ts78xfyq9wl4t4m0000gn/C/calibre_6.1.0_tmp_4jar7646/c4r4o_m2.opf'
  output_profile: 'kindle_pw3'
  cover: '/var/folders/fl/bh95gz354ts78xfyq9wl4t4m0000gn/C/calibre_6.1.0_tmp_4jar7646/247_972b.jpeg'
  verbose: 2
Resolved conversion options
calibre version: 6.1.0
{'asciiize': False,
 'author_sort': None,
 'authors': None,
 'base_font_size': 0.0,
 'book_producer': None,
 'change_justification': 'original',
 'chapter': "//*[((name()='h1' or name()='h2') and re:test(., "
            "'\\s*((chapter|book|section|part)\\s+)|((prolog|prologue|epilogue)(\\s+|$))', "
            "'i')) or @class = 'chapter']",
 'chapter_mark': 'pagebreak',
 'comments': None,
 'cover': '/var/folders/fl/bh95gz354ts78xfyq9wl4t4m0000gn/C/calibre_6.1.0_tmp_4jar7646/247_972b.jpeg',
 'debug_pipeline': None,
 'dehyphenate': True,
 'delete_blank_paragraphs': True,
 'disable_font_rescaling': False,
 'dont_compress': False,
 'duplicate_links_in_toc': False,
 'embed_all_fonts': False,
 'embed_font_family': None,
 'enable_heuristics': False,
 'expand_css': False,
 'extra_css': None,
 'extract_to': None,
 'filter_css': '',
 'fix_indents': True,
 'font_size_mapping': None,
 'format_scene_breaks': True,
 'html_unwrap_factor': 0.4,
 'input_encoding': None,
 'input_profile': <calibre.customize.profiles.InputProfile object at 0x1091c8400>,
 'insert_blank_line': False,
 'insert_blank_line_size': 0.5,
 'insert_metadata': False,
 'isbn': None,
 'italicize_common_cases': True,
 'keep_ligatures': False,
 'language': None,
 'level1_toc': None,
 'level2_toc': None,
 'level3_toc': None,
 'line_height': 0.0,
 'linearize_tables': False,
 'margin_bottom': 5.0,
 'margin_left': 5.0,
 'margin_right': 5.0,
 'margin_top': 5.0,
 'markup_chapter_headings': True,
 'max_toc_links': 50,
 'minimum_line_height': 120.0,
 'mobi_file_type': 'old',
 'mobi_ignore_margins': False,
 'mobi_keep_original_images': False,
 'mobi_toc_at_start': False,
 'no_chapters_in_toc': False,
 'no_inline_navbars': True,
 'no_inline_toc': False,
 'output_profile': <calibre.customize.profiles.KindlePaperWhite3Output object at 0x1091c8a00>,
 'page_breaks_before': '/',
 'personal_doc': '[PDOC]',
 'prefer_author_sort': False,
 'prefer_metadata_cover': False,
 'pretty_print': False,
 'pubdate': None,
 'publisher': None,
 'rating': None,
 'read_metadata_from_opf': '/var/folders/fl/bh95gz354ts78xfyq9wl4t4m0000gn/C/calibre_6.1.0_tmp_4jar7646/c4r4o_m2.opf',
 'remove_fake_margins': True,
 'remove_first_image': False,
 'remove_paragraph_spacing': False,
 'remove_paragraph_spacing_indent_size': 1.5,
 'renumber_headings': True,
 'replace_scene_breaks': '',
 'search_replace': '[]',
 'series': None,
 'series_index': None,
 'share_not_sync': False,
 'smarten_punctuation': False,
 'sr1_replace': None,
 'sr1_search': None,
 'sr2_replace': None,
 'sr2_search': None,
 'sr3_replace': None,
 'sr3_search': None,
 'start_reading_at': None,
 'subset_embedded_fonts': False,
 'tags': None,
 'timestamp': None,
 'title': None,
 'title_sort': None,
 'toc_filter': None,
 'toc_threshold': 6,
 'toc_title': None,
 'transform_css_rules': '[]',
 'transform_html_rules': '[]',
 'unsmarten_punctuation': False,
 'unwrap_lines': True,
 'use_auto_toc': False,
 'verbose': 2}
InputFormatPlugin: EPUB Input running
on /var/folders/fl/bh95gz354ts78xfyq9wl4t4m0000gn/C/calibre_6.1.0_tmp_4jar7646/2s6do5ag.epub
Parsing all content...
Parsing OEBPS/text00014.html ...
Parsing OEBPS/text00018.html ...
Parsing OEBPS/text00000.html ...
Parsing OEBPS/text00004.html ...
Parsing OEBPS/text00008.html ...
Parsing OEBPS/text00012.html ...
Parsing OEBPS/text00022.html ...
Parsing OEBPS/flow0003.css ...
Parsing OEBPS/text00001.html ...
Parsing OEBPS/text00017.html ...
Parsing OEBPS/text00003.html ...
Parsing OEBPS/text00007.html ...
Parsing OEBPS/text00011.html ...
Parsing OEBPS/text00021.html ...
Parsing OEBPS/flow0001.css ...
Parsing OEBPS/text00016.html ...
Parsing OEBPS/text00002.html ...
Parsing OEBPS/text00006.html ...
Parsing OEBPS/text00010.html ...
Parsing OEBPS/text00020.html ...
Parsing OEBPS/text00024.html ...
Parsing OEBPS/text00015.html ...
Parsing OEBPS/text00005.html ...
Parsing OEBPS/text00009.html ...
Parsing OEBPS/text00013.html ...
Parsing OEBPS/text00019.html ...
Parsing OEBPS/text00023.html ...
Parsing OEBPS/flow0004.css ...
Reading TOC from NCX...
Merging user specified metadata...
Detecting structure...
Flattening CSS and remapping font sizes...
Source base font size is 12.00000pt
Removing fake margins...
Found 25 items of level: div_1
Found 3350 items of level: p_1
div_1  left margin stats: Counter()
div_1  right margin stats: Counter()
Negative text indent detected at level  p_1, ignoring this level
Cleaning up manifest...
Trimming unused files from manifest...
Trimming 'OEBPS/Image00002.jpg' from manifest
Trimming 'OEBPS/Image00001.jpg' from manifest
Creating MOBI Output...
Serializing resources...
Creating MOBI 6 output
Generating in-line TOC...
Applying case-transforming CSS...
Parsing manglecase.css ...
Parsing tocstyle.css ...
Rasterizing SVG images...
Traceback (most recent call last):
  File "runpy.py", line 196, in _run_module_as_main
  File "runpy.py", line 86, in _run_code
  File "site.py", line 39, in <module>
  File "site.py", line 35, in main
  File "calibre/utils/ipc/worker.py", line 215, in main
  File "calibre/gui2/convert/gui_conversion.py", line 38, in gui_convert_override
  File "calibre/gui2/convert/gui_conversion.py", line 25, in gui_convert
  File "calibre/ebooks/conversion/plumber.py", line 1281, in run
  File "calibre/ebooks/conversion/plugins/mobi_output.py", line 212, in convert
  File "calibre/ebooks/conversion/plugins/mobi_output.py", line 235, in write_mobi
  File "calibre/ebooks/oeb/transforms/rasterize.py", line 81, in __call__
  File "calibre/ebooks/oeb/transforms/rasterize.py", line 149, in rasterize_spine
  File "calibre/ebooks/oeb/transforms/rasterize.py", line 168, in rasterize_item
  File "calibre/ebooks/oeb/transforms/rasterize.py", line 176, in rasterize_inline
  File "calibre/ebooks/oeb/transforms/rasterize.py", line 111, in rasterize_svg
  File "calibre/ebooks/oeb/transforms/rasterize.py", line 37, in rasterize_svg
TypeError: QSize.setWidth(): argument 1 has unexpected type 'float'
```