### PR TITLE
Two semi-dependent changes:

### DIFF
--- a/resources/default_tweaks.py
+++ b/resources/default_tweaks.py
@@ -574,3 +574,17 @@ allow_template_database_functions_in_composites = False
 # for https://whatever URLs. %u is replaced by the URL to be opened. The scheme
 # takes a glob pattern allowing a single entry to match multiple URL types.
 openers_by_scheme = {}
+
+#: Change standard column heading text to some value
+# Use the dictionary below to change a column heading. The format of the
+# dictionary is
+#   {lookup_name: new_heading, ...}
+# The new_heading must be unique: no two columns can have the same heading.
+# This tweak works only with standard columns: it cannot be used to change
+# the heading for a custom column. If a custom column has the same heading as
+# one provided here then a number will appended to the custom column's heading
+# to make it unique.
+#
+# Example:
+#   alternate_column_headings = {'authors':'Writers', 'size':'MBytes'}
+alternate_column_headings = {}

--- a/src/calibre/gui2/library/views.py
+++ b/src/calibre/gui2/library/views.py
@@ -808,8 +808,8 @@ class BooksView(QTableView):  # {{{
         state = {}
         state['hidden_columns'] = [cm[i] for i in range(h.count())
                 if h.isSectionHidden(i) and cm[i] != 'ondevice']
-        state['last_modified_injected'] = True
-        state['languages_injected'] = True
+        for f in ('last_modified', 'languages', 'formats', 'id', 'path'):
+            state[f+'_injected'] = True
         state['sort_history'] = \
             self.cleanup_sort_history(self.model().sort_history, ignore_column_map=self.is_library_view)
         state['column_positions'] = {}
@@ -923,7 +923,7 @@ class BooksView(QTableView):  # {{{
 
     def get_default_state(self):
         old_state = {
-                'hidden_columns': ['last_modified', 'languages'],
+                'hidden_columns': ['last_modified', 'languages', 'formats', 'id', 'path'],
                 'sort_history':[DEFAULT_SORT],
                 'column_positions': {},
                 'column_sizes': {},
@@ -931,9 +931,9 @@ class BooksView(QTableView):  # {{{
                     'size':'center',
                     'timestamp':'center',
                     'pubdate':'center'},
-                'last_modified_injected': True,
-                'languages_injected': True,
                 }
+        for f in ('last_modified', 'languages', 'formats', 'id', 'path'):
+            old_state[f+'_injected'] = True
         h = self.column_header
         cm = self.column_map
         for i in range(h.count()):
@@ -965,18 +965,14 @@ class BooksView(QTableView):  # {{{
                         db.new_api.set_pref(name, ans)
                 else:
                     injected = False
-                    if not ans.get('last_modified_injected', False):
-                        injected = True
-                        ans['last_modified_injected'] = True
-                        hc = ans.get('hidden_columns', [])
-                        if 'last_modified' not in hc:
-                            hc.append('last_modified')
-                    if not ans.get('languages_injected', False):
-                        injected = True
-                        ans['languages_injected'] = True
-                        hc = ans.get('hidden_columns', [])
-                        if 'languages' not in hc:
-                            hc.append('languages')
+                    for f in ('last_modified', 'languages', 'formats', 'id', 'path'):
+                        if not ans.get(f+'_injected', False):
+                            print('injecting', f)
+                            injected = True
+                            ans[f+'_injected'] = True
+                            hc = ans.get('hidden_columns', [])
+                            if f not in hc:
+                                hc.append(f)
                     if injected:
                         db.new_api.set_pref(name, ans)
         return ans


### PR DESCRIPTION
1) Add a tweak to change the heading for standard columns
2) Add "id", "formats", and "path" as standard columns. They are by default hidden, like "languages"