### PR TITLE
Bug(s) #1997137: Tag browser error.

### DIFF
--- a/src/calibre/gui2/preferences/search.py
+++ b/src/calibre/gui2/preferences/search.py
@@ -229,6 +229,7 @@ class ConfigWidget(ConfigWidgetBase, Ui_Form):
         self.gst_value.blockSignals(False)
 
     def commit(self):
+        restart = ConfigWidgetBase.commit(self)
         if self.opt_case_sensitive.isChecked() and self.opt_use_primary_find_in_search.isChecked():
             error_dialog(self, _('Incompatible options'), _(
                 'The option to have un-accented characters match accented characters has no effect'
@@ -252,7 +253,7 @@ class ConfigWidget(ConfigWidgetBase, Ui_Form):
         else:
             cats.discard('search')
         self.db.new_api.set_pref('categories_using_hierarchy', list(cats))
-        return ConfigWidgetBase.commit(self)
+        return restart
 
     def refresh_gui(self, gui):
         gui.refresh_search_bar_widgets()
@@ -260,8 +261,8 @@ class ConfigWidget(ConfigWidgetBase, Ui_Form):
         gui.current_db.new_api.clear_caches()
         set_use_primary_find_in_search(prefs['use_primary_find_in_search'])
         gui.set_highlight_only_button_icon()
-        if self.muc_changed:
-            gui.tags_view.recount()
+        if self.gst_changed or self.muc_changed:
+            gui.tags_view.model().reset_tag_browser()
         gui.search.search_as_you_type(config['search_as_you_type'])
         gui.search.do_search()
 

--- a/src/calibre/gui2/preferences/search.py
+++ b/src/calibre/gui2/preferences/search.py
@@ -229,12 +229,12 @@ class ConfigWidget(ConfigWidgetBase, Ui_Form):
         self.gst_value.blockSignals(False)
 
     def commit(self):
-        restart = ConfigWidgetBase.commit(self)
         if self.opt_case_sensitive.isChecked() and self.opt_use_primary_find_in_search.isChecked():
             error_dialog(self, _('Incompatible options'), _(
                 'The option to have un-accented characters match accented characters has no effect'
                 ' if you also turn on case-sensitive searching. So only turn on one of those options'), show=True)
             raise AbortCommit()
+        restart = ConfigWidgetBase.commit(self)
         if self.gst_changed:
             self.db.new_api.set_pref('grouped_search_terms', self.gst)
             self.db.field_metadata.add_grouped_search_terms(self.gst)

--- a/src/calibre/gui2/tag_browser/view.py
+++ b/src/calibre/gui2/tag_browser/view.py
@@ -715,6 +715,7 @@ class TagsView(QTreeView):  # {{{
         index = self.indexAt(point)
         self.context_menu = QMenu(self)
         added_show_hidden_categories = False
+        key = None
 
         def add_show_hidden_categories():
             nonlocal added_show_hidden_categories
@@ -1046,7 +1047,7 @@ class TagsView(QTreeView):  # {{{
 
         # partioning. If partitioning is active, provide a way to turn it on or
         # off for this category.
-        if gprefs['tags_browser_partition_method'] != 'disable':
+        if gprefs['tags_browser_partition_method'] != 'disable' and key is not None:
             m = self.context_menu
             p = self.db.prefs.get('tag_browser_dont_collapse', gprefs['tag_browser_dont_collapse'])
             if key in p:


### PR DESCRIPTION
There are two independent problems here.

1) The exception is caused by right-clicking in the white space of the tag browser. I can't make it happen right-clicking anywhere else. It has nothing to do with grouped searches.

2) The "creation of grouped search terms" problem has been there since forever. The search preferences didn't tell the tag browser to completely rebuild the tree. Restarting calibre fixed it.