### PR TITLE
Implement get_delay() for news recipes

### DIFF
--- a/src/calibre/web/fetch/simple.py
+++ b/src/calibre/web/fetch/simple.py
@@ -180,6 +180,7 @@ class RecursiveFetcher:
         self.compress_news_images = getattr(options, 'compress_news_images', False)
         self.compress_news_images_auto_size = getattr(options, 'compress_news_images_auto_size', 16)
         self.scale_news_images = getattr(options, 'scale_news_images', None)
+        self.get_delay = getattr(options, 'get_delay', lambda url=None: self.delay)
         self.download_stylesheets = not options.no_stylesheets
         self.show_progress = True
         self.failed_links = []
@@ -268,8 +269,9 @@ class RecursiveFetcher:
             return data
 
         delta = time.monotonic() - self.last_fetch_at
-        if delta < self.delay:
-            time.sleep(self.delay - delta)
+        delay = self.get_delay(url)
+        if delta < delay:
+            time.sleep(delay - delta)
         url = canonicalize_url(url)
         open_func = getattr(self.browser, 'open_novisit', self.browser.open)
         try:


### PR DESCRIPTION
I've noticed for many popular sites like NYTimes that implement bot protection, there is an opportunity to differentiate the delay based on the targeted url host. For example, for NYTimes, static assets like images are hosted on static01.nyt.com which is not as strictly protected as www.nytimes.com.

This PR allows users to programmatically determine the delay based on the url to be downloaded. 

Based on my own testing with nytimes.com and bloomberg.com, this can gain up to a 50% reduction in run time, more if the pages are image heavy.

```python
import random
from urllib.parse import urlparse

from calibre.web.feeds.news import BasicNewsRecipe


class DemoGetDelayRecipe(BasicNewsRecipe):
    title = "Demo Get Delay"
    __author__ = "ping"
    description = "Demo `get_delay()` usage"
    language = "en"
    remove_javascript = True
    no_stylesheets = True

    simultaneous_downloads = 1
    if not hasattr(BasicNewsRecipe, "get_delay"):
        # for backward compat
        delay = 3

    feeds = [
        ("Home", "https://www.nytimes.com/services/xml/rss/nyt/HomePage.xml"),
    ]

    def get_delay(self, url=None):
        if url and urlparse(url).netloc in ("static01.nyt.com",):
            return 0

        delay = random.choice([r * 0.5 for r in range(2, 6)])
        self.log.debug(f"Delaying fetch for {url} by {delay}s...")
        return delay
```