### PR TITLE
fix inconsistency field type for default book

### DIFF
--- a/src/calibre/gui2/dialogs/template_dialog.py
+++ b/src/calibre/gui2/dialogs/template_dialog.py
@@ -548,7 +548,7 @@ class TemplateDialog(QDialog, Ui_TemplateDialog):
                 elif fm[col]['datatype'] == 'bool':
                     mi.set(col, False)
                 elif fm[col]['is_multiple']:
-                    mi.set(col, (col,))
+                    mi.set(col, [col])
                 else:
                     mi.set(col, col, 1)
             mi = (mi, )


### PR DESCRIPTION
Fix a inconsistency that return a turple for custom fields with multiple value for the "default book" in the template editor, instead of a list.

mi.get('author') + mi.get('#custom_multiple') => TypeError - can only concatenate list (not "tuple") to list.