### PR TITLE
When "unlock tabs" no close button for 'all book'

### DIFF
--- a/src/calibre/gui2/init.py
+++ b/src/calibre/gui2/init.py
@@ -440,12 +440,15 @@ class VLTabs(QTabBar):  # {{{
 
     def unlock_tab(self):
         gprefs['vl_tabs_closable'] = True
+        for idx in range(self.count()):
+            if not str(self.tabData(idx) or '').strip():
+                break
         self.setTabsClosable(True)
         try:
-            self.tabButton(0, QTabBar.ButtonPosition.RightSide).setVisible(False)
+            self.tabButton(idx, QTabBar.ButtonPosition.RightSide).setVisible(False)
         except AttributeError:
             try:
-                self.tabButton(0, QTabBar.ButtonPosition.LeftSide).setVisible(False)
+                self.tabButton(idx, QTabBar.ButtonPosition.LeftSide).setVisible(False)
             except AttributeError:
                 # On some OS X machines (using native style) the tab button is
                 # on the left


### PR DESCRIPTION
When your "unlock the tabs", calibre assumes that the 'All books' tab is always on the left, when it is not necessarily the case.
Bug 1: Close button on 'all book' tab
Bug 2: No close button on a virtual library tab that can be closed