### PR TITLE
update Washington football team name in Washington Post recipe

### DIFF
--- a/recipes/wash_post.recipe
+++ b/recipes/wash_post.recipe
@@ -58,7 +58,7 @@ class TheWashingtonPost(BasicNewsRecipe):
         # Undocumented feeds.
         (u'White House',
          u'http://feeds.washingtonpost.com/rss/politics/whitehouse'),
-        (u'Redskins', u'http://feeds.washingtonpost.com/rss/sports/redskins'),
+        (u'Commanders', u'http://feeds.washingtonpost.com/rss/sports/redskins'),
     ]
 
     def preprocess_html(self, soup, *a):


### PR DESCRIPTION
The Washington NFL team was renamed in 2022. Updating news recipe to reflect the new name, "Commanders"