### PR TITLE
More efficient grayscaling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@
 /cmake-build-*
 /bypy/b
 /bypy/virtual-machines.conf
+/.vscode/

--- a/src/calibre/utils/img.py
+++ b/src/calibre/utils/img.py
@@ -449,8 +449,9 @@ def crop_image(img, x, y, width, height):
 # Image transformations {{{
 
 
-def grayscale_image(img):
-    return imageops.grayscale(image_from_data(img))
+def grayscale_image(img) -> QImage:
+    img: QImage = image_from_data(img)
+    return img.convertToFormat(QImage.Format.Format_Grayscale8)
 
 
 def set_image_opacity(img, alpha=0.5):


### PR DESCRIPTION
### The Problem
When converting a manga in the CBZ format to EPUB, I encountered that some of the png files where visibly unaltered, as they already were grayscale. But after the conversion some of them still grew 200% in file size! That is a lot of wasted disc space.

### The culprit
After some time inspecting the images using XnView, I found a difference. A PNG file can be saved with different [color types](https://en.wikipedia.org/wiki/PNG#Pixel_format). After conversion, the new PNG file is saved as RGB color, which uses 24 bit compared to the original Grayscale 8 bit.
My understanding is that this happens because we use imageops to do the grayscaling, but never tell PyQt6 that the PNG file itself now is grayscaled (it seems PyQt6 defaults to a 24 bit color format???). It's PyQt6 we use to save the file, so it's important that PyQt6 knows which format it should save as.

### The solution
Instead of using imageops as a middleman, just let PyQt6 handle the change in color format. As a side effect, PyQt6 automatically grayscales colored images when changing the format! On top of that, it seems PyQt6 grayscale conversion is much faster than imageops. Converting the one manga i used for testing took 37 seconds, but now only takes 22 seconds!

### Still some bad conversions
One of my visually unaltered PNG files still grew around 50%. These PNG images where originally saved with a color type XnView called "pallete". This color type were even more efficient. So maybe one should look even deeper into these different color formats, to save on disc space even further.