### PR TITLE
This is a large commit.

### DIFF
--- a/manual/url_scheme.rst
+++ b/manual/url_scheme.rst
@@ -116,6 +116,16 @@ If you perform a search in calibre and want to generate a link for it you can
 do so by right clicking the search bar and choosing :guilabel:`Copy search as
 URL`.
 
+Open a book details window on a book in some library
+------------------------------------------------------
+
+The URL syntax is::
+
+    calibre://book-details/Library_Name/book_id
+
+This opens a book details window on the specified book from the specified library without changing the
+current library or the selected book.
+
 
 .. _hex_encoding:
 

--- a/src/calibre/db/backend.py
+++ b/src/calibre/db/backend.py
@@ -1121,6 +1121,7 @@ class DB:
                 CREATE TABLE %s(
                     id    INTEGER PRIMARY KEY AUTOINCREMENT,
                     value %s NOT NULL %s,
+                    link TEXT NOT NULL DEFAULT "",
                     UNIQUE(value));
                 '''%(table, dt, collate),
 

--- a/src/calibre/db/cache.py
+++ b/src/calibre/db/cache.py
@@ -2405,6 +2405,9 @@ class Cache:
         table = self.fields[field].table
         if not hasattr(table, 'link_map'):
             raise ValueError(f"Lookup name {field} doesn't have a link map")
+        # Clear the links for book cache as we don't know what will be affected
+        self.link_maps_cache = {}
+
         fids = {k: self.get_item_id(field, k) for k in value_to_link_map.keys()}
         id_to_link_map = {fid:value_to_link_map[k] for k, fid in fids.items() if fid is not None}
         result_map = table.set_links(id_to_link_map, self.backend)

--- a/src/calibre/db/cache.py
+++ b/src/calibre/db/cache.py
@@ -2397,6 +2397,8 @@ class Cache:
             values, not field ids.
 
         returns books changed by setting the link
+
+        NB: this method doesn't change values not in the value_to_link_map
         '''
         if field not in self.fields:
             raise ValueError(f'Lookup name {field} is not a valid name')

--- a/src/calibre/db/cache.py
+++ b/src/calibre/db/cache.py
@@ -291,7 +291,14 @@ class Cache:
             self.format_metadata_cache.clear()
         if search_cache:
             self._clear_search_caches(book_ids)
-        self.link_maps_cache = {}
+        self.clear_link_map_cache(book_ids)
+
+    def clear_link_map_cache(self, book_ids=None):
+        if book_ids is None:
+            self.link_maps_cache = {}
+        else:
+            for book in book_ids:
+                self.link_maps_cache.pop(book, None)
 
     @write_api
     def reload_from_db(self, clear_caches=True):
@@ -1487,6 +1494,7 @@ class Cache:
             if update_path and do_path_update:
                 self._update_path(dirtied, mark_as_dirtied=False)
             self._mark_as_dirty(dirtied)
+            self.clear_link_map_cache(dirtied)
             self.event_dispatcher(EventType.metadata_changed, name, dirtied)
         return dirtied
 
@@ -1502,6 +1510,7 @@ class Cache:
             self.format_metadata_cache.pop(book_id, None)
             if mark_as_dirtied:
                 self._mark_as_dirty(book_ids)
+            self.clear_link_map_cache(book_ids)
 
     @read_api
     def get_a_dirtied_book(self):
@@ -2161,6 +2170,7 @@ class Cache:
                 for book_id in moved_books:
                     self._set_field(f.index_field.name, {book_id:self._get_next_series_num_for(self._fast_field_for(f, book_id), field=field)})
             self._mark_as_dirty(affected_books)
+            self.clear_link_map_cache(affected_books)
         self.event_dispatcher(EventType.items_renamed, field, affected_books, id_map)
         return affected_books, id_map
 
@@ -2180,6 +2190,7 @@ class Cache:
                 self._set_field(field.index_field.name, {bid:1.0 for bid in affected_books})
             else:
                 self._mark_as_dirty(affected_books)
+            self.clear_link_map_cache(affected_books)
         self.event_dispatcher(EventType.items_removed, field, affected_books, item_ids)
         return affected_books
 
@@ -2314,6 +2325,7 @@ class Cache:
                 self._set_field('author_sort', val_map)
         if changed_books:
             self._mark_as_dirty(changed_books)
+            self.clear_link_map_cache(changed_books)
         return changed_books
 
     @write_api
@@ -2324,6 +2336,7 @@ class Cache:
             changed_books |= self._books_for_field('authors', author_id)
         if changed_books:
             self._mark_as_dirty(changed_books)
+            self.clear_link_map_cache(changed_books)
         return changed_books
 
     @read_api
@@ -2416,6 +2429,7 @@ class Cache:
             changed_books |= self._books_for_field(field, id_)
         if changed_books:
             self._mark_as_dirty(changed_books)
+            self.clear_link_map_cache(changed_books)
         return changed_books
 
     @read_api

--- a/src/calibre/db/fields.py
+++ b/src/calibre/db/fields.py
@@ -642,7 +642,7 @@ class AuthorsField(ManyToManyField):
         return {
             'name': self.table.id_map[author_id],
             'sort': self.table.asort_map[author_id],
-            'link': self.table.alink_map[author_id],
+            'link': self.table.link_map[author_id],
         }
 
     def category_sort_value(self, item_id, book_ids, lang_map):

--- a/src/calibre/db/lazy.py
+++ b/src/calibre/db/lazy.py
@@ -330,6 +330,9 @@ class ProxyMetadata(Metadata):
         sa(self, '_user_metadata', db.field_metadata)
 
     def __getattribute__(self, field):
+        if field == 'link_maps':
+            db = ga(self, '_db')()
+            return db.get_all_link_maps_for_book(ga(self, '_book_id'))
         getter = getters.get(field, None)
         if getter is not None:
             return getter(ga(self, '_db'), ga(self, '_book_id'), ga(self, '_cache'))

--- a/src/calibre/db/lazy.py
+++ b/src/calibre/db/lazy.py
@@ -330,9 +330,6 @@ class ProxyMetadata(Metadata):
         sa(self, '_user_metadata', db.field_metadata)
 
     def __getattribute__(self, field):
-        if field == 'link_maps':
-            db = ga(self, '_db')()
-            return db.get_all_link_maps_for_book(ga(self, '_book_id'))
         getter = getters.get(field, None)
         if getter is not None:
             return getter(ga(self, '_db'), ga(self, '_book_id'), ga(self, '_cache'))
@@ -353,6 +350,10 @@ class ProxyMetadata(Metadata):
                     return series_index_getter(field[:-6])(ga(self, '_db'), ga(self, '_book_id'), ga(self, '_cache'))
                 return custom_getter(field, ga(self, '_db'), ga(self, '_book_id'), ga(self, '_cache'))
             return composite_getter(self, field, ga(self, '_db'), ga(self, '_book_id'), ga(self, '_cache'), ga(self, 'formatter'), ga(self, 'template_cache'))
+
+        if field == 'link_maps':
+            db = ga(self, '_db')()
+            return db.get_all_link_maps_for_book(ga(self, '_book_id'))
 
         try:
             return ga(self, '_cache')[field]

--- a/src/calibre/db/schema_upgrades.py
+++ b/src/calibre/db/schema_upgrades.py
@@ -793,3 +793,28 @@ CREATE TRIGGER fkc_annot_update
 
     def upgrade_version_24(self):
         self.db.reindex_annotations()
+
+    def upgrade_version_25(self):
+        for record in self.db.execute(
+                'SELECT label,name,datatype,editable,display,normalized,id,is_multiple FROM custom_columns'):
+            data = {
+                    'label':record[0],
+                    'name':record[1],
+                    'datatype':record[2],
+                    'editable':bool(record[3]),
+                    'display':record[4],
+                    'normalized':bool(record[5]),
+                    'num':record[6],
+                    'is_multiple':bool(record[7]),
+                    }
+            if data['normalized']:
+                tn = 'custom_column_{}'.format(data['num'])
+                self.db.execute(f'ALTER TABLE {tn} ADD COLUMN link TEXT NOT NULL DEFAULT "";')
+        self.db.execute('ALTER TABLE publishers ADD COLUMN link TEXT NOT NULL DEFAULT "";')
+        self.db.execute('ALTER TABLE series ADD COLUMN link TEXT NOT NULL DEFAULT "";')
+        self.db.execute('ALTER TABLE tags ADD COLUMN link TEXT NOT NULL DEFAULT "";')
+        # These aren't necessary in that there is no UI to set links, but having them
+        # makes the code uniform
+        self.db.execute('ALTER TABLE languages ADD COLUMN link TEXT NOT NULL DEFAULT "";')
+        self.db.execute('ALTER TABLE ratings ADD COLUMN link TEXT NOT NULL DEFAULT "";')
+

--- a/src/calibre/db/schema_upgrades.py
+++ b/src/calibre/db/schema_upgrades.py
@@ -795,6 +795,7 @@ CREATE TRIGGER fkc_annot_update
         self.db.reindex_annotations()
 
     def upgrade_version_25(self):
+        alters = []
         for record in self.db.execute(
                 'SELECT label,name,datatype,editable,display,normalized,id,is_multiple FROM custom_columns'):
             data = {
@@ -809,12 +810,14 @@ CREATE TRIGGER fkc_annot_update
                     }
             if data['normalized']:
                 tn = 'custom_column_{}'.format(data['num'])
-                self.db.execute(f'ALTER TABLE {tn} ADD COLUMN link TEXT NOT NULL DEFAULT "";')
-        self.db.execute('ALTER TABLE publishers ADD COLUMN link TEXT NOT NULL DEFAULT "";')
-        self.db.execute('ALTER TABLE series ADD COLUMN link TEXT NOT NULL DEFAULT "";')
-        self.db.execute('ALTER TABLE tags ADD COLUMN link TEXT NOT NULL DEFAULT "";')
+                alters.append(f'ALTER TABLE {tn} ADD COLUMN link TEXT NOT NULL DEFAULT "";')
+
+        alters.append('ALTER TABLE publishers ADD COLUMN link TEXT NOT NULL DEFAULT "";')
+        alters.append('ALTER TABLE series ADD COLUMN link TEXT NOT NULL DEFAULT "";')
+        alters.append('ALTER TABLE tags ADD COLUMN link TEXT NOT NULL DEFAULT "";')
         # These aren't necessary in that there is no UI to set links, but having them
         # makes the code uniform
-        self.db.execute('ALTER TABLE languages ADD COLUMN link TEXT NOT NULL DEFAULT "";')
-        self.db.execute('ALTER TABLE ratings ADD COLUMN link TEXT NOT NULL DEFAULT "";')
+        alters.append('ALTER TABLE languages ADD COLUMN link TEXT NOT NULL DEFAULT "";')
+        alters.append('ALTER TABLE ratings ADD COLUMN link TEXT NOT NULL DEFAULT "";')
+        self.db.execute('\n'.join(alters))
 

--- a/src/calibre/db/tables.py
+++ b/src/calibre/db/tables.py
@@ -199,19 +199,22 @@ class ManyToOneTable(Table):
 
     def read(self, db):
         self.id_map = {}
+        self.link_map = {}
         self.col_book_map = defaultdict(set)
         self.book_col_map = {}
         self.read_id_maps(db)
         self.read_maps(db)
 
     def read_id_maps(self, db):
-        query = db.execute('SELECT id, {} FROM {}'.format(
+        query = db.execute('SELECT id, {}, link FROM {}'.format(
             self.metadata['column'], self.metadata['table']))
         if self.unserialize is None:
-            self.id_map = dict(query)
+            us = lambda x: x
         else:
             us = self.unserialize
-            self.id_map = {book_id:us(val) for book_id, val in query}
+        for id_, val, link in query:
+            self.id_map[id_] = us(val)
+            self.link_map[id_] = link
 
     def read_maps(self, db):
         cbm = self.col_book_map
@@ -342,6 +345,14 @@ class ManyToOneTable(Table):
             db.execute('UPDATE {0} SET {1}=? WHERE {1}=?; DELETE FROM {2} WHERE id=?'.format(
                 self.link_table, lcol, table), (existing_item, item_id, item_id))
         return affected_books, new_id
+
+    def set_links(self, link_map, db):
+        link_map = {id_:(l or '').strip() for id_, l in iteritems(link_map)}
+        link_map = {id_:l for id_, l in iteritems(link_map) if l != self.link_map.get(id_)}
+        self.link_map.update(link_map)
+        db.executemany(f'UPDATE {self.metadata["table"]} SET link=? WHERE id=?',
+            [(v, k) for k, v in iteritems(link_map)])
+        return link_map
 
 
 class RatingTable(ManyToOneTable):
@@ -526,7 +537,7 @@ class ManyToManyTable(ManyToOneTable):
 class AuthorsTable(ManyToManyTable):
 
     def read_id_maps(self, db):
-        self.alink_map = lm = {}
+        self.link_map = lm = {}
         self.asort_map = sm = {}
         self.id_map = im = {}
         us = self.unserialize
@@ -547,8 +558,8 @@ class AuthorsTable(ManyToManyTable):
 
     def set_links(self, link_map, db):
         link_map = {aid:(l or '').strip() for aid, l in iteritems(link_map)}
-        link_map = {aid:l for aid, l in iteritems(link_map) if l != self.alink_map.get(aid, None)}
-        self.alink_map.update(link_map)
+        link_map = {aid:l for aid, l in iteritems(link_map) if l != self.link_map.get(aid, None)}
+        self.link_map.update(link_map)
         db.executemany('UPDATE authors SET link=? WHERE id=?',
             [(v, k) for k, v in iteritems(link_map)])
         return link_map
@@ -556,14 +567,14 @@ class AuthorsTable(ManyToManyTable):
     def remove_books(self, book_ids, db):
         clean = ManyToManyTable.remove_books(self, book_ids, db)
         for item_id in clean:
-            self.alink_map.pop(item_id, None)
+            self.link_map.pop(item_id, None)
             self.asort_map.pop(item_id, None)
         return clean
 
     def rename_item(self, item_id, new_name, db):
         ret = ManyToManyTable.rename_item(self, item_id, new_name, db)
         if item_id not in self.id_map:
-            self.alink_map.pop(item_id, None)
+            self.link_map.pop(item_id, None)
             self.asort_map.pop(item_id, None)
         else:
             # Was a simple rename, update the author sort value

--- a/src/calibre/db/tests/add_remove.py
+++ b/src/calibre/db/tests/add_remove.py
@@ -225,7 +225,7 @@ class AddRemoveTest(BaseTest):
             self.assertNotIn(3, c.all_book_ids())
             self.assertNotIn('Unknown', set(itervalues(table.id_map)))
             self.assertNotIn(item_id, table.asort_map)
-            self.assertNotIn(item_id, table.alink_map)
+            self.assertNotIn(item_id, table.link_map)
             ae(len(table.id_map), olen-1)
 
         # Check that files are removed

--- a/src/calibre/db/tests/writing.py
+++ b/src/calibre/db/tests/writing.py
@@ -922,11 +922,13 @@ class WritingTest(BaseTest):
     def test_link_maps(self):
         cache = self.init_cache()
 
+        # Add two tags
         cache.set_field('tags', {1:'foo'})
         self.assertEqual(('foo',), cache.field_for('tags', 1), 'Setting tag foo failed')
         cache.set_field('tags', {1:'foo, bar'})
         self.assertEqual(('foo', 'bar'), cache.field_for('tags', 1), 'Adding second tag failed')
 
+        # Check adding a link
         links = cache.get_link_map('tags')
         self.assertDictEqual(links, {}, 'Initial tags link dict is not empty')
         links['foo'] = 'url'
@@ -934,13 +936,26 @@ class WritingTest(BaseTest):
         links2 = cache.get_link_map('tags')
         self.assertDictEqual(links2, links, 'tags link dict mismatch')
 
+        # Check getting links for a book and that links are correct
         cache.set_field('publisher', {1:'random'})
         cache.set_link_map('publisher', {'random': 'url2'})
-
         links = cache.get_all_link_maps_for_book(1)
-        self.assert_('foo' in links['tags'], 'foo not there')
-        self.assert_('bar' not in links['tags'], 'bar is there')
-        self.assert_('random' in links['publisher'], 'random is not there')
-        self.assertSetEqual({'tags', 'publisher'}, set(links.keys()), 'Link map has extra stuff')
+        self.assertSetEqual({v for v in links.keys()}, {'tags', 'publisher'}, 'Wrong link keys')
+        self.assertSetEqual({v for v in links['tags'].keys()}, {'foo', }, 'Should be "foo"')
+        self.assertSetEqual({v for v in links['publisher'].keys()}, {'random', }, 'Should be "random"')
+        self.assertEqual('url', links['tags']['foo'], 'link for tag foo is wrong')
+        self.assertEqual('url2', links['publisher']['random'], 'link for publisher random is wrong')
+
+        # Now test deleting the links.
+        links = cache.get_link_map('tags')
+        to_del = {l:'' for l in links.keys()}
+        cache.set_link_map('tags', to_del)
+        self.assertEqual({}, cache.get_link_map('tags'), 'links on tags were not deleted')
+        links = cache.get_link_map('publisher')
+        to_del = {l:'' for l in links.keys()}
+        cache.set_link_map('publisher', to_del)
+        self.assertEqual({}, cache.get_link_map('publisher'), 'links on publisher were not deleted')
+        self.assertEqual({}, cache.get_all_link_maps_for_book(1), 'Not all links for book were deleted')
+
 
     # }}}

--- a/src/calibre/db/tests/writing.py
+++ b/src/calibre/db/tests/writing.py
@@ -919,4 +919,28 @@ class WritingTest(BaseTest):
         ae(cache.field_for('series_index', 1), 2.0)
         ae(cache.field_for('series_index', 2), 3.5)
 
+    def test_link_maps(self):
+        cache = self.init_cache()
+
+        cache.set_field('tags', {1:'foo'})
+        self.assertEqual(('foo',), cache.field_for('tags', 1), 'Setting tag foo failed')
+        cache.set_field('tags', {1:'foo, bar'})
+        self.assertEqual(('foo', 'bar'), cache.field_for('tags', 1), 'Adding second tag failed')
+
+        links = cache.get_link_map('tags')
+        self.assertDictEqual(links, {}, 'Initial tags link dict is not empty')
+        links['foo'] = 'url'
+        cache.set_link_map('tags', links)
+        links2 = cache.get_link_map('tags')
+        self.assertDictEqual(links2, links, 'tags link dict mismatch')
+
+        cache.set_field('publisher', {1:'random'})
+        cache.set_link_map('publisher', {'random': 'url2'})
+
+        links = cache.get_all_link_maps_for_book(1)
+        self.assert_('foo' in links['tags'], 'foo not there')
+        self.assert_('bar' not in links['tags'], 'bar is there')
+        self.assert_('random' in links['publisher'], 'random is not there')
+        self.assertSetEqual({'tags', 'publisher'}, set(links.keys()), 'Link map has extra stuff')
+
     # }}}

--- a/src/calibre/db/write.py
+++ b/src/calibre/db/write.py
@@ -295,7 +295,8 @@ def get_db_id(val, db, m, table, kmap, rid_map, allow_case_change,
         table.col_book_map[item_id] = set()
         if is_authors:
             table.asort_map[item_id] = aus
-            table.alink_map[item_id] = ''
+        if hasattr(table, 'link_map'):
+            table.link_map[item_id] = ''
     elif allow_case_change and val != table.id_map[item_id]:
         case_changes[item_id] = val
     val_map[val] = item_id
@@ -491,7 +492,8 @@ def many_many(book_id_val_map, db, field, allow_case_change, *args):
             table.col_book_map.pop(item_id, None)
             if is_authors:
                 table.asort_map.pop(item_id, None)
-                table.alink_map.pop(item_id, None)
+            if hasattr(table, 'link_map'):
+                table.link_map.pop(item_id, None)
 
     return dirtied
 

--- a/src/calibre/ebooks/metadata/book/render.py
+++ b/src/calibre/ebooks/metadata/book/render.py
@@ -91,6 +91,24 @@ def mi_to_html(
         rating_font='Liberation Serif', rtl=False, comments_heading_pos='hide',
         for_qt=False, vertical_fields=()
     ):
+
+    show_links = not hasattr(mi, '_bd_dbwref')
+
+    def get_link_map(column):
+        if not show_links:
+            return {}
+        try:
+            return mi.link_maps[column]
+        except (KeyError, ValueError):
+            return {column:{}}
+
+    def add_other_link(field, field_value):
+        link = get_link_map(field).get(field_value, None)
+        if link:
+            return (' <a title="%s" href="%s">%s</a>'%(_('Click to open {}').format(link), link, _('(item link)')))
+        else:
+            return ''
+
     if field_list is None:
         field_list = get_field_list(mi)
     ans = []
@@ -170,9 +188,12 @@ def mi_to_html(
                     else:
                         all_vals = [v.strip()
                             for v in val.split(metadata['is_multiple']['cache_to_list']) if v.strip()]
-                        links = ['<a href="{}" title="{}">{}</a>'.format(
-                            search_action(field, x), _('Click to see books with {0}: {1}').format(
+                        if show_links:
+                            links = ['<a href="{}" title="{}">{}</a>'.format(
+                                search_action(field, x), _('Click to see books with {0}: {1}').format(
                                      metadata['name'], a(x)), p(x)) for x in all_vals]
+                        else:
+                            links = all_vals
                         val = value_list(metadata['is_multiple']['list_to_ui'], links)
                     ans.append((field, row % (name, val)))
         elif field == 'path':
@@ -188,10 +209,15 @@ def mi_to_html(
                         durl = ':::'.join((durl.split(':::'))[2:])
                     extra = '<br><span style="font-size:smaller">%s</span>'%(
                             prepare_string_for_xml(durl))
-                link = '<a href="{}" title="{}">{}</a>{}'.format(action(scheme, loc=loc),
+                if show_links:
+                    link = '<a href="{}" title="{}">{}</a>{}'.format(action(scheme, loc=loc),
                         prepare_string_for_xml(path, True), pathstr, extra)
+                else:
+                    link = prepare_string_for_xml(path, True)
                 ans.append((field, row % (name, link)))
         elif field == 'formats':
+            # Don't need show_links here because formats are removed from mi on
+            # cross library displays.
             if isdevice:
                 continue
             path = mi.path or ''
@@ -209,12 +235,15 @@ def mi_to_html(
             ans.append((field, row % (name, value_list(', ', fmts))))
         elif field == 'identifiers':
             urls = urls_from_identifiers(mi.identifiers, sort_results=True)
-            links = [
-                '<a href="{}" title="{}:{}">{}</a>'.format(
-                    action('identifier', url=url, name=namel, id_type=id_typ, value=id_val, field='identifiers', book_id=book_id),
-                    a(id_typ), a(id_val), p(namel))
-                for namel, id_typ, id_val, url in urls]
-            links = value_list(', ', links)
+            if show_links:
+                links = [
+                    '<a href="{}" title="{}:{}">{}</a>'.format(
+                        action('identifier', url=url, name=namel, id_type=id_typ, value=id_val, field='identifiers', book_id=book_id),
+                        a(id_typ), a(id_val), p(namel))
+                    for namel, id_typ, id_val, url in urls]
+                links = value_list(', ', links)
+            else:
+                links = ', '.join(mi.identifiers)
             if links:
                 ans.append((field, row % (_('Ids')+':', links)))
         elif field == 'authors':
@@ -222,39 +251,46 @@ def mi_to_html(
             formatter = EvalFormatter()
             for aut in mi.authors:
                 link = ''
-                if mi.author_link_map.get(aut):
-                    link = lt = mi.author_link_map[aut]
-                elif default_author_link:
-                    if default_author_link.startswith('search-'):
-                        which_src = default_author_link.partition('-')[2]
-                        link, lt = author_search_href(which_src, title=mi.title, author=aut)
+                if show_links:
+                    if default_author_link:
+                        if default_author_link.startswith('search-'):
+                            which_src = default_author_link.partition('-')[2]
+                            link, lt = author_search_href(which_src, title=mi.title, author=aut)
+                        else:
+                            vals = {'author': qquote(aut), 'title': qquote(mi.title)}
+                            try:
+                                vals['author_sort'] =  qquote(mi.author_sort_map[aut])
+                            except KeyError:
+                                vals['author_sort'] = qquote(aut)
+                            link = lt = formatter.safe_format(default_author_link, vals, '', vals)
                     else:
-                        vals = {'author': qquote(aut), 'title': qquote(mi.title)}
-                        try:
-                            vals['author_sort'] =  qquote(mi.author_sort_map[aut])
-                        except KeyError:
-                            vals['author_sort'] = qquote(aut)
-                        link = lt = formatter.safe_format(default_author_link, vals, '', vals)
-                aut = p(aut)
+                        aut = p(aut)
                 if link:
-                    authors.append('<a title="%s" href="%s">%s</a>'%(a(lt), action('author', url=link, name=aut, title=lt), aut))
+                    val = '<a title="%s" href="%s">%s</a>'%(a(lt), action('author', url=link, name=aut, title=lt), aut)
                 else:
-                    authors.append(aut)
+                    val = aut
+                val += add_other_link('authors', aut)
+                authors.append(val)
             ans.append((field, row % (name, value_list(' & ', authors))))
         elif field == 'languages':
             if not mi.languages:
                 continue
             names = filter(None, map(calibre_langcode_to_name, mi.languages))
-            names = ['<a href="{}" title="{}">{}</a>'.format(search_action_with_data('languages', n, book_id), _(
-                'Search calibre for books with the language: {}').format(n), n) for n in names]
+            if show_links:
+                names = ['<a href="{}" title="{}">{}</a>'.format(search_action_with_data('languages', n, book_id), _(
+                    'Search calibre for books with the language: {}').format(n), n) for n in names]
             ans.append((field, row % (name, value_list(', ', names))))
         elif field == 'publisher':
             if not mi.publisher:
                 continue
-            val = '<a href="{}" title="{}">{}</a>'.format(
-                search_action_with_data('publisher', mi.publisher, book_id),
-                _('Click to see books with {0}: {1}').format(metadata['name'], a(mi.publisher)),
-                p(mi.publisher))
+            if show_links:
+                val = '<a href="{}" title="{}">{}</a>'.format(
+                    search_action_with_data('publisher', mi.publisher, book_id),
+                    _('Click to see books with {0}: {1}').format(metadata['name'], a(mi.publisher)),
+                    p(mi.publisher))
+                val += add_other_link('publisher', mi.publisher)
+            else:
+                val = p(mi.publisher)
             ans.append((field, row % (name, val)))
         elif field == 'title':
             # otherwise title gets metadata['datatype'] == 'text'
@@ -268,79 +304,85 @@ def mi_to_html(
             if val is None:
                 continue
             val = p(val)
-            if metadata['datatype'] == 'series':
-                sidx = mi.get(field+'_index')
-                if sidx is None:
-                    sidx = 1.0
-                try:
-                    st = metadata['search_terms'][0]
-                except Exception:
-                    st = field
-                series = getattr(mi, field)
-                val = _(
-                    '%(sidx)s of <a href="%(href)s" title="%(tt)s">'
-                    '<span class="%(cls)s">%(series)s</span></a>') % dict(
-                        sidx=fmt_sidx(sidx, use_roman=use_roman_numbers), cls="series_name",
-                        series=p(series), href=search_action_with_data(st, series, book_id, field),
-                        tt=p(_('Click to see books in this series')))
-            elif metadata['datatype'] == 'datetime':
-                aval = getattr(mi, field)
-                if is_date_undefined(aval):
-                    continue
-                aval = format_date(aval, 'yyyy-MM-dd')
-                key = field if field != 'timestamp' else 'date'
-                if val == aval:
-                    val = '<a href="{}" title="{}">{}</a>'.format(
-                        search_action_with_data(key, str(aval), book_id, None, original_value=val), a(
-                            _('Click to see books with {0}: {1}').format(metadata['name'] or field, val)), val)
-                else:
-                    val = '<a href="{}" title="{}">{}</a>'.format(
-                        search_action_with_data(key, str(aval), book_id, None, original_value=val), a(
-                            _('Click to see books with {0}: {1} (derived from {2})').format(
-                                metadata['name'] or field, aval, val)), val)
-            elif metadata['datatype'] == 'text' and metadata['is_multiple']:
-                try:
-                    st = metadata['search_terms'][0]
-                except Exception:
-                    st = field
-                all_vals = mi.get(field)
-                if not metadata.get('display', {}).get('is_names', False):
-                    all_vals = sorted(all_vals, key=sort_key)
-                links = ['<a href="{}" title="{}">{}</a>'.format(
-                    search_action_with_data(st, x, book_id, field), _('Click to see books with {0}: {1}').format(
-                        metadata['name'] or field, a(x)), p(x))
-                         for x in all_vals]
-                val = value_list(metadata['is_multiple']['list_to_ui'], links)
-            elif metadata['datatype'] == 'text' or metadata['datatype'] == 'enumeration':
-                # text/is_multiple handled above so no need to add the test to the if
-                try:
-                    st = metadata['search_terms'][0]
-                except Exception:
-                    st = field
-                val = '<a href="{}" title="{}">{}</a>'.format(
-                    search_action_with_data(st, unescaped_val, book_id, field), a(
-                        _('Click to see books with {0}: {1}').format(metadata['name'] or field, val)), val)
-            elif metadata['datatype'] == 'bool':
-                val = '<a href="{}" title="{}">{}</a>'.format(
-                    search_action_with_data(field, val, book_id, None), a(
-                        _('Click to see books with {0}: {1}').format(metadata['name'] or field, val)), val)
-            else:
-                try:
-                    aval = str(getattr(mi, field))
-                    if not aval:
+            if show_links:
+                if metadata['datatype'] == 'series':
+                    sidx = mi.get(field+'_index')
+                    if sidx is None:
+                        sidx = 1.0
+                    try:
+                        st = metadata['search_terms'][0]
+                    except Exception:
+                        st = field
+                    series = getattr(mi, field)
+                    val = _(
+                        '%(sidx)s of <a href="%(href)s" title="%(tt)s">'
+                        '<span class="%(cls)s">%(series)s</span></a>') % dict(
+                            sidx=fmt_sidx(sidx, use_roman=use_roman_numbers), cls="series_name",
+                            series=p(series), href=search_action_with_data(st, series, book_id, field),
+                            tt=p(_('Click to see books in this series')))
+                    val += add_other_link('series', mi.series)
+                elif metadata['datatype'] == 'datetime':
+                    aval = getattr(mi, field)
+                    if is_date_undefined(aval):
                         continue
+                    aval = format_date(aval, 'yyyy-MM-dd')
+                    key = field if field != 'timestamp' else 'date'
                     if val == aval:
                         val = '<a href="{}" title="{}">{}</a>'.format(
-                            search_action_with_data(field, str(aval), book_id, None, original_value=val), a(
+                            search_action_with_data(key, str(aval), book_id, None, original_value=val), a(
                                 _('Click to see books with {0}: {1}').format(metadata['name'] or field, val)), val)
                     else:
                         val = '<a href="{}" title="{}">{}</a>'.format(
-                            search_action_with_data(field, str(aval), book_id, None, original_value=val), a(
+                            search_action_with_data(key, str(aval), book_id, None, original_value=val), a(
                                 _('Click to see books with {0}: {1} (derived from {2})').format(
                                     metadata['name'] or field, aval, val)), val)
-                except Exception:
-                    import traceback
-                    traceback.print_exc()
+                elif metadata['datatype'] == 'text' and metadata['is_multiple']:
+                    try:
+                        st = metadata['search_terms'][0]
+                    except Exception:
+                        st = field
+                    all_vals = mi.get(field)
+                    if not metadata.get('display', {}).get('is_names', False):
+                        all_vals = sorted(all_vals, key=sort_key)
+                    links = []
+                    for x in all_vals:
+                        v = '<a href="{}" title="{}">{}</a>'.format(
+                            search_action_with_data(st, x, book_id, field), _('Click to see books with {0}: {1}').format(
+                            metadata['name'] or field, a(x)), p(x))
+                        v += add_other_link(field, x)
+                        links.append(v)
+                    val = value_list(metadata['is_multiple']['list_to_ui'], links)
+                elif metadata['datatype'] == 'text' or metadata['datatype'] == 'enumeration':
+                    # text/is_multiple handled above so no need to add the test to the if
+                    try:
+                        st = metadata['search_terms'][0]
+                    except Exception:
+                        st = field
+                    v = '<a href="{}" title="{}">{}</a>'.format(
+                        search_action_with_data(st, unescaped_val, book_id, field), a(
+                            _('Click to see books with {0}: {1}').format(metadata['name'] or field, val)), val)
+                    val = v + add_other_link(field, val)
+                elif metadata['datatype'] == 'bool':
+                    val = '<a href="{}" title="{}">{}</a>'.format(
+                        search_action_with_data(field, val, book_id, None), a(
+                            _('Click to see books with {0}: {1}').format(metadata['name'] or field, val)), val)
+                else:
+                    try:
+                        aval = str(getattr(mi, field))
+                        if not aval:
+                            continue
+                        if val == aval:
+                            val = '<a href="{}" title="{}">{}</a>'.format(
+                                search_action_with_data(field, str(aval), book_id, None, original_value=val), a(
+                                    _('Click to see books with {0}: {1}').format(metadata['name'] or field, val)), val)
+                        else:
+                            val = '<a href="{}" title="{}">{}</a>'.format(
+                                search_action_with_data(field, str(aval), book_id, None, original_value=val), a(
+                                    _('Click to see books with {0}: {1} (derived from {2})').format(
+                                        metadata['name'] or field, aval, val)), val)
+                    except Exception:
+                        import traceback
+                        traceback.print_exc()
 
             ans.append((field, row % (name, val)))
 

--- a/src/calibre/ebooks/metadata/opf2.py
+++ b/src/calibre/ebooks/metadata/opf2.py
@@ -595,6 +595,8 @@ class OPF:  # {{{
                                     renderer=dump_dict)
     author_link_map = MetadataField('author_link_map', is_dc=False,
                                 formatter=json.loads, renderer=dump_dict)
+    link_map = MetadataField('link_maps', is_dc=False,
+                                formatter=json.loads, renderer=dump_dict)
 
     def __init__(self, stream, basedir=os.getcwd(), unquote_urls=True,
             populate_spine=True, try_to_guess_cover=False, preparsed_opf=None, read_toc=True):
@@ -1310,7 +1312,7 @@ class OPF:  # {{{
         for attr in ('title', 'authors', 'author_sort', 'title_sort',
                      'publisher', 'series', 'series_index', 'rating',
                      'isbn', 'tags', 'category', 'comments', 'book_producer',
-                     'pubdate', 'user_categories', 'author_link_map'):
+                     'pubdate', 'user_categories', 'author_link_map', 'link_map'):
             val = getattr(mi, attr, None)
             if attr == 'rating' and val:
                 val = float(val)
@@ -1673,6 +1675,8 @@ def metadata_to_opf(mi, as_string=True, default_lang=None):
         return factory('meta', name='calibre:' + n, content=c)
     if getattr(mi, 'author_link_map', None) is not None:
         meta('author_link_map', dump_dict(mi.author_link_map))
+    if getattr(mi, 'link_maps', None) is not None:
+        meta('link_maps', dump_dict(mi.link_maps))
     if mi.series:
         meta('series', mi.series)
     if mi.series_index is not None:

--- a/src/calibre/gui2/actions/show_book_details.py
+++ b/src/calibre/gui2/actions/show_book_details.py
@@ -23,25 +23,61 @@ class ShowBookDetailsAction(InterfaceAction):
     def genesis(self):
         self.qaction.triggered.connect(self.show_book_info)
         self.memory = []
+        self.dialogs = [None, ]
 
-    def show_book_info(self, *args):
+    def show_book_info(self, *args, **kwargs):
         if self.gui.current_view() is not self.gui.library_view:
             error_dialog(self.gui, _('No detailed info available'),
                 _('No detailed information is available for books '
                   'on the device.')).exec()
             return
+        library_path = kwargs.get('library_path', None)
+        book_id = kwargs.get('book_id', None)
+        library_id = kwargs.get('library_id', None)
+        query = kwargs.get('query', None)
         index = self.gui.library_view.currentIndex()
-        if index.isValid():
-            d = BookInfo(self.gui, self.gui.library_view, index,
-                    self.gui.book_details.handle_click)
+        if library_path or index.isValid():
+            # Window #0 is slaved to changes in the book list. As such
+            # it must not be used for details from other libraries.
+            for dn,v in enumerate(self.dialogs):
+                if dn == 0 and library_path:
+                    continue
+                if v is None:
+                    break
+            else:
+                self.dialogs.append(None)
+                dn += 1
+
+            try:
+                d = BookInfo(self.gui, self.gui.library_view, index,
+                        self.gui.book_details.handle_click, dialog_number=dn,
+                        library_id=library_id, library_path=library_path, book_id=book_id, query=query)
+            except ValueError as e:
+                error_dialog(self.gui, _('Book not found'), str(e)).exec()
+                return
+
             d.open_cover_with.connect(self.gui.bd_open_cover_with, type=Qt.ConnectionType.QueuedConnection)
+            self.dialogs[dn] = d
             self.memory.append(d)
             d.closed.connect(self.closed, type=Qt.ConnectionType.QueuedConnection)
             d.show()
 
+    def shutting_down(self):
+        for d in self.dialogs:
+            if d:
+                d.done(0)
+
+    def library_about_to_change(self, *args):
+        for i,d in enumerate(self.dialogs):
+            if i == 0:
+                continue
+            if d:
+                d.done(0)
+
     def closed(self, d):
         try:
             d.closed.disconnect(self.closed)
+            self.dialogs[d.dialog_number] = None
             self.memory.remove(d)
         except ValueError:
             pass

--- a/src/calibre/gui2/dialogs/tag_list_editor.py
+++ b/src/calibre/gui2/dialogs/tag_list_editor.py
@@ -546,6 +546,8 @@ class TagListEditor(QDialog, Ui_TagListEditor):
         self.table.blockSignals(False)
 
     def finish_editing(self, edited_item):
+        if edited_item.column != 0:
+            return
         if not edited_item.text():
             error_dialog(self, _('Item is blank'), _(
                 'An item cannot be set to nothing. Delete it instead.'), show=True)
@@ -680,7 +682,5 @@ class TagListEditor(QDialog, Ui_TagListEditor):
     def accepted(self):
         self.links = {}
         for r in range(0, self.table.rowCount()):
-            l = self.table.item(r, 3).text()
-            if l:
-                self.links[self.table.item(r, 0).text()] = l
+            self.links[self.table.item(r, 0).text()] = self.table.item(r, 3).text()
         self.save_geometry()

--- a/src/calibre/gui2/ui.py
+++ b/src/calibre/gui2/ui.py
@@ -690,6 +690,22 @@ class Main(MainWindow, MainWindowMixin, DeviceMixin, EmailMixin,  # {{{
             library_path = self.library_broker.path_for_library_id(library_id)
             if not db_matches(self.current_db, library_id, library_path):
                 self.library_moved(library_path)
+        elif action == 'book-details':
+            parts = tuple(filter(None, path.split('/')))
+            if len(parts) != 2:
+                return
+            library_id, book_id = parts
+            library_id = decode_library_id(library_id)
+            library_path = self.library_broker.path_for_library_id(library_id)
+            if library_path is None:
+                return
+            try:
+                book_id = int(book_id)
+            except Exception:
+                prints('Ignoring invalid book id', book_id, file=sys.stderr)
+                return
+            details = self.iactions['Show Book Details']
+            details.show_book_info(library_id=library_id, library_path=library_path, book_id=book_id)
         elif action == 'show-book':
             parts = tuple(filter(None, path.split('/')))
             if len(parts) != 2:


### PR DESCRIPTION
DB changes:
1) Add link columns to "normalized" tables. All such in-memory tables have an attribute self.link_map.
2) Add API to set and get links for fields
3) get_metadata now includes an attribute giving the link maps for the book. Book link maps are cached.
4) ProxyMetadata can return link maps
5) Added a test for the API.

URL Scheme:
1) Added a "book-details" URL that asks calibre to open a book info window on a book in some library

Book Details:
1) You can now have multiple book info windows.
2) If an item as an associated link then that link is made available using "(item link)" link text.
3) Book info windows on books in other libraries have no links

UI:
1) the Manage Category editor presents a fourth column for links.

OPF:
1) The OPF used for backing up (metadata.opf) contains the link map for the book. Currently this isn't used, but it should be used in recover_database. I didn't do anything with OPF3.