### PR TITLE
Fix for FTS re-index all formats of a book not working.

### DIFF
--- a/src/calibre/db/cache.py
+++ b/src/calibre/db/cache.py
@@ -560,7 +560,7 @@ class Cache:
     def reindex_fts_book(self, book_id, *fmts):
         if not self.is_fts_enabled():
             return
-        if not fmts:
+        if not fmts or not all(fmts):
             fmts = self._formats(book_id)
         self.backend.reindex_fts_book(book_id, *fmts)
         self._queue_next_fts_job()


### PR DESCRIPTION
Existing right-click on book details, re-index FTS doesn't work because it passes format as `''`, which arrives as `['']`.  While `''` and `[]` both eval to False, `['']` evals to True.

It could be that not passing fmts as a list is a better solution, but that would touch more code.