### PR TITLE
Add a "Show items in selected books" choice to manage tags and manage…

### DIFF
--- a/src/calibre/gui2/dialogs/edit_authors_dialog.py
+++ b/src/calibre/gui2/dialogs/edit_authors_dialog.py
@@ -108,7 +108,10 @@ class EditAuthorsDialog(QDialog, Ui_EditAuthorsDialog):
         self.buttonBox.button(QDialogButtonBox.StandardButton.Cancel).setText(_('&Cancel'))
         self.buttonBox.accepted.connect(self.accepted)
         self.buttonBox.rejected.connect(self.rejected)
-        self.apply_vl_checkbox.stateChanged.connect(self.use_vl_changed)
+        self.apply_vl_checkbox.setAutoExclusive(False)
+        self.apply_vl_checkbox.toggled.connect(self.use_vl_changed)
+        self.apply_selection_checkbox.setAutoExclusive(False)
+        self.apply_selection_checkbox.toggled.connect(self.apply_selection_box_changed)
 
         self.table.setAlternatingRowColors(True)
         self.table.setSelectionMode(QAbstractItemView.SelectionMode.SingleSelection)
@@ -211,7 +214,21 @@ class EditAuthorsDialog(QDialog, Ui_EditAuthorsDialog):
             self.ignore_cell_changed = orig
 
     def use_vl_changed(self, x):
+        if self.apply_vl_checkbox.isChecked():
+            self.apply_selection_checkbox.setChecked(False)
         self.show_table(None, None, None, False)
+
+    def apply_selection_box_changed(self, x):
+        if self.apply_selection_checkbox.isChecked():
+            self.apply_vl_checkbox.setChecked(False)
+        self.show_table(None, None, None, False)
+
+    def selection_to_apply(self):
+        if self.apply_selection_checkbox.isChecked():
+            return 'selection'
+        if self.apply_vl_checkbox.isChecked():
+            return 'virtual_library'
+        return None
 
     def clear_filter(self):
         self.filter_box.setText('')
@@ -221,8 +238,7 @@ class EditAuthorsDialog(QDialog, Ui_EditAuthorsDialog):
         self.show_table(None, None, None, False)
 
     def show_table(self, id_to_select, select_sort, select_link, is_first_letter):
-        auts_to_show = {t[0] for t in
-                   self.find_aut_func(use_virtual_library=self.apply_vl_checkbox.isChecked())}
+        auts_to_show = {t[0] for t in self.find_aut_func(self.selection_to_apply())}
         filter_text = icu_lower(str(self.filter_box.text()))
         if filter_text:
             auts_to_show = {id_ for id_ in auts_to_show

--- a/src/calibre/gui2/dialogs/edit_authors_dialog.py
+++ b/src/calibre/gui2/dialogs/edit_authors_dialog.py
@@ -326,6 +326,7 @@ class EditAuthorsDialog(QDialog, Ui_EditAuthorsDialog):
             self.find_box.setFocus()
             self.start_find_pos = -1
         self.table.blockSignals(False)
+        self.table.setFocus(Qt.FocusReason.OtherFocusReason)
 
     def row_height_changed(self, row, old, new):
         self.table.verticalHeader().blockSignals(True)

--- a/src/calibre/gui2/dialogs/edit_authors_dialog.py
+++ b/src/calibre/gui2/dialogs/edit_authors_dialog.py
@@ -108,9 +108,13 @@ class EditAuthorsDialog(QDialog, Ui_EditAuthorsDialog):
         self.buttonBox.button(QDialogButtonBox.StandardButton.Cancel).setText(_('&Cancel'))
         self.buttonBox.accepted.connect(self.accepted)
         self.buttonBox.rejected.connect(self.rejected)
-        self.apply_vl_checkbox.setAutoExclusive(False)
+        self.show_button_layout.setSpacing(0)
+        self.show_button_layout.setContentsMargins(0, 0, 0, 0)
+        self.apply_all_checkbox.setContentsMargins(0, 0, 0, 0)
+        self.apply_all_checkbox.setChecked(True)
+        self.apply_vl_checkbox.setContentsMargins(0, 0, 0, 0)
         self.apply_vl_checkbox.toggled.connect(self.use_vl_changed)
-        self.apply_selection_checkbox.setAutoExclusive(False)
+        self.apply_selection_checkbox.setContentsMargins(0, 0, 0, 0)
         self.apply_selection_checkbox.toggled.connect(self.apply_selection_box_changed)
 
         self.table.setAlternatingRowColors(True)
@@ -214,13 +218,9 @@ class EditAuthorsDialog(QDialog, Ui_EditAuthorsDialog):
             self.ignore_cell_changed = orig
 
     def use_vl_changed(self, x):
-        if self.apply_vl_checkbox.isChecked():
-            self.apply_selection_checkbox.setChecked(False)
         self.show_table(None, None, None, False)
 
     def apply_selection_box_changed(self, x):
-        if self.apply_selection_checkbox.isChecked():
-            self.apply_vl_checkbox.setChecked(False)
         self.show_table(None, None, None, False)
 
     def selection_to_apply(self):

--- a/src/calibre/gui2/dialogs/edit_authors_dialog.ui
+++ b/src/calibre/gui2/dialogs/edit_authors_dialog.ui
@@ -66,14 +66,34 @@
       </spacer>
      </item>
      <item row="0" column="4">
-      <widget class="QCheckBox" name="apply_vl_checkbox">
+      <widget class="QRadioButton" name="apply_vl_checkbox">
        <property name="toolTip">
-        <string>&lt;p&gt;Only show authors in the
+        <string>&lt;p&gt;Show authors only if they appear in the
           current Virtual library. Edits already done may be hidden but will
-          not be forgotten.&lt;/p&gt;</string>
+          not be forgotten.
+          &lt;/p&gt;&lt;p&gt;
+          Note that this box affects only what is displayed. Changes
+          will affect all books in your library even if this box
+          is checked.&lt;/p&gt;&lt;</string>
        </property>
        <property name="text">
         <string>Only show authors in the current &amp;Virtual library</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="4">
+      <widget class="QRadioButton" name="apply_selection_checkbox">
+       <property name="toolTip">
+        <string>&lt;p&gt;Show items only if they appear in the
+          currently selected books. Edits already done may be hidden but will
+          not be forgotten.
+          &lt;/p&gt;&lt;p&gt;
+          Note that this box affects only what is displayed. Changes
+          will affect all books in your library even if this box
+          is checked.&lt;/p&gt;&lt;</string>
+       </property>
+       <property name="text">
+        <string>O&amp;nly show authors in the currently selected books</string>
        </property>
       </widget>
      </item>

--- a/src/calibre/gui2/dialogs/edit_authors_dialog.ui
+++ b/src/calibre/gui2/dialogs/edit_authors_dialog.ui
@@ -65,37 +65,48 @@
        </property>
       </spacer>
      </item>
-     <item row="0" column="4">
-      <widget class="QRadioButton" name="apply_vl_checkbox">
-       <property name="toolTip">
-        <string>&lt;p&gt;Show authors only if they appear in the
-          current Virtual library. Edits already done may be hidden but will
-          not be forgotten.
-          &lt;/p&gt;&lt;p&gt;
-          Note that this box affects only what is displayed. Changes
-          will affect all books in your library even if this box
-          is checked.&lt;/p&gt;&lt;</string>
-       </property>
-       <property name="text">
-        <string>Only show authors in the current &amp;Virtual library</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="4">
-      <widget class="QRadioButton" name="apply_selection_checkbox">
-       <property name="toolTip">
-        <string>&lt;p&gt;Show items only if they appear in the
-          currently selected books. Edits already done may be hidden but will
-          not be forgotten.
-          &lt;/p&gt;&lt;p&gt;
-          Note that this box affects only what is displayed. Changes
-          will affect all books in your library even if this box
-          is checked.&lt;/p&gt;&lt;</string>
-       </property>
-       <property name="text">
-        <string>O&amp;nly show authors in the currently selected books</string>
-       </property>
-      </widget>
+     <item row="0" column="4" rowspan="2">
+      <layout class="QVBoxLayout" name="show_button_layout">
+       <item>
+        <widget class="QRadioButton" name="apply_all_checkbox">
+         <property name="text">
+          <string>Show &amp;all authors</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="apply_vl_checkbox">
+         <property name="toolTip">
+          <string>&lt;p&gt;Show authors only if they appear in the
+                    current Virtual library. Edits already done may be hidden but will
+                    not be forgotten.
+                    &lt;/p&gt;&lt;p&gt;
+                    Note that this box affects only what is displayed. Changes
+                    will affect all books in your library even if this box
+                    is checked.&lt;/p&gt;&lt;</string>
+         </property>
+         <property name="text">
+          <string>Only show authors in the current &amp;Virtual library</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="apply_selection_checkbox">
+         <property name="toolTip">
+          <string>&lt;p&gt;Show items only if they appear in the
+                    currently selected books. Edits already done may be hidden but will
+                    not be forgotten.
+                    &lt;/p&gt;&lt;p&gt;
+                    Note that this box affects only what is displayed. Changes
+                    will affect all books in your library even if this box
+                    is checked.&lt;/p&gt;&lt;</string>
+         </property>
+         <property name="text">
+          <string>O&amp;nly show authors in the currently selected books</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </item>
      <item row="1" column="0">
       <widget class="QLabel">

--- a/src/calibre/gui2/dialogs/tag_list_editor.py
+++ b/src/calibre/gui2/dialogs/tag_list_editor.py
@@ -779,6 +779,7 @@ class TagListEditor(QDialog, Ui_TagListEditor):
                 self.table.setCurrentCell(0, 0)
                 self.search_box.setFocus()
                 self.start_find_pos = -1
+        self.table.setFocus(Qt.FocusReason.OtherFocusReason)
 
     def not_found_label_timer_event(self):
         self.not_found_label.setVisible(False)

--- a/src/calibre/gui2/dialogs/tag_list_editor.py
+++ b/src/calibre/gui2/dialogs/tag_list_editor.py
@@ -372,7 +372,10 @@ class TagListEditor(QDialog, Ui_TagListEditor):
             ac.triggered.connect(self.clear_filter)
         le.returnPressed.connect(self.do_filter)
         self.filter_button.clicked.connect(self.do_filter)
-        self.apply_vl_checkbox.clicked.connect(self.vl_box_changed)
+        self.apply_vl_checkbox.setAutoExclusive(False)
+        self.apply_vl_checkbox.toggled.connect(self.vl_box_changed)
+        self.apply_selection_checkbox.setAutoExclusive(False)
+        self.apply_selection_checkbox.toggled.connect(self.apply_selection_box_changed)
 
         self.is_enumerated = False
         if fm:
@@ -537,8 +540,23 @@ class TagListEditor(QDialog, Ui_TagListEditor):
         return txt.swapcase()
 
     def vl_box_changed(self):
+        if self.apply_vl_checkbox.isChecked():
+            self.apply_selection_checkbox.setChecked(False)
         self.search_item_row = -1
         self.fill_in_table(None, None, False)
+
+    def apply_selection_box_changed(self):
+        if self.apply_selection_checkbox.isChecked():
+            self.apply_vl_checkbox.setChecked(False)
+        self.search_item_row = -1
+        self.fill_in_table(None, None, False)
+
+    def selection_to_apply(self):
+        if self.apply_selection_checkbox.isChecked():
+            return 'selection'
+        if self.apply_vl_checkbox.isChecked():
+            return 'virtual_library'
+        return None
 
     def do_search(self):
         self.not_found_label.setVisible(False)
@@ -653,7 +671,7 @@ class TagListEditor(QDialog, Ui_TagListEditor):
     def fill_in_table(self, tags, tag_to_match, ttm_is_first_letter):
         self.create_table()
 
-        data = self.get_book_ids(self.apply_vl_checkbox.isChecked())
+        data = self.get_book_ids(self.selection_to_apply())
         self.all_tags = {}
         filter_text = icu_lower(str(self.filter_box.text()))
         for k,v,count in data:

--- a/src/calibre/gui2/dialogs/tag_list_editor.py
+++ b/src/calibre/gui2/dialogs/tag_list_editor.py
@@ -372,9 +372,12 @@ class TagListEditor(QDialog, Ui_TagListEditor):
             ac.triggered.connect(self.clear_filter)
         le.returnPressed.connect(self.do_filter)
         self.filter_button.clicked.connect(self.do_filter)
-        self.apply_vl_checkbox.setAutoExclusive(False)
+        self.show_button_layout.setSpacing(0)
+        self.show_button_layout.setContentsMargins(0, 0, 0, 0)
+        self.apply_all_checkbox.setContentsMargins(0, 0, 0, 0)
+        self.apply_all_checkbox.setChecked(True)
         self.apply_vl_checkbox.toggled.connect(self.vl_box_changed)
-        self.apply_selection_checkbox.setAutoExclusive(False)
+        self.apply_selection_checkbox.setContentsMargins(0, 0, 0, 0)
         self.apply_selection_checkbox.toggled.connect(self.apply_selection_box_changed)
 
         self.is_enumerated = False
@@ -540,14 +543,10 @@ class TagListEditor(QDialog, Ui_TagListEditor):
         return txt.swapcase()
 
     def vl_box_changed(self):
-        if self.apply_vl_checkbox.isChecked():
-            self.apply_selection_checkbox.setChecked(False)
         self.search_item_row = -1
         self.fill_in_table(None, None, False)
 
     def apply_selection_box_changed(self):
-        if self.apply_selection_checkbox.isChecked():
-            self.apply_vl_checkbox.setChecked(False)
         self.search_item_row = -1
         self.fill_in_table(None, None, False)
 

--- a/src/calibre/gui2/dialogs/tag_list_editor.ui
+++ b/src/calibre/gui2/dialogs/tag_list_editor.ui
@@ -72,7 +72,7 @@
     </spacer>
    </item>
    <item row="0" column="4">
-    <widget class="QCheckBox" name="apply_vl_checkbox">
+    <widget class="QRadioButton" name="apply_vl_checkbox">
      <property name="toolTip">
       <string>&lt;p&gt;Show items only if they appear in the
           current Virtual library. Edits already done may be hidden but will
@@ -84,6 +84,22 @@
      </property>
      <property name="text">
       <string>Only show items in the current &amp;Virtual library</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="4">
+    <widget class="QRadioButton" name="apply_selection_checkbox">
+     <property name="toolTip">
+      <string>&lt;p&gt;Show items only if they appear in the
+          currently selected books. Edits already done may be hidden but will
+          not be forgotten.
+          &lt;/p&gt;&lt;p&gt;
+          Note that this box affects only what is displayed. Changes
+          will affect all books in your library even if this box
+          is checked.&lt;/p&gt;</string>
+     </property>
+     <property name="text">
+      <string>O&amp;nly show items in the currently selected books</string>
      </property>
     </widget>
    </item>

--- a/src/calibre/gui2/dialogs/tag_list_editor.ui
+++ b/src/calibre/gui2/dialogs/tag_list_editor.ui
@@ -71,37 +71,48 @@
      </property>
     </spacer>
    </item>
-   <item row="0" column="4">
-    <widget class="QRadioButton" name="apply_vl_checkbox">
-     <property name="toolTip">
-      <string>&lt;p&gt;Show items only if they appear in the
-          current Virtual library. Edits already done may be hidden but will
-          not be forgotten.
-          &lt;/p&gt;&lt;p&gt;
-          Note that this box affects only what is displayed. Changes
-          will affect all books in your library even if this box
-          is checked.&lt;/p&gt;</string>
-     </property>
-     <property name="text">
-      <string>Only show items in the current &amp;Virtual library</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="4">
-    <widget class="QRadioButton" name="apply_selection_checkbox">
-     <property name="toolTip">
-      <string>&lt;p&gt;Show items only if they appear in the
-          currently selected books. Edits already done may be hidden but will
-          not be forgotten.
-          &lt;/p&gt;&lt;p&gt;
-          Note that this box affects only what is displayed. Changes
-          will affect all books in your library even if this box
-          is checked.&lt;/p&gt;</string>
-     </property>
-     <property name="text">
-      <string>O&amp;nly show items in the currently selected books</string>
-     </property>
-    </widget>
+   <item row="0" column="4" rowspan="2">
+    <layout class="QVBoxLayout" name="show_button_layout">
+     <item>
+      <widget class="QRadioButton" name="apply_all_checkbox">
+       <property name="text">
+        <string>Show &amp;all items</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="apply_vl_checkbox">
+       <property name="toolTip">
+        <string>&lt;p&gt;Show items only if they appear in the
+             current Virtual library. Edits already done may be hidden but will
+             not be forgotten.
+             &lt;/p&gt;&lt;p&gt;
+             Note that this box affects only what is displayed. Changes
+             will affect all books in your library even if this box
+             is checked.&lt;/p&gt;</string>
+       </property>
+       <property name="text">
+        <string>Only show items in the current &amp;Virtual library</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="apply_selection_checkbox">
+       <property name="toolTip">
+        <string>&lt;p&gt;Show items only if they appear in the
+             currently selected books. Edits already done may be hidden but will
+             not be forgotten.
+             &lt;/p&gt;&lt;p&gt;
+             Note that this box affects only what is displayed. Changes
+             will affect all books in your library even if this box
+             is checked.&lt;/p&gt;</string>
+       </property>
+       <property name="text">
+        <string>O&amp;nly show items in the currently selected books</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item row="1" column="0">
     <widget class="QLabel" name="label">


### PR DESCRIPTION
… authors.

Radio buttons are more visually intuitive than checkboxes, but it is a little strange not having a "Use all" radio button. You click the radio button again to turn it off. Adding the third button takes up more vertical space than it is worth. Switching back to checkboxes (that act like radio buttons) is trivial if you think that is a better visual appearance.