### PR TITLE
Better implied comic conversion of grayscale images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@
 /cmake-build-*
 /bypy/b
 /bypy/virtual-machines.conf
+/.vscode/

--- a/src/calibre/utils/img.py
+++ b/src/calibre/utils/img.py
@@ -449,8 +449,9 @@ def crop_image(img, x, y, width, height):
 # Image transformations {{{
 
 
-def grayscale_image(img):
-    return imageops.grayscale(image_from_data(img))
+def grayscale_image(img) -> QImage:
+    img: QImage = image_from_data(img)
+    return img.convertToFormat(QImage.Format.Format_Grayscale8)
 
 
 def set_image_opacity(img, alpha=0.5):

--- a/src/calibre/utils/img.py
+++ b/src/calibre/utils/img.py
@@ -450,8 +450,7 @@ def crop_image(img, x, y, width, height):
 
 
 def grayscale_image(img) -> QImage:
-    img: QImage = image_from_data(img)
-    return img.convertToFormat(QImage.Format.Format_Grayscale8)
+    return imageops.grayscale(image_from_data(img))
 
 
 def set_image_opacity(img, alpha=0.5):


### PR DESCRIPTION
### The setup
I have a manga and a Kobo Libra 2. The resolution on the Kobo Libra 2 is big for an e-reader, so most images do not need scaling. Most are grayscale, so there is no need to convert anything for them. I do cut landscape pictures in two because the screen is relatively small; it’s too small to read a double page without zooming. But mostly, just moving and organizing the files is enough.

### The problem
Even though most images look identical to the original after conversion, they grow 100%-200% in file size. I've come to the conclusion that this is because many of the imageops operations change the image to a format more suitable for manipulation, but do not convert them back to the original format. For grayscale images, this means they are being saved in an RGB format, rather than a simpler grayscale og pallette format. Wasting space for nothing.

### A solution - 2nd attempt
In my first attempt to fix this problem @kovidgoyal made me aware that setting the number of colors to 256 instead of 'off' would fix my problem. Have confirmed that this is true.

The thing that nags me, is why we even save a confirmed grayscale image in an RGB format in the first place. This pull request fixes this problem. Before saving the file, it now checks if the image is grayscale and if it is, it sets the number of colors to 256 for that image. It only does this if the number of colors is set to 'off', and the output format is 'png'. So the user keeps control.

This is not a perfect solution, but I think it is better than expecting users to explicitly tell the conversion program that a grayscale image has a range of 256 colors. This should instead be implied, and this little fix does that.

Another benefit, is that when a user decides not to grayscale colored images, they can get the benefit of gray images saved with 256 colors, but still have there colored images use as many colors as they have. Though they will be converted to png and grow huge, but that is another problem in it self.

On the other hand, it is now not possible to save a grayscale png file with more than 256 shades (as it would be caught by my if statement). Should have made it ignore files it registered in the QImage.Format.Format_Grayscale16. But as mentioned earlier, no file seems to miss the conversion to Format_RGB32, which makes that check redundant at the moment.