### PR TITLE
perf: CssChecker Pool performance

### DIFF
--- a/src/calibre/ebooks/oeb/polish/check/css.py
+++ b/src/calibre/ebooks/oeb/polish/check/css.py
@@ -8,6 +8,7 @@ import sys
 from collections import namedtuple
 from itertools import repeat
 from threading import Lock
+from functools import lru_cache
 
 from qt.core import QApplication, QEventLoop, pyqtSignal, sip,QObject
 from qt.webengine import (
@@ -62,67 +63,63 @@ def message_to_error(message, name, line_offset=0):
         ans.HELP += ' ' + _('See <a href="{}">detailed description</a>.').format(rule['url'])
     return ans
 
-
+@lru_cache()
 def csslint_js():
-    ans = getattr(csslint_js, 'ans', None)
-    if ans is None:
-        ans = csslint_js.ans = P('csslint.js', data=True, allow_user_override=False).decode('utf-8') + '''
+    ans = P('csslint.js', data=True, allow_user_override=False).decode('utf-8') + '''
 
-        window.check_css =  function(src) {
-            var rules = CSSLint.getRules();
-            var ruleset = {};
-            var ignored_rules = {
-                'order-alphabetical': 1,
-                'font-sizes': 1,
-                'zero-units': 1,
-                'bulletproof-font-face': 1,
-                'import': 1,
-                'box-model': 1,
-                'adjoining-classes': 1,
-                'box-sizing': 1,
-                'compatible-vendor-prefixes': 1,
-                'text-indent': 1,
-                'unique-headings': 1,
-                'fallback-colors': 1,
-                'font-faces': 1,
-                'regex-selectors': 1,
-                'universal-selector': 1,
-                'unqualified-attributes': 1,
-                'overqualified-elements': 1,
-                'shorthand': 1,
-                'duplicate-background-images': 1,
-                'floats': 1,
-                'ids': 1,
-                'gradients': 1
-            };
-            var error_rules = {
-                'known-properties': 1,
-                'duplicate-properties': 1,
-                'vendor-prefix': 1
-            };
+    window.check_css =  function(src) {
+        var rules = CSSLint.getRules();
+        var ruleset = {};
+        var ignored_rules = {
+            'order-alphabetical': 1,
+            'font-sizes': 1,
+            'zero-units': 1,
+            'bulletproof-font-face': 1,
+            'import': 1,
+            'box-model': 1,
+            'adjoining-classes': 1,
+            'box-sizing': 1,
+            'compatible-vendor-prefixes': 1,
+            'text-indent': 1,
+            'unique-headings': 1,
+            'fallback-colors': 1,
+            'font-faces': 1,
+            'regex-selectors': 1,
+            'universal-selector': 1,
+            'unqualified-attributes': 1,
+            'overqualified-elements': 1,
+            'shorthand': 1,
+            'duplicate-background-images': 1,
+            'floats': 1,
+            'ids': 1,
+            'gradients': 1
+        };
+        var error_rules = {
+            'known-properties': 1,
+            'duplicate-properties': 1,
+            'vendor-prefix': 1
+        };
 
-            for (var i = 0; i < rules.length; i++) {
-                var rule = rules[i];
-                if (!ignored_rules[rule.id] && rule.browsers === "All") ruleset[rule.id] = error_rules[rule.id] ? 2 : 1;
-            }
-            var result = CSSLint.verify(src, ruleset);
-            return result;
+        for (var i = 0; i < rules.length; i++) {
+            var rule = rules[i];
+            if (!ignored_rules[rule.id] && rule.browsers === "All") ruleset[rule.id] = error_rules[rule.id] ? 2 : 1;
         }
-        document.title = 'ready';
-        '''
+        var result = CSSLint.verify(src, ruleset);
+        return result;
+    }
+    document.title = 'ready';
+    '''
     return ans
 
-
+@lru_cache()
 def create_profile():
-    ans = getattr(create_profile, 'ans', None)
-    if ans is None:
-        ans = create_profile.ans = QWebEngineProfile(QApplication.instance())
-        setup_profile(ans)
-        s = QWebEngineScript()
-        s.setName('csslint.js')
-        s.setSourceCode(csslint_js())
-        s.setWorldId(QWebEngineScript.ScriptWorldId.ApplicationWorld)
-        ans.scripts().insert(s)
+    ans = QWebEngineProfile(QApplication.instance())
+    setup_profile(ans)
+    s = QWebEngineScript()
+    s.setName('csslint.js')
+    s.setSourceCode(csslint_js())
+    s.setWorldId(QWebEngineScript.ScriptWorldId.ApplicationWorld)
+    ans.scripts().insert(s)
     return ans
 
 


### PR DESCRIPTION
CssChecker Pool Use QEventLoop instead processEvents. Using Qt signal better than busy check
lru_cache is better than getattr to lazy initialization share object