### PR TITLE
Bug #1999571: Similar books: Grouped search problems.

### DIFF
--- a/src/calibre/db/cache.py
+++ b/src/calibre/db/cache.py
@@ -2350,6 +2350,13 @@ class Cache:
         return self._books_for_field(f.name, int(item_id_or_composite_value))
 
     @read_api
+    def split_if_is_multiple_composite(self, f, v):
+        fm = self.field_metadata.get(f, None)
+        if fm and fm['datatype'] == 'composite' and fm['is_multiple']:
+            return [v.strip() for v in v.split(',') if v.strip()]
+        return v
+
+    @read_api
     def data_for_find_identical_books(self):
         ''' Return data that can be used to implement
         :meth:`find_identical_books` in a worker process without access to the

--- a/src/calibre/gui2/actions/similar_books.py
+++ b/src/calibre/gui2/actions/similar_books.py
@@ -66,6 +66,7 @@ class SimilarBooksAction(InterfaceAction):
                 v = mi.get(f, None)
                 if not v:
                     continue
+                v = db.new_api.split_if_is_multiple_composite(f, v)
                 if isinstance(v, list):
                     val.update(v)
                 else:


### PR DESCRIPTION
Fixed by adding a new API method db.cache,split_if_is_multiple_composite(). This method converts the value to a list if the composite is "tags-like". The intention is that plugins etc can use the method if needed.