### PR TITLE
Adapt union syntax to work on python 3.9

### DIFF
--- a/src/calibre/utils/copy_files.py
+++ b/src/calibre/utils/copy_files.py
@@ -127,7 +127,7 @@ class WindowsFileCopier:
             winutil.delete_file(make_long_path_useable(src_path))
 
 
-def get_copier() -> Union[UnixFileCopier | WindowsFileCopier]:
+def get_copier() -> Union[UnixFileCopier, WindowsFileCopier]:
     return WindowsFileCopier() if iswindows else UnixFileCopier()
 
 


### PR DESCRIPTION
Hi,

On FreeBSD we are using Python 3.9 by default and I was getting this error while building calibre:

```
Setting up command-line completion...
Installing zsh completion to: /wrkdirs/usr/ports/deskutils/calibre/work/stage/usr/local/share/zsh/site-functions/_calibre
Installing bash completion to: /wrkdirs/usr/ports/deskutils/calibre/work/stage/usr/local/share/bash-completion/completions/
Traceback (most recent call last):
  File "/wrkdirs/usr/ports/deskutils/calibre/work/calibre-6.16.0/setup.py", line 119, in <module>
    sys.exit(main())
  File "/wrkdirs/usr/ports/deskutils/calibre/work/calibre-6.16.0/setup.py", line 104, in main
    command.run_all(opts)
  File "/wrkdirs/usr/ports/deskutils/calibre/work/calibre-6.16.0/setup/__init__.py", line 239, in run_all
    self.run_cmd(self, opts)
  File "/wrkdirs/usr/ports/deskutils/calibre/work/calibre-6.16.0/setup/__init__.py", line 233, in run_cmd
    cmd.run(opts)
  File "/wrkdirs/usr/ports/deskutils/calibre/work/calibre-6.16.0/setup/install.py", line 153, in run
    self.run_postinstall()
  File "/wrkdirs/usr/ports/deskutils/calibre/work/calibre-6.16.0/setup/install.py", line 180, in run_postinstall
    PostInstall(self.opts, info=self.info, warn=self.warn,
  File "/wrkdirs/usr/ports/deskutils/calibre/work/calibre-6.16.0/src/calibre/linux.py", line 782, in __init__
    self.setup_completion()
  File "/wrkdirs/usr/ports/deskutils/calibre/work/calibre-6.16.0/src/calibre/linux.py", line 837, in setup_completion
    write_completion(self, bash_comp_dest, zsh)
  File "/wrkdirs/usr/ports/deskutils/calibre/work/calibre-6.16.0/src/calibre/linux.py", line 588, in write_completion
    from calibre.gui2.viewer.main import option_parser as viewer_op
  File "/wrkdirs/usr/ports/deskutils/calibre/work/calibre-6.16.0/src/calibre/gui2/viewer/main.py", line 15, in <module>
    from calibre.gui2.viewer.ui import EbookViewer, is_float
  File "/wrkdirs/usr/ports/deskutils/calibre/work/calibre-6.16.0/src/calibre/gui2/viewer/ui.py", line 29, in <module>
    from calibre.gui2.viewer.annotations import (
  File "/wrkdirs/usr/ports/deskutils/calibre/work/calibre-6.16.0/src/calibre/gui2/viewer/annotations.py", line 13, in <module>
    from calibre.gui2.viewer.web_view import viewer_config_dir
  File "/wrkdirs/usr/ports/deskutils/calibre/work/calibre-6.16.0/src/calibre/gui2/viewer/web_view.py", line 29, in <module>
    from calibre.srv.code import get_translations_data
  File "/wrkdirs/usr/ports/deskutils/calibre/work/calibre-6.16.0/src/calibre/srv/code.py", line 17, in <module>
    from calibre.srv.ajax import search_result
  File "/wrkdirs/usr/ports/deskutils/calibre/work/calibre-6.16.0/src/calibre/srv/ajax.py", line 15, in <module>
    from calibre.srv.content import get as get_content, icon as get_icon
  File "/wrkdirs/usr/ports/deskutils/calibre/work/calibre-6.16.0/src/calibre/srv/content.py", line 222, in <module>
    @endpoint('/static/{+what}', auth_required=False, cache_control=24)
  File "/wrkdirs/usr/ports/deskutils/calibre/work/calibre-6.16.0/src/calibre/srv/routes.py", line 74, in endpoint
    from calibre.srv.handler import Context
  File "/wrkdirs/usr/ports/deskutils/calibre/work/calibre-6.16.0/src/calibre/srv/handler.py", line 12, in <module>
    from calibre.srv.library_broker import LibraryBroker, path_for_db
  File "/wrkdirs/usr/ports/deskutils/calibre/work/calibre-6.16.0/src/calibre/srv/library_broker.py", line 11, in <module>
    from calibre.db.legacy import LibraryDatabase, create_backend, set_global_state
  File "/wrkdirs/usr/ports/deskutils/calibre/work/calibre-6.16.0/src/calibre/db/legacy.py", line 21, in <module>
    from calibre.db.backend import DB, set_global_state as backend_set_global_state
  File "/wrkdirs/usr/ports/deskutils/calibre/work/calibre-6.16.0/src/calibre/db/backend.py", line 40, in <module>
    from calibre.utils.copy_files import copy_files, copy_tree, rename_files
  File "/wrkdirs/usr/ports/deskutils/calibre/work/calibre-6.16.0/src/calibre/utils/copy_files.py", line 130, in <module>
    def get_copier() -> Union[UnixFileCopier | WindowsFileCopier]:
TypeError: unsupported operand type(s) for |: 'type' and 'type'
```

I've created this simple patch that fixes it, and should be compatible with newer python versions, at least I hope so, not being a python expert.