### PR TITLE
Really choose oldest file modification time in target files

### DIFF
--- a/setup/__init__.py
+++ b/setup/__init__.py
@@ -47,7 +47,7 @@ def newer(targets, sources):
         if not os.path.exists(f):
             return True
     ttimes = map(lambda x: os.stat(x).st_mtime, targets)
-    oldest_target = max(ttimes)
+    oldest_target = min(ttimes)
     try:
         stimes = map(lambda x: os.stat(x).st_mtime, sources)
         newest_source = max(stimes)


### PR DESCRIPTION
Choose oldest file when 2 or more files for `targets` parameter.
This requires `newer()` works propely to select newer files.
