### PR TITLE
Update choose_library.ui

### DIFF
--- a/src/calibre/gui2/dialogs/choose_library.ui
+++ b/src/calibre/gui2/dialogs/choose_library.ui
@@ -38,6 +38,16 @@
      </property>
     </widget>
    </item>
+      <item row="3" column="0" colspan="4">
+    <widget class="QLabel" name="network_warning">
+     <property name="text">
+      <string>Putting your library on a networked drive?</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
    <item row="4" column="0" colspan="4">
     <widget class="QRadioButton" name="existing_library">
      <property name="text">


### PR DESCRIPTION
Added a bit of text that's meant to link to the network drive FAQ entry. I couldn't properly implement the link itself (a href failed, and I couldn't find an example of a working hyperlink in a dialog). 