### PR TITLE
Book detail: Path field can be display on multiline

### DIFF
--- a/src/calibre/ebooks/metadata/book/render.py
+++ b/src/calibre/ebooks/metadata/book/render.py
@@ -225,12 +225,13 @@ def mi_to_html(
                                     break
                         text = _('Book files')
                         name = ngettext('Folder:', 'Folders:', num_of_folders)
-                    link = '<a href="{}" title="{}">{}</a>{}'.format(action(scheme, book_id=book_id, loc=loc),
-                        prepare_string_for_xml(path, True), text, extra)
+                    links = ['<a href="{}" title="{}">{}</a>{}'.format(action(scheme, book_id=book_id, loc=loc),
+                        prepare_string_for_xml(path, True), text, extra)]
                     if num_of_folders > 1:
-                        link += ', <a href="{}" title="{}">{}</a>'.format(
+                        links.append('<a href="{}" title="{}">{}</a>'.format(
                             action('data-path', book_id=book_id, loc=book_id),
-                            prepare_string_for_xml(data_path, True), _('Data files'))
+                            prepare_string_for_xml(data_path, True), _('Data files')))
+                    link = value_list(', ', links)
 
                 else:
                     link = prepare_string_for_xml(path, True)

--- a/src/calibre/gui2/preferences/look_feel.py
+++ b/src/calibre/gui2/preferences/look_feel.py
@@ -483,7 +483,9 @@ class BDVerticalCats(DisplayedFields):  # {{{
 
     def initialize(self, use_defaults=False, pref_data_override=None):
         fm = self.db.field_metadata
-        cats = [k for k in fm if fm[k]['name'] and fm[k]['is_multiple']]
+        cats = [k for k in fm if fm[k]['name'] and fm[k]['is_multiple'] and not k.startswith('#')]
+        cats.append('path')
+        cats.extend([k for k in fm if fm[k]['name'] and fm[k]['is_multiple'] and k.startswith('#')])
         ans = []
         if use_defaults:
             ans = [[k, False] for k in cats]


### PR DESCRIPTION
Currently, in the Book detail, the Path field can show a second link for the extra data of the book. Unfortunately, this second link is hard coded to be displayed in oneline only.
This commit allows the user to choose between oneline or multiline display, via the "Categories on separate lines" in the _Preference->Loonk & Feel->Book detail_ options.