### PR TITLE
Enhancement #1998705: Exclude folder names from “Check Library” results.

### DIFF
--- a/src/calibre/gui2/actions/choose_library.py
+++ b/src/calibre/gui2/actions/choose_library.py
@@ -686,9 +686,12 @@ class ChooseLibraryAction(InterfaceAction):
             d = CheckLibraryDialog(self.gui, m.db)
 
             if not d.do_exec():
-                info_dialog(self.gui, _('No problems found'),
-                        _('The files in your library match the information '
-                        'in the database.'), show=True)
+                if question_dialog(self.gui, _('No problems found'),
+                        _('The files in your library match the information in the database.\n\n'
+                          "Choose 'Open dialog' to change settings and run the check again."),
+                        yes_text=_('Open dialog'), yes_icon='gear.png',
+                        no_text=_('Finished')):
+                    d.exec()
         finally:
             self.gui.status_bar.clear_message()
 

--- a/src/calibre/gui2/dialogs/check_library.py
+++ b/src/calibre/gui2/dialogs/check_library.py
@@ -243,16 +243,22 @@ class CheckLibraryDialog(QDialog):
         h.addWidget(ln)
         self.name_ignores = QLineEdit()
         self.name_ignores.setText(db.new_api.pref('check_library_ignore_names', ''))
-        self.name_ignores.setToolTip(
-            _('Enter comma-separated standard file name wildcards, such as synctoy*.dat'))
+        tt_ext = ('<br><br>' +
+                 _('Note: ignoring folders or files inside a book folder can lead to data loss. Ignored '
+                   "folders and files will be lost if you change the book's title or author(s)."))
+        self.name_ignores.setToolTip('<p>' +
+            _('Enter comma-separated standard shell file name wildcards, such as synctoy*.dat. '
+              'Used in library, author, and book folders') +
+            tt_ext + '</p>')
         ln.setBuddy(self.name_ignores)
         h.addWidget(self.name_ignores)
         le = QLabel(_('Extensions to ignore:'))
         h.addWidget(le)
         self.ext_ignores = QLineEdit()
         self.ext_ignores.setText(db.new_api.pref('check_library_ignore_extensions', ''))
-        self.ext_ignores.setToolTip(
-            _('Enter comma-separated extensions without a leading dot. Used only in book folders'))
+        self.ext_ignores.setToolTip('<p>' +
+            _('Enter comma-separated extensions without a leading dot. Used only in book folders') +
+            tt_ext + '</p>')
         le.setBuddy(self.ext_ignores)
         h.addWidget(self.ext_ignores)
         self._layout.addLayout(h)

--- a/src/calibre/library/check_library.py
+++ b/src/calibre/library/check_library.py
@@ -180,8 +180,9 @@ class CheckLibrary:
     def process_book(self, lib, book_info):
         (db_path, title_dir, book_id) = book_info
         filenames = frozenset(f for f in os.listdir(os.path.join(lib, db_path))
-                               if os.path.splitext(f)[1] not in self.ignore_ext or
-                               f == 'cover.jpg')
+                               if not self.ignore_name(f) and (
+                                   os.path.splitext(f)[1] not in self.ignore_ext or
+                                   f == 'cover.jpg' ))
         book_id = int(book_id)
         formats = frozenset(filter(self.is_ebook_file, filenames))
         book_formats = frozenset(x[0]+'.'+x[1].lower() for x in


### PR DESCRIPTION
I added tooltip text saying that ignoring folders and files in book folders is asking for data loss.

I also added the ability to open the check dialog when no errors were detected to make it easier to change settings.