### PR TITLE
add zstd as a dependency

### DIFF
--- a/bypy/sources.json
+++ b/bypy/sources.json
@@ -996,5 +996,15 @@
             "hash": "sha256:1324b66b356051de662ba87d84f73ada062acd42b047ed1246e60a449f833e10",
             "urls": ["pypi"]
         }
+    },
+
+    {
+        "name": "zstd",
+        "os": "linux",
+        "unix": {
+            "filename": "zstd-1.5.4.tar.gz",
+            "hash": "sha256:0f470992aedad543126d06efab344dc5f3e171893810455787d38347343a4424",
+            "urls": ["https://github.com/facebook/zstd/releases/download/v1.5.4/{filename}"]
+        }
     }
 ]

--- a/bypy/sources.json
+++ b/bypy/sources.json
@@ -850,6 +850,16 @@
     },
 
     {
+        "name": "zstd",
+        "os": "linux",
+        "unix": {
+            "filename": "zstd-1.5.4.tar.gz",
+            "hash": "sha256:0f470992aedad543126d06efab344dc5f3e171893810455787d38347343a4424",
+            "urls": ["https://github.com/facebook/zstd/releases/download/v1.5.4/{filename}"]
+        }
+    },
+
+    {
         "name": "pyzstd",
 		"comment": "Needed by py7zr",
         "unix": {
@@ -995,16 +1005,6 @@
             "filename": "MacFSEvents-0.8.1.tar.gz",
             "hash": "sha256:1324b66b356051de662ba87d84f73ada062acd42b047ed1246e60a449f833e10",
             "urls": ["pypi"]
-        }
-    },
-
-    {
-        "name": "zstd",
-        "os": "linux",
-        "unix": {
-            "filename": "zstd-1.5.4.tar.gz",
-            "hash": "sha256:0f470992aedad543126d06efab344dc5f3e171893810455787d38347343a4424",
-            "urls": ["https://github.com/facebook/zstd/releases/download/v1.5.4/{filename}"]
         }
     }
 ]

--- a/bypy/sources.json
+++ b/bypy/sources.json
@@ -477,6 +477,16 @@
     },
 
     {
+        "name": "zstd",
+        "os": "linux",
+        "unix": {
+            "filename": "zstd-1.5.4.tar.gz",
+            "hash": "sha256:0f470992aedad543126d06efab344dc5f3e171893810455787d38347343a4424",
+            "urls": ["https://github.com/facebook/zstd/releases/download/v1.5.4/{filename}"]
+        }
+    },
+
+    {
         "name": "qt-base",
         "version": "6.4.2",
         "hashes": {
@@ -846,16 +856,6 @@
             "filename": "brotli-1.0.9.zip",
             "hash": "sha256:4d1b810aa0ed773f81dceda2cc7b403d01057458730e309856356d4ef4188438",
             "urls": ["pypi"]
-        }
-    },
-
-    {
-        "name": "zstd",
-        "os": "linux",
-        "unix": {
-            "filename": "zstd-1.5.4.tar.gz",
-            "hash": "sha256:0f470992aedad543126d06efab344dc5f3e171893810455787d38347343a4424",
-            "urls": ["https://github.com/facebook/zstd/releases/download/v1.5.4/{filename}"]
         }
     },
 


### PR DESCRIPTION
Since Qt has zstd enabled by default, most distributions build Qt with zstd enabled, some dynamically linked libraries with zstd enabled are called by the statically linked libraries bundled with Calibre, it's error-prone to build Calibre without zstd.

See also: https://github.com/flathub/com.calibre_ebook.calibre/issues/34#issuecomment-1435642018

---

You may squash this PR when you merge it if you want to