### PR TITLE
Two commits:

### DIFF
--- a/src/calibre/gui2/actions/__init__.py
+++ b/src/calibre/gui2/actions/__init__.py
@@ -79,6 +79,10 @@ class InterfaceAction(QObject):
     #: with no default key binding.
     action_spec = ('text', 'icon', None, None)
 
+    #: If not none, used for the name displayed to the user when customizing
+    #: the keyboard shortcuts for the above action spec (self.qaction)
+    action_shortcut_name = None
+
     #: If True, a menu is automatically created and added to self.qaction
     action_add_menu = False
 
@@ -181,7 +185,9 @@ class InterfaceAction(QObject):
         if shortcut is not None:
             keys = ((shortcut,) if isinstance(shortcut, string_or_bytes) else
                     tuple(shortcut))
-            if shortcut_name is None and spec[0]:
+            if shortcut_name is None and self.action_shortcut_name is not None:
+                shortcut_name = self.action_shortcut_name
+            if not shortcut_name and spec[0]:
                 shortcut_name = str(spec[0])
 
             if shortcut_name and self.action_spec[0] and not (

--- a/src/calibre/gui2/actions/show_book_details.py
+++ b/src/calibre/gui2/actions/show_book_details.py
@@ -8,69 +8,88 @@ __docformat__ = 'restructuredtext en'
 from qt.core import Qt, sip
 
 from calibre.gui2.actions import InterfaceAction
-from calibre.gui2.dialogs.book_info import BookInfo
+from calibre.gui2.dialogs.book_info import BookInfo, DialogNumbers
 from calibre.gui2 import error_dialog
 
 
 class ShowBookDetailsAction(InterfaceAction):
 
     name = 'Show Book Details'
-    action_spec = (_('Show Book details'), 'dialog_information.png',
+    action_spec = (_('Book details'), 'dialog_information.png',
                    _('Show the detailed metadata for the current book in a separate window'), _('I'))
+    action_shortcut_name = _('Show Book details in a separate window')
     dont_add_to = frozenset(('context-menu-device',))
     action_type = 'current'
+    action_add_menu = True
+    action_menu_clone_qaction = _('Show Book details in a separate window')
 
     def genesis(self):
+        self.dialogs = [None, None, None]
+        m = self.qaction.menu()
+        self.show_info_locked = l = self.create_menu_action(m,
+            'show_locked_details', _('Show Book details in a separate locked window'),
+            icon='drm-locked.png', shortcut=None)
+        l.triggered.connect(self.open_locked_window)
+        l = self.create_menu_action(m,
+            'close_all_details', _('Close all book details windows'), icon='close.png', shortcut=None)
+        l.triggered.connect(self.close_all_windows)
         self.qaction.triggered.connect(self.show_book_info)
-        self.dialogs = [None, ]
 
     def show_book_info(self, *args, **kwargs):
         library_path = kwargs.get('library_path', None)
         book_id = kwargs.get('book_id', None)
         library_id = kwargs.get('library_id', None)
-        query = kwargs.get('query', None)
+        locked = kwargs.get('locked', False)
         index = self.gui.library_view.currentIndex()
         if self.gui.current_view() is not self.gui.library_view and not library_path:
             error_dialog(self.gui, _('No detailed info available'),
                 _('No detailed information is available for books '
                   'on the device.')).exec()
             return
-        if library_path or index.isValid():
-            # Window #0 is slaved to changes in the book list. As such
-            # it must not be used for details from other libraries.
-            for dn,v in enumerate(self.dialogs):
-                if dn == 0 and library_path:
-                    continue
-                if v is None:
-                    break
-            else:
-                self.dialogs.append(None)
-                dn += 1
-
-            try:
-                d = BookInfo(self.gui, self.gui.library_view, index,
-                        self.gui.book_details.handle_click, dialog_number=dn,
-                        library_id=library_id, library_path=library_path, book_id=book_id, query=query)
-            except ValueError as e:
-                error_dialog(self.gui, _('Book not found'), str(e)).exec()
+        if library_path:
+            dn = DialogNumbers.DetailsLink
+        else:
+            if not index.isValid():
                 return
+            dn = DialogNumbers.Locked if locked else DialogNumbers.Slaved
+        if self.dialogs[dn] is not None:
+            if dn == DialogNumbers.Slaved:
+                # This is the slaved window. It will update automatically
+                return
+            else:
+                # Replace the other windows. There is a signals race condition
+                # between closing the existing window and opening the new one,
+                # so do all the work here
+                d = self.dialogs[dn]
+                d.closed.disconnect(self.closed)
+                d.done(0)
+                self.dialogs[dn] = None
+        try:
+            d = BookInfo(self.gui, self.gui.library_view, index,
+                    self.gui.book_details.handle_click, dialog_number=dn,
+                    library_id=library_id, library_path=library_path, book_id=book_id)
+        except ValueError as e:
+            error_dialog(self.gui, _('Book not found'), str(e)).exec()
+            return
 
-            d.open_cover_with.connect(self.gui.bd_open_cover_with, type=Qt.ConnectionType.QueuedConnection)
-            self.dialogs[dn] = d
-            d.closed.connect(self.closed, type=Qt.ConnectionType.QueuedConnection)
-            d.show()
+        d.open_cover_with.connect(self.gui.bd_open_cover_with, type=Qt.ConnectionType.QueuedConnection)
+        self.dialogs[dn] = d
+        d.closed.connect(self.closed, type=Qt.ConnectionType.QueuedConnection)
+        d.show()
+
+    def open_locked_window(self):
+        self.show_book_info(locked=True)
 
     def shutting_down(self):
-        for d in self.dialogs:
-            if d:
-                d.done(0)
+        self.close_all_windows()
+
+    def close_all_windows(self):
+        for dialog in [d for d in self.dialogs if d is not None]:
+            dialog.done(0)
 
     def library_about_to_change(self, *args):
-        for i,d in enumerate(self.dialogs):
-            if i == 0:
-                continue
-            if d:
-                d.done(0)
+        for dialog in [d for d in self.dialogs[1:] if d is not None]:
+            dialog.done(0)
 
     def closed(self, d):
         try:

--- a/src/calibre/gui2/book_details.py
+++ b/src/calibre/gui2/book_details.py
@@ -541,8 +541,7 @@ def details_context_menu_event(view, ev, book_info, add_popup_action=False, edit
     menu.addSeparator()
     from calibre.gui2.ui import get_gui
     if add_popup_action:
-        ema = get_gui().iactions['Show Book Details'].menuless_qaction
-        menu.addAction(_('Open the Book details window') + '\t' + ema.shortcut().toString(QKeySequence.SequenceFormat.NativeText), book_info.show_book_info)
+        menu.addMenu(get_gui().iactions['Show Book Details'].qaction.menu())
     else:
         ema = get_gui().iactions['Edit Metadata'].menuless_qaction
         menu.addAction(_('Open the Edit metadata window') + '\t' + ema.shortcut().toString(QKeySequence.SequenceFormat.NativeText), edit_metadata)


### PR DESCRIPTION
Commit 1:
Add the ability to name the shortcut for qactions in InterfaceActionPlugin.

Commit 2:
1) Remove the ability to open book-details link windows using a query. It was never documented and ui.py didn't support it.

2) Simplify management of book details windows. There can now only be three windows, all non-modal on top of calibre, all with calibre as the parent. Each window has a "purpose". The first is the normal book details slave window, the second is a locked book details window, and the third is a book-details link window.

3) Add more menu actions to Show Book Details: open a locked window and close all book details windows. Use this menu where the menuless qaction was previously used.
