### PR TITLE
HTML entity to Markdown Highlighter

### DIFF
--- a/src/calibre/gui2/markdown_editor.py
+++ b/src/calibre/gui2/markdown_editor.py
@@ -183,7 +183,7 @@ if __name__ == '__main__':
     w.setWindowFlag(Qt.WindowType.Dialog)
     w.show()
     w.markdown = '''\
-test *italic* **bold** ***bold-italic*** `code` [link](https://calibre-ebook.com) <span style="font-weight: bold; color:red">span</span>
+normal&amp; *italic&#38;* **bold&#x0026;** ***bold-italic*** `code` [link](https://calibre-ebook.com) <span style="font-weight: bold; color:red">span</span>
 
 > Blockquotes
 

--- a/src/calibre/gui2/markdown_syntax_highlighter.py
+++ b/src/calibre/gui2/markdown_syntax_highlighter.py
@@ -32,7 +32,8 @@ class MarkdownHighlighter(QSyntaxHighlighter):
         'CodeSpan': re.compile(r'(?<!\\)(?P<delim>`+).+?(?P=delim)'),
         'HeaderLine': re.compile(r'(?u)^(-|=)+\s*$'),
         'HR': re.compile(r'(?u)^(\s*(\*|-|_)\s*){3,}$'),
-        'Html': re.compile(r'(?u)</?[^/\s].*?(?<!\\)>')
+        'Html': re.compile(r'(?u)</?[^/\s].*?(?<!\\)>'),
+        'Entity': re.compile(r'&([A-z]{2,7}|#\d{1,7}|#x[\dA-Fa-f]{1,6});'),
     }
 
     key_theme_maps = {
@@ -55,6 +56,7 @@ class MarkdownHighlighter(QSyntaxHighlighter):
         'CodeSpan': "codespan",
         'HR': "line",
         'Html': "html",
+        'Entity': "entity",
     }
 
     light_theme =  {
@@ -70,7 +72,8 @@ class MarkdownHighlighter(QSyntaxHighlighter):
         "codespan": {"color":"#ff5800", "font-weight":"normal", "font-style":"normal"},
         "codeblock": {"color":"#ff5800", "font-weight":"normal", "font-style":"normal"},
         "line": {"color":"#2aa198", "font-weight":"normal", "font-style":"normal"},
-        "html": {"color":"#c000c0", "font-weight":"normal", "font-style":"normal"}
+        "html": {"color":"#c000c0", "font-weight":"normal", "font-style":"normal"},
+        "entity": {"color":"#006496", "font-weight":"normal", "font-style":"normal"},
     }
 
     dark_theme =  {
@@ -86,7 +89,8 @@ class MarkdownHighlighter(QSyntaxHighlighter):
         "codespan": {"color":"#90ee90", "font-weight":"normal", "font-style":"normal"},
         "codeblock": {"color":"#ff9900", "font-weight":"normal", "font-style":"normal"},
         "line": {"color":"#2aa198", "font-weight":"normal", "font-style":"normal"},
-        "html": {"color":"#F653A6", "font-weight":"normal", "font-style":"normal"}
+        "html": {"color":"#f653a6", "font-weight":"normal", "font-style":"normal"},
+        "entity": {"color":"#ff82ac", "font-weight":"normal", "font-style":"normal"},
     }
 
     def __init__(self, parent):
@@ -140,6 +144,8 @@ class MarkdownHighlighter(QSyntaxHighlighter):
         self.highlightLink(text, cursor, bf)
 
         self.highlightImage(text, cursor, bf)
+
+        self.highlightEntity(text, cursor, bf)
 
         self.highlightCodeSpan(text, cursor, bf)
 
@@ -293,6 +299,13 @@ class MarkdownHighlighter(QSyntaxHighlighter):
             if stripped[0] not in ('*','-','+') and not re.match(self.MARKDOWN_KEYS_REGEX['OrderedList'], stripped):
                 self.setFormat(self.offset+ mo.start(), mo.end() - mo.start(), self.MARKDOWN_KWS_FORMAT['CodeBlock'])
                 found = True
+        return found
+
+    def highlightEntity(self, text, cursor, bf):
+        found = False
+        for mo in re.finditer(self.MARKDOWN_KEYS_REGEX['Entity'],text):
+            self.setFormat(self.offset+ mo.start(), mo.end() - mo.start(), self.MARKDOWN_KWS_FORMAT['Entity'])
+            found = True
         return found
 
     def highlightHtml(self, text):


### PR DESCRIPTION
Add support of HTML entity to the Markdown Highlighter. Also, apply the local bold and italic to the entity.