### PR TITLE
Two minor improvements:

### DIFF
--- a/src/calibre/gui2/search_restriction_mixin.py
+++ b/src/calibre/gui2/search_restriction_mixin.py
@@ -453,23 +453,23 @@ class SearchRestrictionMixin:
             db.data.set_base_restriction_name('')
         elif library == '*':
             if not self.search.current_text:
-                error_dialog(self, _('No search'),
-                     _('There is no current search to use'), show=True)
-                return
+                # Clear the temporary VL if the search box is empty
+                db.data.set_base_restriction('')
+                db.data.set_base_restriction_name('')
+            else:
+                txt = _build_full_search_string(self)
+                try:
+                    db.data.search_getting_ids('', txt, use_virtual_library=False)
+                except ParseException as e:
+                    error_dialog(self, _('Invalid search'),
+                                 _('The search in the search box is not valid'),
+                                 det_msg=e.msg, show=True)
+                    return
 
-            txt = _build_full_search_string(self)
-            try:
-                db.data.search_getting_ids('', txt, use_virtual_library=False)
-            except ParseException as e:
-                error_dialog(self, _('Invalid search'),
-                             _('The search in the search box is not valid'),
-                             det_msg=e.msg, show=True)
-                return
-
-            self.search_based_vl = txt
-            db.data.set_base_restriction(txt)
-            self.search_based_vl_name = self._trim_restriction_name('*' + txt)
-            db.data.set_base_restriction_name(self.search_based_vl_name)
+                self.search_based_vl = txt
+                db.data.set_base_restriction(txt)
+                self.search_based_vl_name = self._trim_restriction_name('*' + txt)
+                db.data.set_base_restriction_name(self.search_based_vl_name)
         elif library == self.search_based_vl_name:
             db.data.set_base_restriction(self.search_based_vl)
             db.data.set_base_restriction_name(self.search_based_vl_name)

--- a/src/calibre/gui2/tag_browser/model.py
+++ b/src/calibre/gui2/tag_browser/model.py
@@ -1717,15 +1717,18 @@ class TagsModel(QAbstractItemModel):  # {{{
                         letters_seen = {}
                         for subnode in tag_item.children:
                             if subnode.tag.sort:
-                                letters_seen[subnode.tag.sort[0]] = True
+                                c = subnode.tag.sort[0]
+                                if c in r'\.^$[]|()':
+                                    c = f'\\{c}'
+                                letters_seen[c] = True
                         if letters_seen:
                             charclass = ''.join(letters_seen)
                             if k == 'author_sort':
-                                expr = r'%s:"~(^[%s])|(&\s*[%s])"'%(k, charclass, charclass)
+                                expr = r'%s:"""~(^[%s])|(&\s*[%s])"""'%(k, charclass, charclass)
                             elif k == 'series':
-                                expr = r'series_sort:"~^[%s]"'%(charclass)
+                                expr = r'series_sort:"""~^[%s]"""'%(charclass)
                             else:
-                                expr = r'%s:"~^[%s]"'%(k, charclass)
+                                expr = r'%s:"""~^[%s]"""'%(k, charclass)
                         else:
                             expr = r'%s:false'%(k)
                         if node_searches[tag_item.tag.state] == 'true':


### PR DESCRIPTION
1) Clear the temporary VL if the search box is empty instead of giving an error. 
2) Escape regexp special characters in tag browser first letter searches. Use super-quoting to make escaping work reliably.

Re #2: without these changes the tag browser produced invalid reqular expressions if an item began with a regexp special character.