### PR TITLE
Make tools on the search bar customizable.

### DIFF
--- a/resources/default_tweaks.py
+++ b/resources/default_tweaks.py
@@ -522,12 +522,6 @@ content_server_thumbnail_compression_quality = 75
 #    cover_drop_exclude = {'tiff', 'webp'}
 cover_drop_exclude = ()
 
-#: Show the Saved searches box in the Search bar
-# In newer versions of calibre, only a single button that allows you to add a
-# new Saved search is shown in the Search bar. If you would like to have the
-# old Saved searches box with its two buttons back, set this tweak to True.
-show_saved_search_box = False
-
 #: Exclude fields when copy/pasting metadata
 # You can ask calibre to not paste some metadata fields when using the
 # Edit metadata->Copy metadata/Paste metadata actions. For example,

--- a/src/calibre/gui2/__init__.py
+++ b/src/calibre/gui2/__init__.py
@@ -284,6 +284,8 @@ def create_defs():
 
     defs['action-layout-toolbar-child'] = ()
 
+    defs['action-layout-searchbar'] = ('Saved searches',)
+
     defs['action-layout-context-menu'] = (
             'Edit Metadata', 'Send To Device', 'Save To Disk',
             'Connect Share', 'Copy To Library', None,
@@ -395,6 +397,7 @@ def create_defs():
     defs['edit_metadata_templates_only_F2_on_booklist'] = False
     # JSON dumps converts integer keys to strings, so do it explicitly
     defs['tb_search_order'] = {'0': 1, '1': 2, '2': 3, '3': 4, '4': 0}
+    defs['search_tool_bar_shows_text'] = True
 
     def migrate_tweak(tweak_name, pref_name):
         # If the tweak has been changed then leave the tweak in the file so

--- a/src/calibre/gui2/bars.py
+++ b/src/calibre/gui2/bars.py
@@ -9,7 +9,7 @@ from functools import partial
 from qt.core import (
     Qt, QAction, QMenu, QObject, QToolBar, QToolButton, QSize, pyqtSignal, QKeySequence, QMenuBar,
     QTimer, QPropertyAnimation, QEasingCurve, pyqtProperty, QPainter, QWidget, QPalette, sip,
-    QHBoxLayout)
+    QHBoxLayout, QFrame)
 
 from calibre.constants import ismacos
 from calibre.gui2 import gprefs, native_menubar_defaults, config
@@ -679,11 +679,23 @@ class BarsManager(QObject):
         for ac in self.search_tool_bar_actions:
             self.search_tool_bar.removeWidget(ac)
 
+        self.search_tool_bar.setContentsMargins(0, 0, 0, 0)
+        self.search_tool_bar.setSpacing(0)
+
         self.search_tool_bar_actions = []
         for what in gprefs['action-layout-searchbar']:
-            if what in self.parent().iactions:
+            if what is None:
+                frame = QFrame()
+                frame.setFrameShape(QFrame.Shape.VLine)
+                frame.setFrameShadow(QFrame.Shadow.Sunken)
+                frame.setLineWidth(1)
+                frame.setContentsMargins(0, 5, 0, 5)
+                self.search_tool_bar.addWidget(frame)
+                self.search_tool_bar_actions.append(frame)
+            elif what in self.parent().iactions:
                 qact = self.parent().iactions[what].qaction
                 tb = QToolButton()
+                tb.setContentsMargins(0, 0, 0, 0)
                 tb.setDefaultAction(qact)
                 if not gprefs['search_tool_bar_shows_text']:
                     tb.setText(None)

--- a/src/calibre/gui2/layout.py
+++ b/src/calibre/gui2/layout.py
@@ -14,8 +14,7 @@ from qt.core import (
 from calibre import human_readable
 from calibre.constants import __appname__
 from calibre.gui2.bars import BarsManager
-from calibre.gui2.search_box import SavedSearchBox, SearchBox2
-from calibre.gui2.widgets2 import RightClickButton
+from calibre.gui2.search_box import SearchBox2
 from calibre.utils.config_base import tweaks
 
 
@@ -265,40 +264,8 @@ class SearchBar(QFrame):  # {{{
         x.setIcon(QIcon.ic('arrow-down.png'))
         l.addWidget(x)
 
-        x = parent.saved_search = SavedSearchBox(self)
-        x.setObjectName("saved_search")
-        l.addWidget(x)
-        x.setVisible(tweaks['show_saved_search_box'])
-
-        x = parent.copy_search_button = QToolButton(self)
-        x.setAutoRaise(True)
-        x.setCursor(Qt.CursorShape.PointingHandCursor)
-        x.setIcon(QIcon.ic("search_copy_saved.png"))
-        x.setObjectName("copy_search_button")
-        l.addWidget(x)
-        x.setToolTip(_("Copy current search text (instead of search name)"))
-        x.setVisible(tweaks['show_saved_search_box'])
-
-        x = parent.save_search_button = RightClickButton(self)
-        x.setAutoRaise(True)
-        x.setCursor(Qt.CursorShape.PointingHandCursor)
-        x.setIcon(QIcon.ic("search_add_saved.png"))
-        x.setObjectName("save_search_button")
-        l.addWidget(x)
-        x.setVisible(tweaks['show_saved_search_box'])
-
-        x = parent.add_saved_search_button = RightClickButton(self)
-        x.setToolTip(_(
-            'Use an existing Saved search or create a new one'
-        ))
-        x.setText(_('Saved search'))
-        x.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
-        x.setCursor(Qt.CursorShape.PointingHandCursor)
-        x.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
-        x.setAutoRaise(True)
-        x.setIcon(QIcon.ic("folder_saved_search.png"))
-        l.addWidget(x)
-        x.setVisible(not tweaks['show_saved_search_box'])
+        # Add the searchbar tool buttons to the bar
+        l.addLayout(self.parent().bars_manager.search_tool_bar)
 
     def populate_sort_menu(self):
         from calibre.gui2.ui import get_gui
@@ -342,9 +309,10 @@ class MainWindowMixin:  # {{{
 
         self.iactions['Fetch News'].init_scheduler()
 
-        self.search_bar = SearchBar(self)
         self.bars_manager = BarsManager(self.donate_action,
                 self.location_manager, self)
+        # instantiating SearchBar must happen after setting bars manager
+        self.search_bar = SearchBar(self)
         for bar in self.bars_manager.main_bars:
             self.addToolBar(Qt.ToolBarArea.TopToolBarArea, bar)
             bar.setStyleSheet('QToolBar { border: 0px }')

--- a/src/calibre/gui2/preferences/search.py
+++ b/src/calibre/gui2/preferences/search.py
@@ -32,6 +32,7 @@ class ConfigWidget(ConfigWidgetBase, Ui_Form):
         r('show_highlight_toggle_button', gprefs)
         r('limit_search_columns', prefs)
         r('use_primary_find_in_search', prefs)
+        r('search_tool_bar_shows_text', gprefs)
         r('case_sensitive', prefs)
         fl = db.field_metadata.get_search_terms()
         r('limit_search_columns_to', prefs, setting=CommaSeparatedList, choices=fl)
@@ -236,6 +237,7 @@ class ConfigWidget(ConfigWidgetBase, Ui_Form):
         return ConfigWidgetBase.commit(self)
 
     def refresh_gui(self, gui):
+        gui.refresh_search_bar_widgets()
         gui.current_db.new_api.clear_caches()
         set_use_primary_find_in_search(prefs['use_primary_find_in_search'])
         gui.set_highlight_only_button_icon()

--- a/src/calibre/gui2/preferences/search.ui
+++ b/src/calibre/gui2/preferences/search.ui
@@ -24,7 +24,7 @@
        <string>Genera&amp;l</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_6">
-       <item row="6" column="0">
+       <item row="11" column="0">
         <widget class="QPushButton" name="clear_history_button">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -40,7 +40,7 @@
          </property>
         </widget>
        </item>
-       <item row="5" column="0" colspan="2">
+       <item row="10" column="0" colspan="2">
         <widget class="QGroupBox" name="groupBox">
          <property name="title">
           <string>What to search by default</string>
@@ -120,7 +120,7 @@
          </property>
         </widget>
        </item>
-       <item row="7" column="0">
+       <item row="20" column="0">
         <spacer name="verticalSpacer_2">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -137,6 +137,13 @@
         <widget class="QCheckBox" name="opt_use_primary_find_in_search">
          <property name="text">
           <string>Unaccented characters match &amp;accented characters and punctuation is ignored</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="QCheckBox" name="opt_search_tool_bar_shows_text">
+         <property name="text">
+          <string>Show text next to buttons in the search bar</string>
          </property>
         </widget>
        </item>

--- a/src/calibre/gui2/preferences/toolbar.py
+++ b/src/calibre/gui2/preferences/toolbar.py
@@ -245,6 +245,7 @@ class ConfigWidget(ConfigWidgetBase, Ui_Form):
             ('toolbar', _('The main toolbar')),
             ('toolbar-device', _('The main toolbar when a device is connected')),
             ('toolbar-child', _('The optional second toolbar')),
+            ('searchbar', ('The buttons on the search bar')),
             ('menubar', _('The menubar')),
             ('menubar-device', _('The menubar when a device is connected')),
             ('context-menu', _('The context menu for the books in the '


### PR DESCRIPTION
Given that the saved searches action and the saved search button on the search bar now do the same thing, it seems reasonable to allow the user to choose whether the saved search button shows. I went from there to "Why not allow adding other buttons to the bar?" There is a lot of available real estate on that bar. This commit does that using a new toolbar in preferences / toolbars.

I didn't use a QToolBar, instead constructing a 'classic' toolbar in an QHBoxLayout. That gave me more control over the look and placement. And also, I had no end of trouble trying to work through how to use a QToolBar that isn't attached to a QMainWIndow.

In the process I removed the legacy Saved Search combo box, its associated buttons, and the tweak. I am sure there are some people still using the years-old interface and that they will complain. I can accept that, given that the button is better in almost every way.