### PR TITLE
Improve error handling in get_results method

### DIFF
--- a/src/calibre/gui2/store/search/search.py
+++ b/src/calibre/gui2/store/search/search.py
@@ -384,7 +384,14 @@ class SearchDialog(QDialog, Ui_Dialog):
         while self.search_pool.has_results():
             res, store_plugin = self.search_pool.get_result()
             if res:
-                self.results_view.model().add_result(res, store_plugin)
+                try:
+                    self.results_view.model().add_result(res, store_plugin)
+                except TypeError as err:
+                    error_message = (
+                            _("An error occurred when processing result: %s of store plugin: %s: %s")
+                            % (str(res), str(store_plugin), str(err))
+                    )
+                    error_dialog(self, _('Error'), error_message, show=True)
 
         if not self.search_pool.threads_running() and not self.results_view.model().has_results():
             info_dialog(self, _('No matches'), _('Couldn\'t find any books matching your query.'), show=True, show_copy_button=False)


### PR DESCRIPTION
### tl;dr

This PR enhances the error-handling capabilities of the `get_results` method. 

### Problem

#### Description

Previously, the method could encounter unhandled exceptions, potentially disrupting the user experience:

```
Traceback (most recent call last):
  File "calibre/gui2/store/search/search.py", line 387, in get_results
  File "calibre/gui2/store/search/models.py", line 97, in add_result
  File "calibre/gui2/store/search/models.py", line 119, in _filter_results
  File "calibre/gui2/store/search/models.py", line 291, in sort
  File "calibre/gui2/store/search/models.py", line 292, in <lambda>
  File "calibre/gui2/store/search/models.py", line 263, in data_as_text
  File "calibre/gui2/store/search/models.py", line 24, in comparable_price
  File "re.py", line 200, in search
TypeError: expected string or bytes-like object
```

#### Screenshot

<img width="742" alt="Screenshot 2023-10-02 at 20 34 24" src="https://github.com/kovidgoyal/calibre/assets/8149019/3c70753f-b892-4eb5-b229-0aa3587882a2">


### Improvement

To address this issue, comprehensive error handling has been added. When processing search results from store plugins, the code now gracefully handles potential TypeError exceptions. In case of an error, an informative error dialog is displayed to the user, providing details about the specific result and the associated store plugin.

This improvement ensures a more reliable and user-friendly experience, enhancing the overall quality of the application.