### PR TITLE
Improve the Markdown Highlighter

### DIFF
--- a/src/calibre/gui2/markdown_syntax_highlighter.py
+++ b/src/calibre/gui2/markdown_syntax_highlighter.py
@@ -34,6 +34,27 @@ class MarkdownHighlighter(QSyntaxHighlighter):
         'Html': re.compile('<.+?>')
     }
 
+    key_theme_maps = {
+        'Bold': "bold",
+        'uBold': "bold",
+        'Italic': "emphasis",
+        'uItalic': "emphasis",
+        'Link': "link",
+        'Image': "image",
+        'HeaderAtx': "header",
+        'Header': "header",
+        'CodeBlock': "codeblock",
+        'UnorderedList': "unorderedlist",
+        'UnorderedListStar': "unorderedlist",
+        'OrderedList': "orderedlist",
+        'BlockQuote': "blockquote",
+        'BlockQuoteCount': "blockquote",
+        'CodeSpan': "codespan",
+        'HR': "line",
+        'eHR': "line",
+        'Html': "html",
+    }
+
     light_theme =  {
         "bold": {"color":"#859900", "font-weight":"bold", "font-style":"normal"},
         "emphasis": {"color":"#b58900", "font-weight":"bold", "font-style":"italic"},
@@ -73,101 +94,16 @@ class MarkdownHighlighter(QSyntaxHighlighter):
         self.theme = theme
         self.MARKDOWN_KWS_FORMAT = {}
 
-        format = QTextCharFormat()
-        format.setForeground(QBrush(QColor(theme['bold']['color'])))
-        format.setFontWeight(QFont.Weight.Bold if theme['bold']['font-weight']=='bold' else QFont.Weight.Normal)
-        format.setFontItalic(True if theme['bold']['font-style']=='italic' else False)
-        self.MARKDOWN_KWS_FORMAT['Bold'] = format
-
-        format = QTextCharFormat()
-        format.setForeground(QBrush(QColor(theme['bold']['color'])))
-        format.setFontWeight(QFont.Weight.Bold if theme['bold']['font-weight']=='bold' else QFont.Weight.Normal)
-        format.setFontItalic(True if theme['bold']['font-style']=='italic' else False)
-        self.MARKDOWN_KWS_FORMAT['uBold'] = format
-
-        format = QTextCharFormat()
-        format.setForeground(QBrush(QColor(theme['emphasis']['color'])))
-        format.setFontWeight(QFont.Weight.Bold if theme['emphasis']['font-weight']=='bold' else QFont.Weight.Normal)
-        format.setFontItalic(True if theme['emphasis']['font-style']=='italic' else False)
-        self.MARKDOWN_KWS_FORMAT['Italic'] = format
-
-        format = QTextCharFormat()
-        format.setForeground(QBrush(QColor(theme['emphasis']['color'])))
-        format.setFontWeight(QFont.Weight.Bold if theme['emphasis']['font-weight']=='bold' else QFont.Weight.Normal)
-        format.setFontItalic(True if theme['emphasis']['font-style']=='italic' else False)
-        self.MARKDOWN_KWS_FORMAT['uItalic'] = format
-
-        format = QTextCharFormat()
-        format.setForeground(QBrush(QColor(theme['link']['color'])))
-        format.setFontWeight(QFont.Weight.Bold if theme['link']['font-weight']=='bold' else QFont.Weight.Normal)
-        format.setFontItalic(True if theme['link']['font-style']=='italic' else False)
-        self.MARKDOWN_KWS_FORMAT['Link'] = format
-
-        format = QTextCharFormat()
-        format.setForeground(QBrush(QColor(theme['image']['color'])))
-        format.setFontWeight(QFont.Weight.Bold if theme['image']['font-weight']=='bold' else QFont.Weight.Normal)
-        format.setFontItalic(True if theme['image']['font-style']=='italic' else False)
-        self.MARKDOWN_KWS_FORMAT['Image'] = format
-
-        format = QTextCharFormat()
-        format.setForeground(QBrush(QColor(theme['header']['color'])))
-        format.setFontWeight(QFont.Weight.Bold if theme['header']['font-weight']=='bold' else QFont.Weight.Normal)
-        format.setFontItalic(True if theme['header']['font-style']=='italic' else False)
-        self.MARKDOWN_KWS_FORMAT['Header'] = format
-
-        format = QTextCharFormat()
-        format.setForeground(QBrush(QColor(theme['header']['color'])))
-        format.setFontWeight(QFont.Weight.Bold if theme['header']['font-weight']=='bold' else QFont.Weight.Normal)
-        format.setFontItalic(True if theme['header']['font-style']=='italic' else False)
-        self.MARKDOWN_KWS_FORMAT['HeaderAtx'] = format
-
-        format = QTextCharFormat()
-        format.setForeground(QBrush(QColor(theme['unorderedlist']['color'])))
-        format.setFontWeight(QFont.Weight.Bold if theme['unorderedlist']['font-weight']=='bold' else QFont.Weight.Normal)
-        format.setFontItalic(True if theme['unorderedlist']['font-style']=='italic' else False)
-        self.MARKDOWN_KWS_FORMAT['UnorderedList'] = format
-
-        format = QTextCharFormat()
-        format.setForeground(QBrush(QColor(theme['orderedlist']['color'])))
-        format.setFontWeight(QFont.Weight.Bold if theme['orderedlist']['font-weight']=='bold' else QFont.Weight.Normal)
-        format.setFontItalic(True if theme['orderedlist']['font-style']=='italic' else False)
-        self.MARKDOWN_KWS_FORMAT['OrderedList'] = format
-
-        format = QTextCharFormat()
-        format.setForeground(QBrush(QColor(theme['blockquote']['color'])))
-        format.setFontWeight(QFont.Weight.Bold if theme['blockquote']['font-weight']=='bold' else QFont.Weight.Normal)
-        format.setFontItalic(True if theme['blockquote']['font-style']=='italic' else False)
-        self.MARKDOWN_KWS_FORMAT['BlockQuote'] = format
-
-        format = QTextCharFormat()
-        format.setForeground(QBrush(QColor(theme['codespan']['color'])))
-        format.setFontWeight(QFont.Weight.Bold if theme['codespan']['font-weight']=='bold' else QFont.Weight.Normal)
-        format.setFontItalic(True if theme['codespan']['font-style']=='italic' else False)
-        self.MARKDOWN_KWS_FORMAT['CodeSpan'] = format
-
-        format = QTextCharFormat()
-        format.setForeground(QBrush(QColor(theme['codeblock']['color'])))
-        format.setFontWeight(QFont.Weight.Bold if theme['codeblock']['font-weight']=='bold' else QFont.Weight.Normal)
-        format.setFontItalic(True if theme['codeblock']['font-style']=='italic' else False)
-        self.MARKDOWN_KWS_FORMAT['CodeBlock'] = format
-
-        format = QTextCharFormat()
-        format.setForeground(QBrush(QColor(theme['line']['color'])))
-        format.setFontWeight(QFont.Weight.Bold if theme['line']['font-weight']=='bold' else QFont.Weight.Normal)
-        format.setFontItalic(True if theme['line']['font-style']=='italic' else False)
-        self.MARKDOWN_KWS_FORMAT['HR'] = format
-
-        format = QTextCharFormat()
-        format.setForeground(QBrush(QColor(theme['line']['color'])))
-        format.setFontWeight(QFont.Weight.Bold if theme['line']['font-weight']=='bold' else QFont.Weight.Normal)
-        format.setFontItalic(True if theme['line']['font-style']=='italic' else False)
-        self.MARKDOWN_KWS_FORMAT['eHR'] = format
-
-        format = QTextCharFormat()
-        format.setForeground(QBrush(QColor(theme['html']['color'])))
-        format.setFontWeight(QFont.Weight.Bold if theme['html']['font-weight']=='bold' else QFont.Weight.Normal)
-        format.setFontItalic(True if theme['html']['font-style']=='italic' else False)
-        self.MARKDOWN_KWS_FORMAT['HTML'] = format
+        for k,t in self.key_theme_maps.items():
+            subtheme = theme[t]
+            format = QTextCharFormat()
+            if 'color' in subtheme:
+                format.setForeground(QBrush(QColor(subtheme['color'])))
+            if 'font-weight' in subtheme:
+                format.setFontWeight(QFont.Weight.Bold if subtheme['font-weight']=='bold' else QFont.Weight.Normal)
+            if 'font-style' in subtheme:
+                format.setFontItalic(True if subtheme['font-style']=='italic' else False)
+            self.MARKDOWN_KWS_FORMAT[k] = format
 
         self.rehighlight()
 

--- a/src/calibre/gui2/markdown_syntax_highlighter.py
+++ b/src/calibre/gui2/markdown_syntax_highlighter.py
@@ -29,8 +29,8 @@ class MarkdownHighlighter(QSyntaxHighlighter):
         'BlockQuote': re.compile(r'(?u)^\s*>+\s*'),
         'BlockQuoteCount': re.compile('^[ \t]*>[ \t]?'),
         'CodeSpan': re.compile('(?P<delim>`+).+?(?P=delim)'),
-        'HR': re.compile(r'(?u)^(\s*(\*|-)\s*){3,}$'),
-        'eHR': re.compile(r'(?u)^(\s*(\*|=)\s*){3,}$'),
+        'HeaderLine': re.compile(r'(?u)^(\s*(-|=)\s*){3,}$'),
+        'HR': re.compile(r'(?u)^(\s*(\*|-|_)\s*){3,}$'),
         'Html': re.compile('<.+?>')
     }
 
@@ -43,6 +43,7 @@ class MarkdownHighlighter(QSyntaxHighlighter):
         'Image': "image",
         'HeaderAtx': "header",
         'Header': "header",
+        'HeaderLine': "header",
         'CodeBlock': "codeblock",
         'UnorderedList': "unorderedlist",
         'UnorderedListStar': "unorderedlist",
@@ -51,7 +52,6 @@ class MarkdownHighlighter(QSyntaxHighlighter):
         'BlockQuoteCount': "blockquote",
         'CodeSpan': "codespan",
         'HR': "line",
-        'eHR': "line",
         'Html': "html",
     }
 
@@ -166,23 +166,8 @@ class MarkdownHighlighter(QSyntaxHighlighter):
 
     def highlightHorizontalLine(self, text, cursor, bf, strt):
         found = False
-        for mo in re.finditer(self.MARKDOWN_KEYS_REGEX['HR'],text):
-            prevBlock = self.currentBlock().previous()
-            prevCursor = QTextCursor(prevBlock)
-            prev = prevBlock.text()
-            prevAscii = str(prev.replace('\u2029','\n'))
-            if prevAscii.strip():
-                #print "Its a header"
-                prevCursor.select(QTextCursor.SelectionType.LineUnderCursor)
-                #prevCursor.setCharFormat(self.MARKDOWN_KWS_FORMAT['Header'])
-                formatRange = QTextLayout.FormatRange()
-                formatRange.format = self.MARKDOWN_KWS_FORMAT['Header']
-                formatRange.length = prevCursor.block().length()
-                formatRange.start = 0
-                prevCursor.block().layout().setFormats([formatRange])
-            self.setFormat(mo.start()+strt, mo.end() - mo.start(), self.MARKDOWN_KWS_FORMAT['HR'])
 
-        for mo in re.finditer(self.MARKDOWN_KEYS_REGEX['eHR'],text):
+        for mo in re.finditer(self.MARKDOWN_KEYS_REGEX['HeaderLine'],text):
             prevBlock = self.currentBlock().previous()
             prevCursor = QTextCursor(prevBlock)
             prev = prevBlock.text()
@@ -192,11 +177,16 @@ class MarkdownHighlighter(QSyntaxHighlighter):
                 prevCursor.select(QTextCursor.SelectionType.LineUnderCursor)
                 #prevCursor.setCharFormat(self.MARKDOWN_KWS_FORMAT['Header'])
                 formatRange = QTextLayout.FormatRange()
-                formatRange.format = self.MARKDOWN_KWS_FORMAT['Header']
+                formatRange.format = self.MARKDOWN_KWS_FORMAT['HeaderLine']
                 formatRange.length = prevCursor.block().length()
                 formatRange.start = 0
                 prevCursor.block().layout().setFormats([formatRange])
+                self.setFormat(mo.start()+strt, mo.end() - mo.start(), self.MARKDOWN_KWS_FORMAT['HeaderLine'])
+                return True
+
+        for mo in re.finditer(self.MARKDOWN_KEYS_REGEX['HR'],text):
             self.setFormat(mo.start()+strt, mo.end() - mo.start(), self.MARKDOWN_KWS_FORMAT['HR'])
+            found = True
         return found
 
     def highlightAtxHeader(self, text, cursor, bf, strt):

--- a/src/calibre/gui2/markdown_syntax_highlighter.py
+++ b/src/calibre/gui2/markdown_syntax_highlighter.py
@@ -56,8 +56,8 @@ class MarkdownHighlighter(QSyntaxHighlighter):
     }
 
     light_theme =  {
-        "bold": {"color":"#859900", "font-weight":"bold", "font-style":"normal"},
-        "emphasis": {"color":"#b58900", "font-weight":"bold", "font-style":"italic"},
+        "bold": {"font-weight":"bold"},
+        "emphasis": {"font-style":"italic"},
         "link": {"color":light_link_color.name(), "font-weight":"normal", "font-style":"normal"},
         "image": {"color":"#cb4b16", "font-weight":"normal", "font-style":"normal"},
         "header": {"color":"#2aa198", "font-weight":"bold", "font-style":"normal"},
@@ -71,8 +71,8 @@ class MarkdownHighlighter(QSyntaxHighlighter):
     }
 
     dark_theme =  {
-        "bold": {"color":"#859900", "font-weight":"bold", "font-style":"normal"},
-        "emphasis": {"color":"#b58900", "font-weight":"bold", "font-style":"italic"},
+        "bold": {"font-weight":"bold"},
+        "emphasis": {"font-style":"italic"},
         "link": {"color":dark_link_color.name(), "font-weight":"normal", "font-style":"normal"},
         "image": {"color":"#cb4b16", "font-weight":"normal", "font-style":"normal"},
         "header": {"color":"#2aa198", "font-weight":"bold", "font-style":"normal"},

--- a/src/calibre/gui2/markdown_syntax_highlighter.py
+++ b/src/calibre/gui2/markdown_syntax_highlighter.py
@@ -177,7 +177,7 @@ class MarkdownHighlighter(QSyntaxHighlighter):
                 prevCursor.select(QTextCursor.SelectionType.LineUnderCursor)
                 #prevCursor.setCharFormat(self.MARKDOWN_KWS_FORMAT['Header'])
                 formatRange = QTextLayout.FormatRange()
-                formatRange.format = self.MARKDOWN_KWS_FORMAT['HeaderLine']
+                formatRange.format = self.MARKDOWN_KWS_FORMAT['Header']
                 formatRange.length = prevCursor.block().length()
                 formatRange.start = 0
                 prevCursor.block().layout().setFormats([formatRange])

--- a/src/calibre/gui2/markdown_syntax_highlighter.py
+++ b/src/calibre/gui2/markdown_syntax_highlighter.py
@@ -278,4 +278,4 @@ class MarkdownHighlighter(QSyntaxHighlighter):
 
     def highlightHtml(self, text):
         for mo in re.finditer(self.MARKDOWN_KEYS_REGEX['Html'], text):
-            self.setFormat(mo.start(), mo.end() - mo.start(), self.MARKDOWN_KWS_FORMAT['HTML'])
+            self.setFormat(mo.start(), mo.end() - mo.start(), self.MARKDOWN_KWS_FORMAT['Html'])

--- a/src/calibre/gui2/markdown_syntax_highlighter.py
+++ b/src/calibre/gui2/markdown_syntax_highlighter.py
@@ -29,7 +29,7 @@ class MarkdownHighlighter(QSyntaxHighlighter):
         'BlockQuote': re.compile(r'(?u)^\s*>+\s*'),
         'BlockQuoteCount': re.compile('^[ \t]*>[ \t]?'),
         'CodeSpan': re.compile('(?P<delim>`+).+?(?P=delim)'),
-        'HeaderLine': re.compile(r'(?u)^(\s*(-|=)\s*){3,}$'),
+        'HeaderLine': re.compile(r'(?u)^(-|=)+\s*$'),
         'HR': re.compile(r'(?u)^(\s*(\*|-|_)\s*){3,}$'),
         'Html': re.compile('<.+?>')
     }


### PR DESCRIPTION
Improve the Markdown Highlighter for the following:

1. Use a map/dict to init the highlighter theme
2. basic bold and emphasis
3. improve HorizontalLine and HeaderLine