### PR TITLE
enum fix: Qt.DisplayRole => Qt.ItemDataRole.DisplayRole

### DIFF
--- a/src/calibre/gui2/dialogs/quickview.py
+++ b/src/calibre/gui2/dialogs/quickview.py
@@ -94,7 +94,7 @@ class TableItem(QTableWidgetItem):
 
     def data(self, role):
         self.get_data()
-        if role == Qt.DisplayRole:
+        if role == Qt.ItemDataRole.DisplayRole:
             return self.val
         return QTableWidgetItem.data(self, role)
 

--- a/src/calibre/gui2/preferences/look_feel.py
+++ b/src/calibre/gui2/preferences/look_feel.py
@@ -793,7 +793,7 @@ class ConfigWidget(ConfigWidgetBase, Ui_Form):
             if v == 0:
                 break
             item = QListWidgetItem(icon_map[v], choices[v-1][1])
-            item.setData(Qt.UserRole, choices[v-1][0])
+            item.setData(Qt.ItemDataRole.UserRole, choices[v-1][0])
             self.tb_search_order.addItem(item)
             node = v
 
@@ -821,7 +821,7 @@ class ConfigWidget(ConfigWidgetBase, Ui_Form):
         # the option order
         node = 0
         for i in range(0, 4):
-            v = self.tb_search_order.item(i).data(Qt.UserRole)
+            v = self.tb_search_order.item(i).data(Qt.ItemDataRole.UserRole)
             # JSON dumps converts integer keys to strings, so do it explicitly
             t[str(node)] = v
             node = v


### PR DESCRIPTION
It worked without this fix, at least on Windows. Better to make it right, though.