### PR TITLE
Now three independent commits

### DIFF
--- a/src/calibre/gui2/actions/open.py
+++ b/src/calibre/gui2/actions/open.py
@@ -5,6 +5,7 @@ __license__   = 'GPL v3'
 __copyright__ = '2010, Kovid Goyal <kovid@kovidgoyal.net>'
 __docformat__ = 'restructuredtext en'
 
+from functools import partial
 
 from calibre.gui2.actions import InterfaceAction
 
@@ -12,13 +13,19 @@ from calibre.gui2.actions import InterfaceAction
 class OpenFolderAction(InterfaceAction):
 
     name = 'Open Folder'
-    action_spec = (_('Open containing folder'), 'document_open.png',
+    action_spec = (_('Open book folder'), 'document_open.png',
                    _('Open the folder containing the current book\'s files'), _('O'))
     dont_add_to = frozenset(('context-menu-device',))
     action_type = 'current'
+    action_add_menu = True
+    action_menu_clone_qaction = _('Open book folder')
 
     def genesis(self):
-        self.qaction.triggered.connect(self.gui.iactions['View'].view_folder)
+        va = self.gui.iactions['View'].view_folder
+        self.qaction.triggered.connect(va)
+        a = self.create_menu_action(self.qaction.menu(), 'show-data-folder',
+                                _('Open book data folder'), icon='document_open.png', shortcut=tuple())
+        a.triggered.connect(partial(va, data_folder=True))
 
     def location_selected(self, loc):
         enabled = loc == 'library'

--- a/src/calibre/gui2/library/models.py
+++ b/src/calibre/gui2/library/models.py
@@ -405,6 +405,8 @@ class BooksModel(QAbstractTableModel):  # {{{
     def refresh_rows(self, rows, current_row=-1):
         self._clear_caches()
         cc = self.columnCount(QModelIndex()) - 1
+        for r in rows:
+            self.db.new_api.clear_extra_files_cache(self.db.id(r))
         for first_row, last_row in group_numbers(rows):
             self.dataChanged.emit(self.index(first_row, 0), self.index(last_row, cc))
             if current_row >= 0 and first_row <= current_row <= last_row:


### PR DESCRIPTION
1) Make model.refresh_rows() also clear the extra files cache for those books. Rationale: if someone changes the contents of data/ outside of calibre then this provides a way to get calibre to recheck.
2) Add opening the data folder to the Open action. Allow it to have a shortcut. Create the data folder if it doesn't exist.
3) Bug #2018227: User Categories: "Hide empty categories" failing for sub-categories