### PR TITLE
Added Kobo Libra 2 to output profiles

### DIFF
--- a/src/calibre/customize/profiles.py
+++ b/src/calibre/customize/profiles.py
@@ -504,6 +504,20 @@ class KoboReaderOutput(OutputProfile):
     fsizes                    = [7.5, 9, 10, 12, 15.5, 20, 22, 24]
 
 
+class KoboLibra2Output(OutputProfile):
+
+    name = 'Kobo Libra 2'
+    short_name = 'koboL2'
+
+    description = _('This profile is intended for the Kobo Libra 2.')
+
+    screen_size               = (1264, 1680)
+    comic_screen_size         = (1264, 1680)
+    dpi                       = 300
+    fbase                     = 12
+    fsizes                    = [7.5, 9, 10, 12, 15.5, 20, 22, 24]
+
+
 class SonyReader300Output(SonyReaderOutput):
 
     author      = 'John Schember'
@@ -906,7 +920,7 @@ output_profiles = [
     OutputProfile, SonyReaderOutput, SonyReader300Output, SonyReader900Output,
     SonyReaderT3Output, MSReaderOutput, MobipocketOutput, HanlinV3Output,
     HanlinV5Output, CybookG3Output, CybookOpusOutput, KindleOutput, iPadOutput,
-    iPad3Output, KoboReaderOutput, TabletOutput, SamsungGalaxy,
+    iPad3Output, KoboReaderOutput, KoboLibra2Output, TabletOutput, SamsungGalaxy,
     SonyReaderLandscapeOutput, KindleDXOutput, IlliadOutput, NookHD,
     IRexDR1000Output, IRexDR800Output, JetBook5Output, NookOutput,
     NookColorOutput, PocketBook900Output,


### PR DESCRIPTION
### Things I don't know
- if `fbase` and `fsizes` makes sense for the kobo libra 2 specifically. I just copied from the KoboReaderOutput class, thinking it would work nicely.

If someone can explain what fbase and fsizes does in practice, then I can test further on my own device to ensure correct settings.