### PR TITLE
Remove deprecated utcnow, utcfromtimestamp

### DIFF
--- a/recipes/apple_daily.recipe
+++ b/recipes/apple_daily.recipe
@@ -5,7 +5,7 @@ __copyright__ = '2013-2015, Eddie Lau'
 __Date__ = ''
 
 from calibre import (__appname__, force_unicode, strftime)
-from calibre.utils.date import now as nowf
+from calibre.utils.date import now as nowf, utcnow
 import os
 import datetime
 import re
@@ -43,7 +43,7 @@ class AppleDaily(BasicNewsRecipe):
                    dict(name='link')]
 
     def get_dtlocal(self):
-        dt_utc = datetime.datetime.utcnow()
+        dt_utc = utcnow()
         # convert UTC to local hk time - at HKT 6am, all news are available
         return dt_utc + datetime.timedelta(8.0 / 24) - datetime.timedelta(6.0 / 24)
 

--- a/recipes/houston_chronicle.recipe
+++ b/recipes/houston_chronicle.recipe
@@ -16,7 +16,7 @@ from collections import OrderedDict
 from calibre.web.feeds.recipes import BasicNewsRecipe
 from calibre.utils.cleantext import clean_ascii_chars
 from calibre.ebooks.BeautifulSoup import NavigableString
-from calibre.utils.date import dt_factory, local_tz
+from calibre.utils.date import dt_factory, local_tz, utcfromtimestamp
 
 regex_date_only = re.compile(r"""(?:January|February|March|April|
  {8}May|June|July|August|September|October|November|
@@ -216,7 +216,7 @@ class HoustonChronicle(BasicNewsRecipe):
         summary = self.get_article_description_from_doc(soup)
         article_date = self.get_published_time_from_doc(soup)
         if article_date is not None:
-            article_timestamp = float((article_date - datetime.utcfromtimestamp(0)).total_seconds())
+            article_timestamp = float((article_date - utcfromtimestamp(0)).total_seconds())
             article.date = article_timestamp
             article.utctime = dt_factory(article_date.timetuple(), assume_utc=True, as_utc=True)
             article.localtime = article.utctime.astimezone(local_tz)

--- a/recipes/scmp.recipe
+++ b/recipes/scmp.recipe
@@ -182,9 +182,8 @@ class SCMP(BasicNewsRecipe):
             body = v
 
         authors = [content_service[a["id"]]["name"] for a in content["authors"]]
-        date_published = datetime.utcfromtimestamp(
-            content["publishedDate"] / 1000
-        ).replace(tzinfo=timezone.utc)
+        date_published = datetime.fromtimestamp(
+            content["publishedDate"] / 1000, timezone.utc)
         date_published_loc = date_published.astimezone(
             timezone(offset=timedelta(hours=8))  # HK time
         )

--- a/recipes/singtaohk.recipe
+++ b/recipes/singtaohk.recipe
@@ -26,7 +26,7 @@ Change Log:
 2011/12/29 -- first version done
 '''
 
-from calibre.utils.date import now as nowf
+from calibre.utils.date import now as nowf, utcnow
 import os
 import datetime
 import re
@@ -82,7 +82,7 @@ class STHKRecipe(BasicNewsRecipe):
     auto_cleanup = False
 
     def get_dtlocal(self):
-        dt_utc = datetime.datetime.utcnow()
+        dt_utc = utcnow()
         # convert UTC to local hk time - at HKT 4.00am, all news are available
         dt_local = dt_utc + \
             datetime.timedelta(8.0 / 24) - datetime.timedelta(4.0 / 24)

--- a/recipes/sueddeutsche_mobil.recipe
+++ b/recipes/sueddeutsche_mobil.recipe
@@ -14,6 +14,7 @@ szmobil.sueddeutsche.de/
 
 from calibre import strftime
 import datetime
+from calibre.utils.date import utcnow
 from calibre.web.feeds.recipes import BasicNewsRecipe
 import re
 
@@ -28,7 +29,7 @@ class SZmobil(BasicNewsRecipe):
     publication_type = u'newspaper'
     category = u'news, politics, Germany'
     cover_url = 'https://zeitung.sueddeutsche.de/szdigital/public/issue/previewimage?size=l&issueId=' + \
-        (datetime.datetime.utcnow() + datetime.timedelta(hours=1)
+        (utcnow() + datetime.timedelta(hours=1)
          ).strftime("%Y-%m-%d") + '&targetVersion=3&productId=sz'
     no_stylesheets = True
     oldest_article = 2

--- a/recipes/sueddeutschezeitung.recipe
+++ b/recipes/sueddeutschezeitung.recipe
@@ -11,6 +11,7 @@ www.sueddeutsche.de/sz/
 from calibre.web.feeds.news import BasicNewsRecipe
 from calibre import strftime
 import datetime
+from calibre.utils.date import utcnow
 
 
 class SueddeutcheZeitung(BasicNewsRecipe):
@@ -26,7 +27,7 @@ class SueddeutcheZeitung(BasicNewsRecipe):
     remove_empty_feeds = True
     delay = 1
     cover_url = 'https://zeitung.sueddeutsche.de/szdigital/public/issue/previewimage?size=l&issueId=' + \
-        (datetime.datetime.utcnow() + datetime.timedelta(hours=1)
+        (utcnow() + datetime.timedelta(hours=1)
          ).strftime("%Y-%m-%d") + '&targetVersion=3&productId=sz'
     PREFIX = 'http://epaper.sueddeutsche.de'
     INDEX = PREFIX + '/app/epaper/textversion/'

--- a/setup/browser_data.py
+++ b/setup/browser_data.py
@@ -5,7 +5,7 @@
 import bz2
 import os
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from urllib.request import urlopen
 
 
@@ -49,7 +49,7 @@ def get_data():
     ans = {
         'common_user_agents': common,
         'user_agents_popularity': ua_freq_map,
-        'timestamp': datetime.utcnow().isoformat() + '+00:00',
+        'timestamp': datetime.now(timezone.utc).isoformat(),
     }
     ans['desktop_platforms'] = list(all_desktop_platforms(ans['common_user_agents']))
     return ans

--- a/setup/plugins_mirror.py
+++ b/setup/plugins_mirror.py
@@ -437,7 +437,7 @@ def fetch_plugins(old_index):
         else:
             if entry.name in old_index:
                 ans[entry.name] = old_index[entry.name]
-            log('Failed to get plugin', entry.name, 'at', datetime.utcnow().isoformat(), 'with error:')
+            log('Failed to get plugin', entry.name, 'at', datetime.now().isoformat(), 'with error:')
             log(plugin)
     # Move staged files
     for plugin in ans.values():
@@ -646,7 +646,7 @@ def main():
         raise SystemExit('Exiting on user interrupt')
     except Exception:
         import traceback
-        log('Failed to run at:', datetime.utcnow().isoformat())
+        log('Failed to run at:', datetime.now().isoformat())
         log(traceback.format_exc())
         raise SystemExit(1)
 

--- a/src/calibre/utils/date.py
+++ b/src/calibre/utils/date.py
@@ -104,7 +104,7 @@ def parse_date(date_string, assume_utc=False, as_utc=True, default=None):
     if isinstance(date_string, bytes):
         date_string = date_string.decode(preferred_encoding, 'replace')
     if default is None:
-        func = datetime.utcnow if assume_utc else datetime.now
+        func = utcnow if assume_utc else now
         default = func().replace(day=15, hour=0, minute=0, second=0, microsecond=0,
                 tzinfo=_utc_tz if assume_utc else _local_tz)
     if iso_pat().match(date_string) is not None:
@@ -190,10 +190,7 @@ def qt_from_dt(d, as_utc=False, assume_utc=False):
 
 
 def fromtimestamp(ctime, as_utc=True):
-    dt = datetime.utcfromtimestamp(ctime).replace(tzinfo=_utc_tz)
-    if not as_utc:
-        dt = dt.astimezone(_local_tz)
-    return dt
+    return datetime.fromtimestamp(ctime, _utc_tz if as_utc else _local_tz)
 
 
 def fromordinal(day, as_utc=True):
@@ -250,16 +247,16 @@ def as_utc(date_time, assume_utc=True):
 
 
 def now():
-    return datetime.now().replace(tzinfo=_local_tz)
+    return datetime.now(_local_tz)
 
 
 def utcnow():
-    return datetime.utcnow().replace(tzinfo=_utc_tz)
+    return datetime.now(_utc_tz)
 
 
 def utcfromtimestamp(stamp):
     try:
-        return datetime.utcfromtimestamp(stamp).replace(tzinfo=_utc_tz)
+        return datetime.fromtimestamp(stamp, _utc_tz)
     except Exception:
         # Raised if stamp is out of range for the platforms gmtime function
         # For example, this happens with negative values on windows


### PR DESCRIPTION
[Python 3.12 has deprecated](https://docs.python.org/3.12/whatsnew/3.12.html#deprecated) `datetime.utcnow` and `datetime.utcfromtimestamp`.

In this change I updated most instances of it. I tested only on 3.10.1, but all of the changes I made should be compatible with 3.8+. (I couldn't figure out how to run Calibre with different versions of Python that I have installed. Is there a way to give `calibre-debug` a python executable to use?)

I tested the changes to `calibre/utils/date.py` thoroughly to have identical output before/after. The other recipes and scripts, I tested by separately running the changed snippets of code.

I left the uses of `datetime.utcfromtimestamp` in the following files, as I'm not sure where the output is being used, and whether it's ok for the datetimes to be timezone-aware or not.
* `src/calibre/devices/kindle/driver.py`
* `src/calibre/library/catalogs/epub_mobi_builder.py`