### PR TITLE
Fix online dictionaries

### DIFF
--- a/src/calibre/spell/__init__.py
+++ b/src/calibre/spell/__init__.py
@@ -23,6 +23,9 @@ def parse_lang_code(raw):
     if lc is None:
         raise ValueError('Invalid language code: %r' % raw)
     cc = None
+    for sc in ['Cyrl', 'Latn']:
+        if sc in parts:
+            parts.remove(sc)
     if len(parts) > 1:
         ccodes, ccodemap = get_codes()[:2]
         q = parts[1].upper()

--- a/src/calibre/spell/import_from.py
+++ b/src/calibre/spell/import_from.py
@@ -45,6 +45,8 @@ def parse_xcu(raw, origin='%origin%'):
             paths = [c.text.replace('%origin%', origin) for v in value for c in v.iterchildren('*') if c.text]
         aff, dic = paths if paths[0].endswith('.aff') else reversed(paths)
         locales = ''.join(XPath('descendant::prop[@oor:name="Locales"]/value/text()')(node)).split()
+        if not locales:
+            locales = [str(item) for item in XPath('descendant::prop[@oor:name="Locales"]/value/it/text()')(node)]
         ans[(dic, aff)] = locales
     return ans
 

--- a/src/calibre/spell/import_from.py
+++ b/src/calibre/spell/import_from.py
@@ -158,8 +158,16 @@ def import_from_oxt(source_path, name, dest_dir=None, prefix='dic-'):
 def import_from_online(directory, name, dest_dir=None, prefix='dic-'):
     br = browser(timeout=30)
     def read_file(key):
-        rp = br.open('/'.join((ONLINE_DICTIONARY_BASE_URL, directory, key)))
-        return rp.read()
+        try:
+            rp = br.open('/'.join((ONLINE_DICTIONARY_BASE_URL, directory, key)))
+            return rp.read()
+        except:
+            # Some dictionaries apparently put the dic and aff file in a
+            # sub-directory dictionaries and incorrectly make paths relative
+            # to that directory instead of the root, for example:
+            # https://github.com/LibreOffice/dictionaries/tree/master/ca
+            rp = br.open('/'.join((ONLINE_DICTIONARY_BASE_URL, directory, 'dictionaries', key)))
+            return rp.read()
 
     return _import_from_virtual_directory(read_file, name, dest_dir=dest_dir, prefix=prefix)
 


### PR DESCRIPTION
Three commit for bug fix that prevent the download of some dictionaries.

1. **fix incorrectly relative paths**<br>Some dictionaries apparently put the dic and aff file in a sub-directory dictionaries and incorrectly make paths relative to that directory instead of the root, for example: [ca](https://github.com/LibreOffice/dictionaries/tree/master/ca)

2. **fix alternative string-list representation in xcu**<br>A alternative representation for string-list use \<it\> tag for each item of the list, for example: [tr-TR](https://github.com/LibreOffice/dictionaries/tree/master/tr_TR)

3. **fix script variante includes in the lang_code**<br>Some dictionaries add a script variante in their lang_code, for example: [mn-MN](https://github.com/LibreOffice/dictionaries/tree/master/mn_MN)
