### PR TITLE
Fix: Incorrect value in the default tweaks per_language_title_sort_articles['fra']

### DIFF
--- a/resources/default_tweaks.py
+++ b/resources/default_tweaks.py
@@ -222,7 +222,7 @@ per_language_title_sort_articles = {
                   r'Una\s+', r'Unos\s+', r'Unas\s+'),
         # French
         'fra'  : (r'Le\s+', r'La\s+', r"L'", u'L´', u'L’', r'Les\s+', r'Un\s+', r'Une\s+',
-                  r'Des\s+', r'De\s+La\s+', r'De\s+', r"D'", u'D´', u'L’'),
+                  r'Des\s+', r'De\s+La\s+', r'De\s+', r"D'", r'D´', r'D’'),
         # Polish
         'pol': (),
         # Italian


### PR DESCRIPTION
The default tweaks **per_language_title_sort_articles['fra']** contained an incorrect value that caused **L’** to be duplicated, but **D’** is missing.