### PR TITLE
For some reason I don't understand, the array of mi values must be a …

### DIFF
--- a/src/calibre/gui2/preferences/save_template.py
+++ b/src/calibre/gui2/preferences/save_template.py
@@ -53,7 +53,7 @@ class SaveTemplate(QWidget, Ui_Form):
         from calibre.gui2.ui import get_gui
         db = get_gui().current_db
         view = get_gui().library_view
-        mi = tuple(map(db.new_api.get_proxy_metadata, view.get_selected_ids()[:10]))
+        mi = list(map(db.new_api.get_proxy_metadata, view.get_selected_ids()[:10]))
         if not mi:
             error_dialog(self, _('Must select books'),
                          _('One or more books must be selected so the template '


### PR DESCRIPTION
…list, not a tuple.

When a tuple, this line:
`w.setText(mi[r].title)`

produces the exception:
```
Traceback (most recent call last):
  File "C:\CBH_Data\calibre.git\calibre_dev\src\calibre\gui2\preferences\save_template.py", line 63, in do_open_editor
  File "C:\CBH_Data\calibre.git\calibre_dev\src\calibre\gui2\dialogs\template_dialog.py", line 433, in __init__
  File "C:\CBH_Data\calibre.git\calibre_dev\src\calibre\gui2\dialogs\template_dialog.py", line 578, in set_mi
AttributeError: 'tuple' object has no attribute 'title'
```