### PR TITLE
Fix various typos

### DIFF
--- a/format_docs/pdb/mobi.txt
+++ b/format_docs/pdb/mobi.txt
@@ -316,7 +316,7 @@ In the PalmDoc format, a length-distance pair is always encoded by a two-byte
 sequence. Of the 16 bits that make up these two bytes, 11 bits go to encoding
 the distance, 3 go to encoding the length, and the remaining two are used to
 make sure the decoder can identify the first byte as the beginning of such a
-two-byte sequence. The exact alforithm needed to decode the compressed text can
+two-byte sequence. The exact algorithm needed to decode the compressed text can
 be found on the PalmDOC page.
 
 PalmDOC data is always divided into 4096 byte blocks and the blocks are acted

--- a/src/calibre/ebooks/pml/pmlml.py
+++ b/src/calibre/ebooks/pml/pmlml.py
@@ -164,7 +164,7 @@ class PMLMLizer:
 
     def prepare_string_for_pml(self, text):
         text = self.remove_newlines(text)
-        # Replace \ with \\ so \ in the text is not interperted as
+        # Replace \ with \\ so \ in the text is not interpreted as
         # a pml code.
         text = text.replace('\\', '\\\\')
         # Replace sequences of \\c \\c with pml sequences denoting

--- a/src/calibre/ebooks/rtf2xml/preamble_div.py
+++ b/src/calibre/ebooks/rtf2xml/preamble_div.py
@@ -406,8 +406,8 @@ cw<ci<font-style<nu<0
 
     def __margin_func(self, line):
         """
-        Handles lines that describe page info. Add the apporpriate info in the
-        token to the self.__margin_dict dicitonary.
+        Handles lines that describe page info. Add the appropriate info in the
+        token to the self.__margin_dict dictionary.
         """
         info = line[6:16]
         changed = self.__margin_dict.get(info)

--- a/src/pyj/read_book/tts.pyj
+++ b/src/pyj/read_book/tts.pyj
@@ -138,7 +138,7 @@ class Client:
 
         for x in text_segments:
             if jstype(x) is 'number':
-                # Currently the sad sack brosers dont support SSML
+                # Currently the sad sack browsers dont support SSML
                 # https://github.com/WICG/speech-api/issues/37
                 # buf.push()
                 # markup = '<mark name="' + x + '"/>'


### PR DESCRIPTION
Found via `codespell -q 3 -S./Changelog.*,./resources/dictionaries  -L alo,ans,pard,ro`