### PR TITLE
Optimized edge case for comic conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@
 /cmake-build-*
 /bypy/b
 /bypy/virtual-machines.conf
+/.vscode/

--- a/src/calibre/ebooks/comic/input.py
+++ b/src/calibre/ebooks/comic/input.py
@@ -104,7 +104,8 @@ class PageProcessor(list):  # {{{
         self.num          = num
         self.dest         = dest
         self.rotate       = False
-        self.src_img_was_grayscaled = False
+        self.src_img_was_grayscale = False
+        self.img_is_grayscale = False
         self.render()
 
     def render(self):
@@ -116,8 +117,9 @@ class PageProcessor(list):  # {{{
         if self.num == 0:  # First image so create a thumbnail from it
             with open(os.path.join(self.dest, 'thumbnail.png'), 'wb') as f:
                 f.write(scale_image(img, as_png=True)[-1])
-        self.src_img_was_grayscaled = img.format() in (QImage.Format.Format_Grayscale8, QImage.Format.Format_Grayscale16) or (
+        self.src_img_was_grayscale = img.format() in (QImage.Format.Format_Grayscale8, QImage.Format.Format_Grayscale16) or (
             img.format() == QImage.Format.Format_Indexed8 and img.allGray())
+        self.img_is_grayscale = self.src_img_was_grayscale
         self.pages = [img]
         if width > height:
             if self.opts.landscape:
@@ -207,6 +209,7 @@ class PageProcessor(list):  # {{{
 
             if not self.opts.dont_grayscale:
                 img = grayscale_image(img)
+                self.img_is_grayscale = True
 
             if self.opts.despeckle:
                 img = despeckle_image(img)
@@ -214,7 +217,7 @@ class PageProcessor(list):  # {{{
             if self.opts.output_format.lower() == 'png':
                 if self.opts.colors:
                     img = quantize_image(img, max_colors=min(256, self.opts.colors))
-                elif self.src_img_was_grayscaled:
+                elif self.img_is_grayscale:
                     img = quantize_image(img, max_colors=256)
             dest = '%d_%d.%s'%(self.num, i, self.opts.output_format)
             dest = os.path.join(self.dest, dest)

--- a/src/calibre/ebooks/comic/input.py
+++ b/src/calibre/ebooks/comic/input.py
@@ -215,7 +215,7 @@ class PageProcessor(list):  # {{{
                 if self.opts.colors:
                     img = quantize_image(img, max_colors=min(256, self.opts.colors))
                 elif self.src_img_was_grayscaled:
-                    img = img.convertToFormat(QImage.Format.Format_Grayscale8)
+                    img = quantize_image(img, max_colors=256)
             dest = '%d_%d.%s'%(self.num, i, self.opts.output_format)
             dest = os.path.join(self.dest, dest)
             with open(dest, 'wb') as f:


### PR DESCRIPTION
If the input image is the format Indexed8 with less colors than 256, converting to Grayscale8 will grow the file size unnecessarily.
I could not find a situation where the Grayscale8 format was superior to the Indexed8 format, when it comes to grayscale images. 

My testing shows the following when it comes to file size of grayscale images:
- that a Indexed8 image with 256 colors is equal to a Grayscale8 image with 256 colors.
- that a Indexed8 image with 64 colors is smaller(better) than a Grayscale8 image with 64 colors.
- the image quality is the same with either format
- after this change, my comic size shrunk to 66mb from 91mb

With this information, a grayscale image may as well be the Indexed8 format, which the quantize method will ensure.

Another fix: Now colored images that gets grayscaled will be saved in this optimal format (they were not caught because the grayscale action did not update the grayscale state of the image/page). Added `self.img_is_grayscale` variable, to store the current grayscaliness of the image, and use that to determine if the optimized format should be used.