### PR TITLE
...

### DIFF
--- a/src/calibre/web/feeds/news.py
+++ b/src/calibre/web/feeds/news.py
@@ -1207,7 +1207,7 @@ class BasicNewsRecipe(Recipe):
             data = x['data']
             if isinstance(data, str):
                 data = data.encode(self.encoding or 'utf-8')
-            url = data.get('url', url)
+            url = x.get('url', url)
         else:
             with open(x, 'rb') as of:
                 data = of.read()


### PR DESCRIPTION
File "calibre\web\feeds\news.py", line 1210, in fetch_obfuscated_article
AttributeError: 'bytes' object has no attribute 'get'

tried the new get_obfuscated-article method, and got this error.