### PR TITLE
Add restrict_fts_formats tweak to limit formats FTS indexes.

### DIFF
--- a/resources/default_tweaks.py
+++ b/resources/default_tweaks.py
@@ -531,6 +531,13 @@ many_libraries = 10
 # all available output formats to be present.
 restrict_output_formats = None
 
+#: Choose formats for Full Text Search Indexing
+# Restrict the list of available formats used for Full Text Search indexing.
+# For example, if you only want to index EPUB and AZW3, change this to
+# restrict_fts_formats = ['EPUB', 'AZW3']. The default value of None causes
+# all available formats to be indexed.
+restrict_fts_formats = None
+
 #: Set the thumbnail image quality used by the Content server
 # The quality of a thumbnail is largely controlled by the compression quality
 # used when creating it. Set this to a larger number to improve the quality.

--- a/src/calibre/db/fts/text.py
+++ b/src/calibre/db/fts/text.py
@@ -7,6 +7,7 @@ import os
 import re
 import unicodedata
 
+from calibre.utils.config import tweaks
 from calibre.customize.ui import plugin_for_input_format
 from calibre.ebooks.oeb.base import XPNSMAP, barename
 from calibre.ebooks.oeb.iterator.book import extract_book
@@ -53,8 +54,15 @@ def to_text(container, name):
         yield from html_to_text(root)
 
 
+def is_in_restrict_fts_formats(input_fmt):
+    restrict = tweaks['restrict_fts_formats']
+    return not restrict or input_fmt in [x.upper() for x in restrict]
+
+
 def is_fmt_ok(input_fmt):
     input_fmt = input_fmt.upper()
+    if not is_in_restrict_fts_formats(input_fmt):
+        return False
     input_plugin = plugin_for_input_format(input_fmt)
     is_comic = bool(getattr(input_plugin, 'is_image_collection', False))
     if not input_plugin or is_comic:


### PR DESCRIPTION
As I suggested in [MR thread](https://www.mobileread.com/forums/showthread.php?p=4244437#post4244437), this adds code to only index formats listed in `restrict_fts_formats` tweak.  All used when `restrict_fts_formats` is `None`.

Uses the same `is_fmt_ok()` mechanism that skips indexing unknown formats, `ORIGINAL_EPUB/AZW3/etc` and comics.  

In both cases, the "X of Y book files" counts Y _with_ `ORIGINAL_EPUB/etc` and formats discarded by `restrict_fts_formats`.