### PR TITLE
If a show-details link references the current library, use the …

### DIFF
--- a/src/calibre/gui2/actions/show_book_details.py
+++ b/src/calibre/gui2/actions/show_book_details.py
@@ -28,6 +28,8 @@ class ShowBookDetailsAction(InterfaceAction):
         library_path = kwargs.get('library_path', None)
         book_id = kwargs.get('book_id', None)
         library_id = kwargs.get('library_id', None)
+        if library_path is not None and self.gui.library_broker.is_gui_library(library_path):
+            library_path = library_id = None
         query = kwargs.get('query', None)
         index = self.gui.library_view.currentIndex()
         if self.gui.current_view() is not self.gui.library_view and not library_path:


### PR DESCRIPTION
…current gui db instead of opening it again.

Also, the second database for book-details is no longer being opened read only. Is that OK?