### PR TITLE
Ignore AppleDouble files on ebook device

### DIFF
--- a/src/calibre/devices/usbms/driver.py
+++ b/src/calibre/devices/usbms/driver.py
@@ -239,6 +239,9 @@ class USBMS(CLI, Device):
 
         def update_booklist(filename, path, prefix):
             changed = False
+            # Ignore AppleDouble files
+            if filename.startswith("._"):
+                return False
             if path_to_ext(filename) in all_formats and self.is_allowed_book_file(filename, path, prefix):
                 try:
                     lpath = os.path.join(path, filename).partition(self.normalize_path(prefix))[2]


### PR DESCRIPTION
When macOS sends file to e-reader device, it also sends a AppleDouble format file has the same name with "._" prefix. Ignore these files so they won't be added to the device metadata file.