### PR TITLE
fix compatibility with newer zeroconf

### DIFF
--- a/src/calibre/devices/smart_device_app/driver.py
+++ b/src/calibre/devices/smart_device_app/driver.py
@@ -2175,7 +2175,12 @@ def monkeypatch_zeroconf():
     # "monkeypatch" zeroconf with a function without the check
     try:
         from zeroconf._utils.name import service_type_name
-        service_type_name.__kwdefaults__['strict'] = False
     except ImportError:
         import zeroconf
         zeroconf.service_type_name = monkeypatched_service_type_name
+    else:
+        try:
+            # zeroconf 0.73 uses an lru cache
+            service_type_name.__wrapped__.__kwdefaults__['strict'] = False
+        except AttributeError:
+            service_type_name.__kwdefaults__['strict'] = False


### PR DESCRIPTION
In zeroconf 0.73, the monkey-patched function was wrapped in an lru_cache, which means that we need to monkey-patch the wrapped version of the function, for a cost of a bit of indirection.

https://github.com/python-zeroconf/python-zeroconf/commit/53a694f60e675ae0560e727be6b721b401c2b68f