### PR TITLE
fix Changelog.old.txt not closed

### DIFF
--- a/Changelog.old.txt
+++ b/Changelog.old.txt
@@ -21133,3 +21133,5 @@ calibre is now able to download social metadata like tags/rating/reviews etc., i
 - Critica Digital
 - Infobae
 - Spiegel International
+
+}}}


### PR DESCRIPTION
Changelog.old.txt don't have the close brace for the last entry.
This result than the last entry is ignored if you try to parse it to retrive the JSON with setup.changelog