### PR TITLE
Fix using an integer constant for Qt.CheckState.Checked

### DIFF
--- a/src/calibre/gui2/preferences/create_custom_column.py
+++ b/src/calibre/gui2/preferences/create_custom_column.py
@@ -491,7 +491,7 @@ class CreateCustomColumn(QDialog):
             self.bool_button_group.setFocusProxy(button)
 
     def composite_show_in_comments_clicked(self, state):
-        if state == 2: # Qt.CheckState.Checked but passed as an int
+        if state == Qt.CheckState.Checked.value: # state is passed as an int
             self.composite_sort_by.setEnabled(False)
             self.composite_sort_by_label.setEnabled(False)
             self.composite_make_category.setEnabled(False)


### PR DESCRIPTION
Sorry about the churn, but this bothered me.