### PR TITLE
Bug fix: when creating a new yes/no column, nothing was selected for …

### DIFF
--- a/src/calibre/gui2/preferences/create_custom_column.py
+++ b/src/calibre/gui2/preferences/create_custom_column.py
@@ -333,6 +333,7 @@ class CreateCustomColumn(QDialog):
             h1.addWidget(b)
             return b
         self.bool_show_icon_button = add_bool_radio_button(_('&Icon'))
+        self.bool_show_icon_button.setChecked(True)
         self.bool_show_text_button = add_bool_radio_button(_('&Text'))
         self.bool_show_both_button = add_bool_radio_button(_('&Both'))
         self.bool_button_group = QGroupBox()


### PR DESCRIPTION
…what to show. If the user doesn't select one of the choices, nothing is shown in the library view.