### PR TITLE
Fix for tag browser "AttributeError: 'NoneType' object has no …

### DIFF
--- a/src/calibre/gui2/tag_browser/view.py
+++ b/src/calibre/gui2/tag_browser/view.py
@@ -977,7 +977,7 @@ class TagsView(QTreeView):  # {{{
                     self.context_menu.addAction(_('Manage Saved searches'),
                         partial(self.context_menu_handler, action='manage_searches',
                                 category=tag.name if tag else None))
-                elif key == 'formats':
+                elif key == 'formats' and tag is not None:
                     self.context_menu.addAction(_('Remove the {} format from selected books').format(tag.name), partial(
                         self.context_menu_handler, action='remove_format', key=tag.name))
 


### PR DESCRIPTION
…attribute 'name'"

I found this by accident:

calibre 6.8*  embedded-python: True
Windows-10-10.0.19044-SP0 Windows ('64bit', 'WindowsPE') ('Windows', '10', '10.0.19044')
Python 3.10.1
[...]
File "C:\CBH_Data\calibre.git\calibre_dev\src\calibre\gui2\tag_browser\view.py", line 981, in show_context_menu
AttributeError: 'NoneType' object has no attribute 'name'