### PR TITLE
Change print statements to print functions

### DIFF
--- a/manual/develop.rst
+++ b/manual/develop.rst
@@ -179,7 +179,7 @@ Setting this environment variable means that calibre will now load all its Pytho
 That's it! You are now ready to start hacking on the calibre code. For example, open the file :file:`src\\calibre\\__init__.py`
 in your favorite editor and add the line::
 
-    print ("Hello, world!")
+    print("Hello, world!")
 
 near the top of the file. Now run the command :command:`calibredb`. The very first line of output should be ``Hello, world!``.
 
@@ -259,7 +259,7 @@ Setting this environment variable means that calibre will now load all its Pytho
 That's it! You are now ready to start hacking on the calibre code. For example, open the file :file:`src/calibre/__init__.py`
 in your favorite editor and add the line::
 
-    print ("Hello, world!")
+    print("Hello, world!")
 
 near the top of the file. Now run the command :command:`calibredb`. The very first line of output should be ``Hello, world!``.
 
@@ -406,7 +406,7 @@ you can also directly import calibre, as follows::
     import init_calibre
     import calibre
 
-    print calibre.__version__
+    print(calibre.__version__)
 
 It is essential that you import the init_calibre module before any other calibre modules/packages as
 it sets up the interpreter to run calibre code.

--- a/manual/function_mode.rst
+++ b/manual/function_mode.rst
@@ -176,9 +176,9 @@ Contents based on these headings. Create the custom function below:
                     parent = root.children[-1] if tag_name == 'h2' and root.children else root
                     parent.add(text, file_name, anchor)
                 toc = toc_to_html(root, current_container(), 'toc.html', 'Table of Contents for ' + metadata.title, metadata.language)
-                print (xml2str(toc))
+                print(xml2str(toc))
             else:
-                print ('No headings to build ToC from found')
+                print('No headings to build ToC from found')
         else:
             # Add an entry corresponding to this match to the Table of Contents
             if 'toc' not in data:

--- a/manual/template_ref_generate.py
+++ b/manual/template_ref_generate.py
@@ -76,7 +76,7 @@ def generate_template_language_help(language):
         func_sig = getattr(func, 'doc')
         m = pat.search(func_sig)
         if m is None:
-            print ('No signature for template function ', class_name)
+            print('No signature for template function ', class_name)
             continue
         func_sig = func_sig[:m.start()+1].strip('`')
         func_cat = getattr(func, 'category')

--- a/src/calibre/customize/builtins.py
+++ b/src/calibre/customize/builtins.py
@@ -1964,12 +1964,12 @@ if __name__ == '__main__':
         ):
             if x in sys.modules:
                 ret = 1
-                print (x, 'has been loaded by a plugin')
+                print(x, 'has been loaded by a plugin')
         if ret:
-            print ('\\nA good way to track down what is loading something is to run'
+            print('\\nA good way to track down what is loading something is to run'
             ' python -c "import init_calibre; import calibre.customize.builtins"')
             print()
-        print ('Time taken to import all plugins: %.2f'%t)
+        print('Time taken to import all plugins: %.2f'%t)
         sys.exit(ret)
 
         ''')])

--- a/src/calibre/linux.py
+++ b/src/calibre/linux.py
@@ -166,7 +166,7 @@ except NameError:
 sys.stdin = open('/dev/tty')
 
 if os.geteuid() != euid:
-    print ('The installer was last run as user id:', euid, 'To remove all files you must run the uninstaller as the same user')
+    print('The installer was last run as user id:', euid, 'To remove all files you must run the uninstaller as the same user')
     if raw_input('Proceed anyway? [y/n]:').lower() != 'y':
         raise SystemExit(1)
 
@@ -181,23 +181,23 @@ for f in {mime_resources!r}:
     file = os.path.join(dummy_mime_path, f)
     open(file, 'w').close()
     cmd = ['xdg-mime', 'uninstall', file]
-    print ('Removing mime resource:', f)
+    print('Removing mime resource:', f)
     ret = subprocess.call(cmd, shell=False)
     if ret != 0:
-        print ('WARNING: Failed to remove mime resource', f)
+        print('WARNING: Failed to remove mime resource', f)
 
 for x in tuple({manifest!r}) + tuple({appdata_resources!r}) + (sys.argv[-1], frozen_path, dummy_mime_path):
     if not x or not os.path.exists(x):
         continue
-    print ('Removing', x)
+    print('Removing', x)
     try:
         if os.path.isdir(x):
             shutil.rmtree(x)
         else:
             os.unlink(x)
     except Exception as e:
-        print ('Failed to delete', x)
-        print ('\t', e)
+        print('Failed to delete', x)
+        print('\t', e)
 
 icr = {icon_resources!r}
 mimetype_icons = []
@@ -206,10 +206,10 @@ def remove_icon(context, name, size, update=False):
     cmd = ['xdg-icon-resource', 'uninstall', '--context', context, '--size', size, name]
     if not update:
         cmd.insert(2, '--noupdate')
-    print ('Removing icon:', name, 'from context:', context, 'at size:', size)
+    print('Removing icon:', name, 'from context:', context, 'at size:', size)
     ret = subprocess.call(cmd, shell=False)
     if ret != 0:
-        print ('WARNING: Failed to remove icon', name)
+        print('WARNING: Failed to remove icon', name)
 
 for i, (context, name, size) in enumerate(icr):
     if context == 'mimetypes':
@@ -220,12 +220,12 @@ for i, (context, name, size) in enumerate(icr):
 mr = {menu_resources!r}
 for f in mr:
     cmd = ['xdg-desktop-menu', 'uninstall', f]
-    print ('Removing desktop file:', f)
+    print('Removing desktop file:', f)
     ret = subprocess.call(cmd, shell=False)
     if ret != 0:
-        print ('WARNING: Failed to remove menu item', f)
+        print('WARNING: Failed to remove menu item', f)
 
-print ()
+print()
 
 if mimetype_icons and raw_input('Remove the e-book format icons? [y/n]:').lower() in ['', 'y']:
     for i, (name, size) in enumerate(mimetype_icons):


### PR DESCRIPTION
The [development environment setup guide](https://manual.calibre-ebook.com/develop.html) mentions that Python 3.8 was the minimum version required. There were some leftover print statements in the documentation that should be updated to print functions to reflect Python 3+.