### PR TITLE
Fix improper use of double quotes.

### DIFF
--- a/src/calibre/db/backend.py
+++ b/src/calibre/db/backend.py
@@ -1385,8 +1385,8 @@ class DB:
     @property
     def custom_tables(self):
         return {x[0] for x in self.conn.get(
-            'SELECT name FROM sqlite_master WHERE type="table" AND '
-            '(name GLOB "custom_column_*" OR name GLOB "books_custom_column_*")')}
+            'SELECT name FROM sqlite_master WHERE type=\'table\' AND '
+            '(name GLOB \'custom_column_*\' OR name GLOB \'books_custom_column_*\')')}
 
     @classmethod
     def exists_at(cls, path):

--- a/src/calibre/db/schema_upgrades.py
+++ b/src/calibre/db/schema_upgrades.py
@@ -300,7 +300,7 @@ class SchemaUpgrade:
         for field in itervalues(self.field_metadata):
             if field['is_category'] and not field['is_custom'] and 'link_column' in field:
                 table = self.db.get(
-                    'SELECT name FROM sqlite_master WHERE type="table" AND name=?',
+                    'SELECT name FROM sqlite_master WHERE type=\'table\' AND name=?',
                     ('books_%s_link'%field['table'],), all=False)
                 if table is not None:
                     create_tag_browser_view(field['table'], field['link_column'], field['column'])
@@ -376,7 +376,7 @@ class SchemaUpgrade:
         for field in itervalues(self.field_metadata):
             if field['is_category'] and not field['is_custom'] and 'link_column' in field:
                 table = self.db.get(
-                    'SELECT name FROM sqlite_master WHERE type="table" AND name=?',
+                    'SELECT name FROM sqlite_master WHERE type=\'table\' AND name=?',
                     ('books_%s_link'%field['table'],), all=False)
                 if table is not None:
                     create_std_tag_browser_view(field['table'], field['link_column'],


### PR DESCRIPTION
SQLite has historically supported using double quotes for string literals against SQL standards.

The default for supporting this has been recently changed upstream [1] (6.f)

Ref: https://sqlite.org/quirks.html#dblquote
     https://www.sqlite.org/releaselog/3_41_0.html [1]

The patches I'm sending are what I've tested in FreeBSD, since the FreeBSD ports tree is following upstream practice and changing the default.