### PR TITLE
calibre-server: don't call listen() on pre-allocated sockets

### DIFF
--- a/src/calibre/srv/embedded.py
+++ b/src/calibre/srv/embedded.py
@@ -131,7 +131,8 @@ class Server:
                 pass
         reset_caches()  # we reset the cache as the server tdir has changed
         try:
-            self.loop.serve_forever()
+            # self.loop.initialize_socket() already called in self.start()
+            self.loop.serve()
         except BaseException as e:
             self.exception = e
         if self.state_callback is not None:

--- a/src/calibre/srv/loop.py
+++ b/src/calibre/srv/loop.py
@@ -499,22 +499,22 @@ class ServerLoop:
                     self.bind_address[0], as_unicode(err), ip))
                 self.bind_address = (ip, self.bind_address[1])
                 self.do_bind()
+            self.socket.listen(min(socket.SOMAXCONN, 128))
         else:
             self.socket = self.pre_activated_socket
             self.pre_activated_socket = None
             self.setup_socket()
-
-    def serve(self):
-        self.connection_map = {}
-        self.socket.listen(min(socket.SOMAXCONN, 128))
         self.bound_address = ba = self.socket.getsockname()
         if isinstance(ba, tuple):
             ba = ':'.join(map(str, ba))
+        if self.LISTENING_MSG:
+            self.log(self.LISTENING_MSG, ba)
+
+    def serve(self):
+        self.connection_map = {}
         self.pool.start()
         with TemporaryDirectory(prefix='srv-') as tdir:
             self.tdir = tdir
-            if self.LISTENING_MSG:
-                self.log(self.LISTENING_MSG, ba)
             self.plugin_pool.start()
             self.ready = True
 

--- a/src/calibre/srv/tests/loop.py
+++ b/src/calibre/srv/tests/loop.py
@@ -214,6 +214,7 @@ class LoopTest(BaseTest):
         os.closerange(3, 4)  # Ensure the socket gets fileno == 3
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)
         s.bind(('localhost', 0))
+        s.listen()
         port = s.getsockname()[1]
         self.ae(s.fileno(), 3)
         os.environ['LISTEN_PID'] = str(os.getpid())


### PR DESCRIPTION
When using systemd socket activation, the pre-allocated socket is already
listening. There is no need to call `socket.listen()` on it again.

* `calibre/srv/loop.py`

Move `socket.listen()` (and log message) from `ServerLoop.serve()` to
`ServerLoop.initialize_socket()`, and skip it for pre-allocated sockets.

* `calibre/srv/embedded.py`

`Server.serve_forever()` should call `ServerLoop.serve()`, not
`ServerLoop.serve_forever()`. The latter function initializes the socket, which
is not needed because `Server.start()` has already called
`ServerLoop.initialize_socket()`.

I've tested that this fixes the socket activation issue in [bug 2039395](https://bugs.launchpad.net/calibre/+bug/2039395). I also
confirmed that it doesn't break starting the server without socket activation,
or the embedded server run from the Calibre GUI.