### PR TITLE
Formatter function to_url()

### DIFF
--- a/manual/template_lang.rst
+++ b/manual/template_lang.rst
@@ -613,7 +613,13 @@ In `GPM` the functions described in `Single Function Mode` all require an additi
 * ``today()`` -- return a date+time string for today (now). This value is designed for use in `format_date` or `days_between`, but can be manipulated like any other string. The date is in `ISO <https://en.wikipedia.org/wiki/ISO_8601>`_ date/time format.
 * ``template(x)`` -- evaluates ``x`` as a template. The evaluation is done in its own context, meaning that variables are not shared between the caller and the template evaluation.
 * ``to_hex(val)`` -- returns the string ``val`` encoded in hex. This is useful when constructing calibre URLs.
-* ``to_url(val)`` -- returns the string ``val`` encoded in URI Syntax (Percent-Encoding). This is useful when constructing calibre URLs.
+<<<<<<< HEAD
+* ``quote_url_path(val)`` -- returns the string ``val`` encoded in URI Syntax (Percent-Encoding). This is useful when constructing calibre URLs.
+* ``quote_url_query(val)`` -- returns the string ``val`` encoded in URI Syntax (Percent-Encoding) for the query section. This is useful when constructing calibre URLs.
+=======
+* ``url_quote_path(val)`` -- returns the string ``val`` encoded in URI Syntax (Percent-Encoding). This is useful when constructing calibre URLs.
+* ``url_quote_query(val)`` -- returns the string ``val`` encoded in URI Syntax (Percent-Encoding) for the query section. This is useful when constructing calibre URLs.
+>>>>>>> 86165cc0a72d97ef0a07a615aece6a51c5994366
 * ``urls_from_identifiers(identifiers, sort_results)`` -- given a comma-separated list of ``identifiers``, where an `identifier` is a colon-separated pair of values (``id_name:id_value``), returns a comma-separated list of HTML URLs generated from the identifiers. The list not sorted if sort_results is ``0`` (character or number), otherwise it is sorted alphabetically by the identifier name. The URLs are generated in the same way as the built-in identifiers column when shown in :guilabel:`Book details`.
 
 .. _template_mode:

--- a/manual/template_lang.rst
+++ b/manual/template_lang.rst
@@ -613,6 +613,7 @@ In `GPM` the functions described in `Single Function Mode` all require an additi
 * ``today()`` -- return a date+time string for today (now). This value is designed for use in `format_date` or `days_between`, but can be manipulated like any other string. The date is in `ISO <https://en.wikipedia.org/wiki/ISO_8601>`_ date/time format.
 * ``template(x)`` -- evaluates ``x`` as a template. The evaluation is done in its own context, meaning that variables are not shared between the caller and the template evaluation.
 * ``to_hex(val)`` -- returns the string ``val`` encoded in hex. This is useful when constructing calibre URLs.
+* ``to_url(val)`` -- returns the string ``val`` encoded in URI Syntax (Percent-Encoding). This is useful when constructing calibre URLs.
 * ``urls_from_identifiers(identifiers, sort_results)`` -- given a comma-separated list of ``identifiers``, where an `identifier` is a colon-separated pair of values (``id_name:id_value``), returns a comma-separated list of HTML URLs generated from the identifiers. The list not sorted if sort_results is ``0`` (character or number), otherwise it is sorted alphabetically by the identifier name. The URLs are generated in the same way as the built-in identifiers column when shown in :guilabel:`Book details`.
 
 .. _template_mode:

--- a/src/calibre/utils/formatter_functions.py
+++ b/src/calibre/utils/formatter_functions.py
@@ -2241,16 +2241,44 @@ class BuiltinToHex(BuiltinFormatterFunction):
         return val.encode().hex()
 
 
-class BuiltinToUrl(BuiltinFormatterFunction):
-    name = 'to_url'
+<<<<<<< HEAD
+class BuiltinQuoteUrlPath(BuiltinFormatterFunction):
+    name = 'quote_url_path'
     arg_count = 1
     category = 'String manipulation'
-    __doc__ = doc = _('to_url(val) -- returns the string encoded in URI Syntax (Percent-Encoding). '
+    __doc__ = doc = _('quote_url_path(val) -- returns the string encoded in URI Syntax (Percent-Encoding). '
+=======
+class BuiltinUrlQuotePath(BuiltinFormatterFunction):
+    name = 'url_quote_path'
+    arg_count = 1
+    category = 'String manipulation'
+    __doc__ = doc = _('url_quote_path(val) -- returns the string encoded in URI Syntax (Percent-Encoding). '
+>>>>>>> 86165cc0a72d97ef0a07a615aece6a51c5994366
                       'This is useful when constructing calibre URLs.')
 
     def evaluate(self, formatter, kwargs, mi, locals, val):
         from urllib.parse import quote
         return quote(str(val))
+
+
+<<<<<<< HEAD
+class BuiltinQuoteUrlQuery(BuiltinFormatterFunction):
+    name = 'quote_url_query'
+    arg_count = 1
+    category = 'String manipulation'
+    __doc__ = doc = _('quote_url_query(val) -- returns the string encoded in URI Syntax (Percent-Encoding) for the query section. '
+=======
+class BuiltinUrlQuoteQuery(BuiltinFormatterFunction):
+    name = 'url_quote_query'
+    arg_count = 1
+    category = 'String manipulation'
+    __doc__ = doc = _('url_quote_query(val) -- returns the string encoded in URI Syntax (Percent-Encoding) for the query section. '
+>>>>>>> 86165cc0a72d97ef0a07a615aece6a51c5994366
+                      'This is useful when constructing calibre URLs.')
+
+    def evaluate(self, formatter, kwargs, mi, locals, val):
+        from urllib.parse import quote_plus
+        return quote_plus(str(val))
 
 
 class BuiltinUrlsFromIdentifiers(BuiltinFormatterFunction):
@@ -2373,7 +2401,12 @@ _formatter_builtins = [
     BuiltinSublist(),BuiltinSubstr(), BuiltinSubtract(), BuiltinSwapAroundArticles(),
     BuiltinSwapAroundComma(), BuiltinSwitch(),
     BuiltinTemplate(), BuiltinTest(), BuiltinTitlecase(), BuiltinToday(),
-    BuiltinToHex(), BuiltinToUrl(), BuiltinTransliterate(), BuiltinUppercase(), BuiltinUrlsFromIdentifiers(),
+    BuiltinToHex(), BuiltinTransliterate(), BuiltinUppercase(),
+<<<<<<< HEAD
+    BuiltinQuoteUrlPath(), BuiltinQuoteUrlQuery(), BuiltinUrlsFromIdentifiers(),
+=======
+    BuiltinUrlQuotePath(), BuiltinUrlQuoteQuery(),  BuiltinUrlsFromIdentifiers(),
+>>>>>>> 86165cc0a72d97ef0a07a615aece6a51c5994366
     BuiltinUserCategories(), BuiltinVirtualLibraries(), BuiltinAnnotationCount()
 ]
 

--- a/src/calibre/utils/formatter_functions.py
+++ b/src/calibre/utils/formatter_functions.py
@@ -2241,6 +2241,18 @@ class BuiltinToHex(BuiltinFormatterFunction):
         return val.encode().hex()
 
 
+class BuiltinToUrl(BuiltinFormatterFunction):
+    name = 'to_url'
+    arg_count = 1
+    category = 'String manipulation'
+    __doc__ = doc = _('to_url(val) -- returns the string encoded in URI Syntax URI Syntax (Percent-Encoding). '
+                      'This is useful when constructing calibre URLs.')
+
+    def evaluate(self, formatter, kwargs, mi, locals, val):
+        from urllib.parse import quote
+        return quote(str(val))
+
+
 class BuiltinUrlsFromIdentifiers(BuiltinFormatterFunction):
     name = 'urls_from_identifiers'
     arg_count = 2
@@ -2361,7 +2373,7 @@ _formatter_builtins = [
     BuiltinSublist(),BuiltinSubstr(), BuiltinSubtract(), BuiltinSwapAroundArticles(),
     BuiltinSwapAroundComma(), BuiltinSwitch(),
     BuiltinTemplate(), BuiltinTest(), BuiltinTitlecase(), BuiltinToday(),
-    BuiltinToHex(), BuiltinTransliterate(), BuiltinUppercase(), BuiltinUrlsFromIdentifiers(),
+    BuiltinToHex(), BuiltinToUrl(), BuiltinTransliterate(), BuiltinUppercase(), BuiltinUrlsFromIdentifiers(),
     BuiltinUserCategories(), BuiltinVirtualLibraries(), BuiltinAnnotationCount()
 ]
 

--- a/src/calibre/utils/formatter_functions.py
+++ b/src/calibre/utils/formatter_functions.py
@@ -2245,7 +2245,7 @@ class BuiltinToUrl(BuiltinFormatterFunction):
     name = 'to_url'
     arg_count = 1
     category = 'String manipulation'
-    __doc__ = doc = _('to_url(val) -- returns the string encoded in URI Syntax URI Syntax (Percent-Encoding). '
+    __doc__ = doc = _('to_url(val) -- returns the string encoded in URI Syntax (Percent-Encoding). '
                       'This is useful when constructing calibre URLs.')
 
     def evaluate(self, formatter, kwargs, mi, locals, val):


### PR DESCRIPTION
return the string in a compliant URI Syntax (Percent-Encoding).

In the same way of the `to_the()`, this is useful when constructing calibre URLs, but in a more human like format.