### PR TITLE
Some refactoring and improvements:

### DIFF
--- a/src/calibre/gui2/dialogs/edit_authors_dialog.py
+++ b/src/calibre/gui2/dialogs/edit_authors_dialog.py
@@ -230,9 +230,7 @@ class EditAuthorsDialog(QDialog, Ui_EditAuthorsDialog):
             self.table.setItem(row, 1, sort_item)
             self.table.setItem(row, 2, link_item)
 
-            item_id = db.get_item_id('authors', name)
-            nw = NotesItemWidget(get_gui().current_db.new_api, 'authors', item_id, row)
-            nw.clicked.connect(self.notes_button_clicked)
+            nw = NotesItemWidget(get_gui().current_db, 'authors', name)
             self.table.setCellWidget(row, 3, nw)
 
             self.set_icon(name_item, id_)
@@ -284,10 +282,6 @@ class EditAuthorsDialog(QDialog, Ui_EditAuthorsDialog):
             self.find_box.setFocus()
             self.start_find_pos = -1
         self.table.blockSignals(False)
-
-    def notes_button_clicked(self, w, field, item_id, db):
-        EditNoteDialog(field, item_id, db).exec()
-        w.set_checked()
 
     def row_height_changed(self, row, old, new):
         self.table.verticalHeader().blockSignals(True)


### PR DESCRIPTION
1) Add a context menu to the notes widget. Remove the keyboard handler as it isn't needed. 
2) Allow passing an item string value instead of an item_id to __init__ 
3) Make the notes widget self contained, making the signal advisory instead of mandatory 
4) Add a delete note button to the widget.