### PR TITLE
Added entries to author_name_copywords

### DIFF
--- a/resources/default_tweaks.py
+++ b/resources/default_tweaks.py
@@ -77,8 +77,8 @@ author_name_suffixes = ('Jr', 'Sr', 'Inc', 'Ph.D', 'Phd',
 author_name_prefixes = ('Mr', 'Mrs', 'Ms', 'Dr', 'Prof')
 author_name_copywords = ('Agency', 'Corporation', 'Company', 'Co.', 'Council',
                          'Committee', 'Inc.', 'Institute', 'National',
-                         'Society', 'Club', 'Team','Software',
-                         'Games','Entertainment','Media','Studios')
+                         'Society', 'Club', 'Team',
+                         'Software', 'Games','Entertainment','Media','Studios')
 author_use_surname_prefixes = False
 author_surname_prefixes = ('da', 'de', 'di', 'la', 'le', 'van', 'von')
 

--- a/resources/default_tweaks.py
+++ b/resources/default_tweaks.py
@@ -77,7 +77,7 @@ author_name_suffixes = ('Jr', 'Sr', 'Inc', 'Ph.D', 'Phd',
 author_name_prefixes = ('Mr', 'Mrs', 'Ms', 'Dr', 'Prof')
 author_name_copywords = ('Agency', 'Corporation', 'Company', 'Co.', 'Council',
                          'Committee', 'Inc.', 'Institute', 'National',
-                         'Society', 'Club', 'Team')
+                         'Society', 'Club', 'Team','Software','Games','Entertainment','Media','Studios')
 author_use_surname_prefixes = False
 author_surname_prefixes = ('da', 'de', 'di', 'la', 'le', 'van', 'von')
 

--- a/resources/default_tweaks.py
+++ b/resources/default_tweaks.py
@@ -77,7 +77,8 @@ author_name_suffixes = ('Jr', 'Sr', 'Inc', 'Ph.D', 'Phd',
 author_name_prefixes = ('Mr', 'Mrs', 'Ms', 'Dr', 'Prof')
 author_name_copywords = ('Agency', 'Corporation', 'Company', 'Co.', 'Council',
                          'Committee', 'Inc.', 'Institute', 'National',
-                         'Society', 'Club', 'Team','Software','Games','Entertainment','Media','Studios')
+                         'Society', 'Club', 'Team','Software',
+                         'Games','Entertainment','Media','Studios')
 author_use_surname_prefixes = False
 author_surname_prefixes = ('da', 'de', 'di', 'la', 'le', 'van', 'von')
 


### PR DESCRIPTION
Added several entries (Software, Games, Entertainment, Media, and Studios) commonly used for video game developers & publishers to author_name_copywords. This is for users who store game manuals and documentation in a Calibre library.