### PR TITLE
smtp.py: call ehlo before starttls

### DIFF
--- a/src/calibre/utils/smtp.py
+++ b/src/calibre/utils/smtp.py
@@ -174,8 +174,8 @@ def sendmail(msg, from_, to, localhost=None, verbose=0, timeout=None,
         if verify_server_cert:
             import ssl
             context = ssl.create_default_context(cafile=cafile)
-        s.starttls(context=context)
         s.ehlo()
+        s.starttls(context=context)
     if username is not None and password is not None:
         s.login(username, password)
     ret = None


### PR DESCRIPTION
Recently Gmail SMTP failed to work with Calibre's Email to functionality, the error is shown as below:

```
Traceback (most recent call last):
  File "calibre/gui2/threaded_jobs.py", line 82, in start_work
  File "calibre/gui2/email.py", line 105, in __call__
  File "calibre/gui2/email.py", line 48, in run
  File "calibre/gui2/email.py", line 137, in sendmail
  File "calibre/utils/smtp.py", line 171, in sendmail
  File "polyglot/smtplib.py", line 36, in __init__
  File "smtplib.py", line 255, in __init__
  File "smtplib.py", line 343, in connect
  File "smtplib.py", line 405, in getreply
smtplib.SMTPServerDisconnected: Connection unexpectedly closed
```

I copied the code from source and run it independently, this error was reproduced.

I found this startoverflow link, all the examples call `SMTP.ehlo` before `SMTP.starttls`.
https://stackoverflow.com/questions/10147455/how-to-send-an-email-with-gmail-as-provider-using-python

One answer noted:
> You need to say EHLO before just running straight into STARTTLS

So I swaped the two lines and the script finally worked.

I don't have further knowledge about SMTP specification, so I'm not very sure whether this change breaks other SMTP service like outlook. But this PR should at least fixes Gmail's usability.
It's possible to add a if statement to make it run only for Gmail.