### PR TITLE
More accessibility changes related to the book list header context menu:

### DIFF
--- a/src/calibre/gui2/actions/booklist_context_menu.py
+++ b/src/calibre/gui2/actions/booklist_context_menu.py
@@ -9,8 +9,8 @@ from calibre.gui2.actions import InterfaceAction
 class BooklistContextMenuAction(InterfaceAction):
 
     name = 'Booklist context menu'
-    action_spec = (_('Book list context menu'), 'context_menu.png',
-                   _('Show the book list context menu'), '')
+    action_spec = (_('Book list header menu'), 'context_menu.png',
+                   _('Show the book list header context menu'), '')
     action_type = 'current'
     action_add_menu = False
     dont_add_to = frozenset(['context-menu-device', 'menubar-device'])


### PR DESCRIPTION
1) add a dialog to set the width without using the mouse.
2) Change the name from "Book list context menu" to "Book list header menu" to avoid confusion with the context menu on book list cells.