### PR TITLE
[Recipe] High Country News - Fix group in builtin recipe UI tree

### DIFF
--- a/recipes/high_country_news.recipe
+++ b/recipes/high_country_news.recipe
@@ -11,9 +11,11 @@ from calibre.web.feeds.news import BasicNewsRecipe
 class HighCountryNews(BasicNewsRecipe):
     ##
     # Written:      2012-01-28
-    # Last Edited:  2022-08-17
+    # Last Edited:  2023-06-30
     #
-    # Remark:       Version 2.2
+    # Remark:       Version 2.3
+    #               Update language to fix how it appears in UI tree
+    #               Version 2.2
     #               Update RSS feeds to hcn.org and keep the old feedburner feeds still in place
     #               as there are some old articles available only at feedburner adress
     #               2019-07-04

--- a/recipes/high_country_news.recipe
+++ b/recipes/high_country_news.recipe
@@ -39,7 +39,7 @@ class HighCountryNews(BasicNewsRecipe):
     publisher = 'High Country News'
     category = 'News, Politics, Social, Nature, Environmental, Western United States, Native American'
     timefmt = ' [%a, %d %b %Y]'
-    language = 'en-Us'
+    language = 'en'
     encoding = 'UTF-8'
     publication_type = 'newspaper'
     oldest_article = 30


### PR DESCRIPTION
Because it say `en-Us` rather than `en` or `en-us` it appears in a branch on its own.

Since this site is web -design oriented and not specific to the USA, I have chosen to change it to `en` rather than `en-us` so it appears under English rather than English (United States).

Note: This is one of many language tweaks that are needed to clean up the UI. I will try to do as many as I can - please advise whether you would like them submitted as a single PR or in individual PRs.