### PR TITLE
Minor fix to the sort by action: the menu wasn't being recomputed …

### DIFF
--- a/src/calibre/gui2/actions/sort.py
+++ b/src/calibre/gui2/actions/sort.py
@@ -183,6 +183,7 @@ class SortByAction(InterfaceAction):
                 if not i.isSelected():
                     hidden.append(i.data(Qt.ItemDataRole.UserRole))
             db.new_api.set_pref(SORT_HIDDEN_PREF, tuple(hidden))
+            self.update_menu()
 
     def named_sort_selected(self, sort_spec):
         self.gui.library_view.multisort(sort_spec)


### PR DESCRIPTION
…after selecting columns to show/not show, causing menu-based actions to show the previous values.