### PR TITLE
fix comments markdown

### DIFF
--- a/src/calibre/library/comments.py
+++ b/src/calibre/library/comments.py
@@ -134,7 +134,8 @@ def markdown(val):
     except AttributeError:
         from calibre.ebooks.markdown import Markdown
         md = markdown.Markdown = Markdown()
-    return md.convert(val)
+    val = md.convert(val)
+    return re.sub(r'<p(|\s+[^>]*?)>\s*<br\s*/?>\s*</p>','<p\\1>\xa0</p>', val)
 
 
 def merge_comments(one, two):


### PR DESCRIPTION
in v4, the switch to QtWebEngine introduced a bug where, in "HTML comments", paragraphs with a single \<br> produced an visual extra gap in the render, problem will have been solved by using non-breaking space \<p>&amp;nbsp;\</p>
(topic https://www.mobileread.com/forums/showthread.php?t=325991)

However, the "calibre.library.comments > markdown" still produces HTML with \<p>\<br>\</p> causing the rendering of "Markdown comments" in Book Details (and Book Info) to still have this extra gap.
This commit is to fix this and do a more consistent rendering between "HTML comments" and "Markdown comments"

![fix comments markdown](https://user-images.githubusercontent.com/46523284/234053067-067710e6-977f-4808-bd2b-2efc10f95c8d.png)