### PR TITLE
Several changes:

### DIFF
--- a/src/calibre/gui2/dialogs/edit_authors_dialog.ui
+++ b/src/calibre/gui2/dialogs/edit_authors_dialog.ui
@@ -182,7 +182,19 @@ after changing Preferences-&gt;Advanced-&gt;Tweaks-&gt;Author sort name algorith
        </property>
       </widget>
      </item>
-     <item row="1" column="2">
+     <item row="1" column="3">
+      <widget class="QPushButton" name="edit_current_cell">
+       <property name="toolTip">
+        <string>&lt;p&gt;Edit the currently selected cell. If an author is edited then it is renamed
+                in every book where it is used. Double-clicking and pressing the edit
+                key also work.&lt;/p&gt;</string>
+       </property>
+       <property name="text">
+        <string>Edi&amp;t current cell</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="4">
       <widget class="QDialogButtonBox" name="buttonBox">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">

--- a/src/calibre/gui2/dialogs/tag_list_editor.ui
+++ b/src/calibre/gui2/dialogs/tag_list_editor.ui
@@ -172,7 +172,9 @@
      <item>
       <widget class="QToolButton" name="delete_button">
        <property name="toolTip">
-        <string>Delete selected items from the database. This will unapply the items from all books and then remove them from the database.</string>
+        <string>&lt;p&gt;Delete selected items from the database.
+                This will unapply the items from all books and then remove them
+                from the database. This button's shortcut is Ctrl+D&lt;/p&gt;</string>
        </property>
        <property name="text">
         <string>...</string>
@@ -208,7 +210,9 @@
      <item>
       <widget class="QToolButton" name="rename_button">
        <property name="toolTip">
-        <string>Rename the items in every book where they are used</string>
+        <string>&lt;p&gt;Edit the currently selected cell. If a tag is edited then it is renamed
+                in every book where it is used. Double-clicking and pressing the edit
+                key also work. This button's shortcut is Ctrl+E&lt;/p&gt;</string>
        </property>
        <property name="text">
         <string>...</string>
@@ -224,7 +228,7 @@
         </size>
        </property>
        <property name="shortcut">
-        <string>Ctrl+R</string>
+        <string>Ctrl+E</string>
        </property>
       </widget>
      </item>
@@ -244,7 +248,9 @@
      <item>
       <widget class="QToolButton" name="undo_button">
        <property name="toolTip">
-        <string>Undo any deletes or edits on the selected lines</string>
+        <string>&lt;p&gt;Undo all deletes or edits on the selected lines.
+                This button's shortcut is Ctrl+U&lt;/p&gt;
+        </string>
        </property>
        <property name="text">
         <string>...</string>


### PR DESCRIPTION
1. Improve performance by caching all icons.
2. Use different icons instead of a check mark for notes. Sorting uses the icon.
3. In manage tags, make the edit button on the left work on all editable cells. Correct the tooltip.
4. In manage tags, put the button press shortcut descriptions into the tooltips.
5. In manage authors, add an "Edit cell" button that works with all editable cells.