### PR TITLE
fix: book cover access without authentication in srv/content

### DIFF
--- a/src/calibre/srv/opds.py
+++ b/src/calibre/srv/opds.py
@@ -218,6 +218,7 @@ def ACQUISITION_ENTRY(book_id, updated, request_context):
     if len(extra):
         ans.append(E.content(extra, type='xhtml'))
     get = partial(request_context.ctx.url_for, '/get', book_id=book_id, library_id=request_context.library_id)
+    cover = partial(request_context.ctx.url_for, '/cover', book_id=book_id, library_id=request_context.library_id)
     if mi.formats:
         fm = mi.format_metadata
         for fmt in mi.formats:
@@ -230,7 +231,7 @@ def ACQUISITION_ENTRY(book_id, updated, request_context):
                     link.set('length', str(ffm['size']))
                     link.set('mtime', ffm['mtime'].isoformat())
                 ans.append(link)
-    ans.append(E.link(type='image/jpeg', href=get(what='cover'), rel="http://opds-spec.org/cover"))
+    ans.append(E.link(type='image/jpeg', href=cover(), rel="http://opds-spec.org/cover"))
     ans.append(E.link(type='image/jpeg', href=get(what='thumb'), rel="http://opds-spec.org/thumbnail"))
     ans.append(E.link(type='image/jpeg', href=get(what='cover'), rel="http://opds-spec.org/image"))
     ans.append(E.link(type='image/jpeg', href=get(what='thumb'), rel="http://opds-spec.org/image/thumbnail"))

--- a/src/pyj/read_book/ui.pyj
+++ b/src/pyj/read_book/ui.pyj
@@ -472,7 +472,7 @@ class ReadUI:
             self.downloads_in_progress.append(xhr)
 
         if raster_cover_name:
-            start_download(raster_cover_name, 'get/cover/' + book_id + '/' + encodeURIComponent(library_id))
+            start_download(raster_cover_name, 'cover/' + book_id + '/' + encodeURIComponent(library_id))
 
         count = 0
         queued = set()


### PR DESCRIPTION
When browsing an opds feed, an image cannot be protected. I created a dedicated route for the cover with auth_required=False

Useful for thorium-reader on browsing the calibre opds feed