### PR TITLE
Add `USER_SITE` to site.py to fix error in pip

### DIFF
--- a/bypy/linux/site.py
+++ b/bypy/linux/site.py
@@ -8,6 +8,8 @@ import sys
 
 import _sitebuiltins
 
+USER_SITE = None
+
 
 def set_quit():
     eof = 'Ctrl-D (i.e. EOF)'

--- a/bypy/macos/site.py
+++ b/bypy/macos/site.py
@@ -3,6 +3,8 @@ import os
 import sys
 import _sitebuiltins
 
+USER_SITE = None
+
 
 def nuke_stdout():
     # Redirect stdout, stdin and stderr to /dev/null

--- a/bypy/windows/site.py
+++ b/bypy/windows/site.py
@@ -13,6 +13,7 @@ import _sitebuiltins
 
 pyd_items = None
 extension_suffixes = sorted(EXTENSION_SUFFIXES, key=len, reverse=True)
+USER_SITE = None
 
 
 def remove_extension_suffix(name):


### PR DESCRIPTION
This pull request fixes the `module 'site' has no attribute 'USER_SITE'` error when run pip in calibre's embedded interpreter.

Fixing this error would enable plugins to install packages compatible with calibre by running command like this:

```
calibre-debug /usr/lib/python3.10/site-packages/pip/__pip-runner__.py -- -t install_path package_name
```