### PR TITLE
Bug 1996649: Enhancement: Tag Browser: Use search folder icon when …

### DIFF
--- a/src/calibre/gui2/tag_browser/model.py
+++ b/src/calibre/gui2/tag_browser/model.py
@@ -119,6 +119,8 @@ class TagTreeItem:  # {{{
             else:
                 if self.is_gst:
                     cc = self.category_custom_icons.get(self.root_node().category_key, None)
+                elif self.tag.category == 'search' and not self.tag.is_searchable:
+                    cc = self.category_custom_icons.get('search_folder:', None)
                 else:
                     cc = self.category_custom_icons.get(self.tag.category, None)
         elif self.type == self.CATEGORY:
@@ -451,6 +453,8 @@ class TagsModel(QAbstractItemModel):  # {{{
         data = self._get_category_nodes(config['sort_tags_by'])
         gst = self.db.new_api.pref('grouped_search_terms', {})
 
+        if self.category_custom_icons.get('search_folder:', None) is None:
+            self.category_custom_icons['search_folder:'] = QIcon.ic('folder_saved_search')
         last_category_node = None
         category_node_map = {}
         self.user_category_node_tree = {}

--- a/src/calibre/gui2/tag_browser/view.py
+++ b/src/calibre/gui2/tag_browser/view.py
@@ -112,8 +112,7 @@ class TagDelegate(QStyledItemDelegate):  # {{{
         style = QApplication.style() if widget is None else widget.style()
         self.initStyleOption(option, index)
         item = index.data(Qt.ItemDataRole.UserRole)
-        if item.type != TagTreeItem.TAG or item.tag.category != 'search' or item.tag.search_expression:
-            self.draw_icon(style, painter, option, widget)
+        self.draw_icon(style, painter, option, widget)
         painter.save()
         self.draw_text(style, painter, option, widget, index, item)
         painter.restore()
@@ -1007,11 +1006,25 @@ class TagsView(QTreeView):  # {{{
                 add_show_hidden_categories()
 
                 if tag is None:
-                    self.context_menu.addSeparator()
-                    self.context_menu.addAction(_('Change category icon'),
-                            partial(self.context_menu_handler, action='set_icon', key=key)).setIcon(QIcon.ic('icon_choose.png'))
-                    self.context_menu.addAction(_('Restore default icon'),
-                            partial(self.context_menu_handler, action='clear_icon', key=key)).setIcon(QIcon.ic('edit-clear.png'))
+                    cm = self.context_menu
+                    cm.addSeparator()
+                    sm = cm.addAction(_('Change {} category icon').format(category),
+                                      partial(self.context_menu_handler, action='set_icon',
+                                              key=key, category=category))
+                    sm.setIcon(QIcon.ic('icon_choose.png'))
+                    sm = cm.addAction(_('Restore {} category default icon').format(category),
+                                      partial(self.context_menu_handler, action='clear_icon',
+                                              key=key, category=category))
+                    sm.setIcon(QIcon.ic('edit-clear.png'))
+                    if key == 'search':
+                        sm = cm.addAction(_('Change Saved searches folder icon'),
+                                          partial(self.context_menu_handler, action='set_icon',
+                                                  key='search_folder:', category=_('Saved searches folder')))
+                        sm.setIcon(QIcon.ic('icon_choose.png'))
+                        sm = cm.addAction(_('Restore Saved searches folder default icon'),
+                             partial(self.context_menu_handler, action='clear_icon',
+                                     key='search_folder:', category=_('Saved searches folder')))
+                        sm.setIcon(QIcon.ic('edit-clear.png'))
 
                 # Always show the User categories editor
                 self.context_menu.addSeparator()


### PR DESCRIPTION
…appropriate.

NB: this changes the tag browser but not the web server. Nothing here breaks the server -- it behaves as it always has. However, there might be some 'feedback' about the tag browser having folder icons and the server not having them. I looked at changing the server, but I don't understand the code so it was beyond me.

Also, the server has a behavior oddity that the tag browser also had until the previous commit. If you click on a generated hierarchical search node then it searches using a non-existent saved search, which finds all books. As before, this behavior has been there for a long time.