### PR TITLE
[Bug 1996020]:  Bulk Metadata Editor: Inconsistency on 'Clear' button

### DIFF
--- a/src/calibre/gui2/custom_column_widgets.py
+++ b/src/calibre/gui2/custom_column_widgets.py
@@ -327,7 +327,6 @@ class DateTimeEdit(DateTimeEditBase):
         self.setDateTime(now())
 
     def set_to_clear(self):
-        self.setDateTime(now())
         self.setDateTime(UNDEFINED_QDATETIME)
 
 


### PR DESCRIPTION
Clicking clear on DateTime setting the apply box is wrong. Fixed.