### PR TITLE
Two independent commits:

### DIFF
--- a/src/calibre/gui2/book_details.py
+++ b/src/calibre/gui2/book_details.py
@@ -5,6 +5,7 @@
 import os
 import re
 from collections import namedtuple
+from contextlib import suppress
 from functools import lru_cache, partial
 from qt.core import (
     QAction, QApplication, QClipboard, QColor, QDialog, QEasingCurve, QIcon,
@@ -474,6 +475,13 @@ def create_copy_links(menu, data=None):
     menu.addSeparator()
     link(_('Link to show book in calibre'), f'calibre://show-book/{library_id}/{book_id}')
     link(_('Link to show book details in a popup window'), f'calibre://book-details/{library_id}/{book_id}')
+    mi = db.new_api.get_proxy_metadata(book_id)
+    data_path = os.path.join(db.backend.library_path, mi.path, 'data')
+    with suppress(OSError):
+        if os.listdir(data_path):
+            if iswindows:
+                data_path = '/' + data_path.replace('\\', '/')
+            link(_("Link to open book's data files folder"), 'file://' + data_path)
     if data:
         field = data.get('field')
         if data['type'] == 'author':
@@ -490,7 +498,6 @@ def create_copy_links(menu, data=None):
 
     if all_links:
         menu.addSeparator()
-        mi = db.new_api.get_proxy_metadata(book_id)
         all_links.insert(0, '')
         all_links.insert(0, mi.get('title') + ' - ' + ' & '.join(mi.get('authors')))
         link(_('Copy all the above links'), '\n'.join(all_links))

--- a/src/calibre/gui2/dialogs/template_dialog.py
+++ b/src/calibre/gui2/dialogs/template_dialog.py
@@ -618,17 +618,17 @@ class TemplateDialog(QDialog, Ui_TemplateDialog):
     def add_python_template_header_text(self):
         self.textbox.setPlainText('''python:
 def evaluate(book, context):
-    # book is a calibre metadata object
-    # context is an instance of calibre.utils.formatter.PythonTemplateContext,
-    # which currently contains the following attributes:
-    # db: a calibre legacy database object.
-    # globals: the template global variable dictionary.
-    # arguments: is a list of arguments if the template is called by a GPM template, otherwise None.
-    # funcs: used to call Built-in/User functions and Stored GPM/Python templates.
-    # Example: context.funcs.list_re_group()
+\t# book is a calibre metadata object
+\t# context is an instance of calibre.utils.formatter.PythonTemplateContext,
+\t# which currently contains the following attributes:
+\t# db: a calibre legacy database object.
+\t# globals: the template global variable dictionary.
+\t# arguments: is a list of arguments if the template is called by a GPM template, otherwise None.
+\t# funcs: used to call Built-in/User functions and Stored GPM/Python templates.
+\t# Example: context.funcs.list_re_group()
 
-    # your Python code goes here
-    return 'a string'
+\t# your Python code goes here
+\treturn 'a string'
 ''')
 
     def set_word_wrap(self, to_what):


### PR DESCRIPTION
1. Use tabs instead of spaces in the template tester's sample python text. This makes indenting and outdenting in the tester consistent.
2. Add a menu action in book details to copy the link to a book's data folder if one exists.