### PR TITLE
Fix minimum required Python version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ __docformat__ = 'restructuredtext en'
 import sys, os
 
 
-def check_version_info(minver=(3, 7, 0)):
+def check_version_info(minver=(3, 8, 0)):
     vi = sys.version_info
     if vi < minver:
         def fmt(v):


### PR DESCRIPTION
According to the development guide, and the usage of the `:=` operator, the minimum required Python version is 3.8.

`setup.py` still checked for 3.7, so I updated it.