### PR TITLE
Refresh the GUI when DataFilesManager is lauched

### DIFF
--- a/src/calibre/gui2/actions/edit_metadata.py
+++ b/src/calibre/gui2/actions/edit_metadata.py
@@ -135,6 +135,8 @@ class EditMetadataAction(InterfaceAction):
         for book_id in ids:
             d = DataFilesManager(db, book_id, self.gui)
             d.exec()
+        cr = self.gui.library_view.currentIndex().row()
+        self.gui.library_view.model().refresh_ids(ids, cr)
 
     def _copy_links(self, lines):
         urls = QUrl.fromStringList(lines)


### PR DESCRIPTION
Fix: When the DataFilesManager is lauched by the default action `EditMetadataAction.manage_data_files()`, the field "Folder" is not updated in the book details panel (update also any composite column that use a extra data files function).