### PR TITLE
Fix manage categories and saved searches to allow assigning a …

### DIFF
--- a/src/calibre/gui2/actions/manage_categories.py
+++ b/src/calibre/gui2/actions/manage_categories.py
@@ -9,7 +9,7 @@ class ManageCategoriesAction(InterfaceAction):
 
     name = 'Manage categories'
     action_spec = (_('Manage categories'), 'tags.png',
-                   _('Manage categories: authors, tags, series, etc.'), '')
+                   _('Manage categories: authors, tags, series, etc.'), ())
     action_type = 'current'
     action_add_menu = True
     dont_add_to = frozenset(['context-menu-device', 'menubar-device'])

--- a/src/calibre/gui2/actions/saved_searches.py
+++ b/src/calibre/gui2/actions/saved_searches.py
@@ -57,7 +57,7 @@ class SavedSearchesAction(InterfaceAction):
 
     name = 'Saved searches'
     action_spec = (_('Saved searches'), 'folder_saved_search.png',
-                   _('Show a menu of saved searches'), None)
+                   _('Show a menu of saved searches'), ())
     action_type = 'current'
     action_add_menu = True
     dont_add_to = frozenset(('context-menu-device', 'menubar-device'))


### PR DESCRIPTION
…shortcut without provoking a conflict.

I used the same technique you used for add_to_library, an empty tuple.