### PR TITLE
Two performance improvements related to large libraries.

### DIFF
--- a/src/calibre/gui2/library/alternate_views.py
+++ b/src/calibre/gui2/library/alternate_views.py
@@ -110,8 +110,9 @@ def event_has_mods(self, event=None):
 
 def mousePressEvent(self, event):
     ep = event.pos()
-    if self.indexAt(ep) in self.selectionModel().selectedIndexes() and \
-            event.button() == Qt.MouseButton.LeftButton and not self.event_has_mods():
+    # for performance, check the selection only once we know we need it
+    if event.button() == Qt.MouseButton.LeftButton and not self.event_has_mods() \
+                and self.indexAt(ep) in self.selectionModel().selectedIndexes():
         self.drag_start_pos = ep
     if hasattr(self, 'handle_mouse_press_event'):
         return self.handle_mouse_press_event(event)


### PR DESCRIPTION
See https://www.mobileread.com/forums/showthread.php?p=4265937#post4265937 for an explanation.

The "exotic" part is changing _map_filtered to a property with a setter. The setter constructs a dict {book_id:row}. view.id_to_index() uses the dict instead of .index on the list.