### PR TITLE
Bug #1996559: Saved Search: Renamed saved search oddities

### DIFF
--- a/src/calibre/gui2/tag_browser/view.py
+++ b/src/calibre/gui2/tag_browser/view.py
@@ -112,7 +112,8 @@ class TagDelegate(QStyledItemDelegate):  # {{{
         style = QApplication.style() if widget is None else widget.style()
         self.initStyleOption(option, index)
         item = index.data(Qt.ItemDataRole.UserRole)
-        self.draw_icon(style, painter, option, widget)
+        if item.type != TagTreeItem.TAG or item.tag.category != 'search' or item.tag.search_expression:
+            self.draw_icon(style, painter, option, widget)
         painter.save()
         self.draw_text(style, painter, option, widget, index, item)
         painter.restore()


### PR DESCRIPTION
Changed saved search nodes generated by walking a hierarchy to do nothing when clicked and to have an appropriate tooltip. Also removed the search icon for these saved search nodes, since they aren't searches.