### PR TITLE
For accessibility, add a context menu item to book details links to …

### DIFF
--- a/src/calibre/gui2/book_details.py
+++ b/src/calibre/gui2/book_details.py
@@ -508,6 +508,7 @@ def details_context_menu_event(view, ev, book_info, add_popup_action=False, edit
         ac.current_url = url
         ac.setText(_('Copy link location'))
         menu.addAction(ac)
+        menu.addAction(QIcon.ic('external-link'), _('Click link'), lambda : book_info.link_clicked.emit(url))
     if not copy_links_added:
         create_copy_links(copy_menu)
 


### PR DESCRIPTION
…click the link.

The target area is small. The user can use right-click until the right menu opens, then click the link,