### PR TITLE
Improve IPv6 support for server mode

### DIFF
--- a/src/calibre/gui2/actions/device.py
+++ b/src/calibre/gui2/actions/device.py
@@ -27,7 +27,11 @@ def local_url_for_content_server():
     from calibre.srv.opts import server_config
     opts = server_config()
     interface = opts.listen_on or '0.0.0.0'
-    interface = {'0.0.0.0': '127.0.0.1', '::':'::1'}.get(interface)
+
+    addr_map = {'0.0.0.0': '127.0.0.1',
+                '::':      '::1'}
+    if interface in addr_map:
+        interface = addr_map[interface]
 
     if is_ipv6_addr(interface):
         interface = f'[{interface}]'

--- a/src/calibre/gui2/actions/device.py
+++ b/src/calibre/gui2/actions/device.py
@@ -16,10 +16,22 @@ from calibre.utils.smtp import config as email_config
 
 
 def local_url_for_content_server():
+    def is_ipv6_addr(addr):
+        import socket
+        try:
+            socket.inet_pton(socket.AF_INET6, addr)
+            return True
+        except OSError:
+            return False
+
     from calibre.srv.opts import server_config
     opts = server_config()
     interface = opts.listen_on or '0.0.0.0'
     interface = {'0.0.0.0': '127.0.0.1', '::':'::1'}.get(interface)
+
+    if is_ipv6_addr(interface):
+        interface = f'[{interface}]'
+
     protocol = 'https' if opts.ssl_certfile and opts.ssl_keyfile else 'http'
     prefix = opts.url_prefix or ''
     port = opts.port

--- a/src/calibre/gui2/actions/device.py
+++ b/src/calibre/gui2/actions/device.py
@@ -16,15 +16,9 @@ from calibre.utils.smtp import config as email_config
 
 
 def local_url_for_content_server():
-    def is_ipv6_addr(addr):
-        import socket
-        try:
-            socket.inet_pton(socket.AF_INET6, addr)
-            return True
-        except OSError:
-            return False
-
     from calibre.srv.opts import server_config
+    from calibre.utils.network import is_ipv6_addr
+
     opts = server_config()
     interface = opts.listen_on or '0.0.0.0'
 

--- a/src/calibre/gui2/preferences/server.py
+++ b/src/calibre/gui2/preferences/server.py
@@ -1299,13 +1299,7 @@ class ConfigWidget(ConfigWidgetBase):
         self.stopping_msg.accept()
 
     def test_server(self):
-        def is_ipv6_addr(addr):
-            import socket
-            try:
-                socket.inet_pton(socket.AF_INET6, addr)
-                return True
-            except OSError:
-                return False
+        from calibre.utils.network import is_ipv6_addr
 
         prefix = self.advanced_tab.get('url_prefix') or ''
         protocol = 'https' if self.advanced_tab.has_ssl else 'http'

--- a/src/calibre/gui2/preferences/server.py
+++ b/src/calibre/gui2/preferences/server.py
@@ -1299,10 +1299,22 @@ class ConfigWidget(ConfigWidgetBase):
         self.stopping_msg.accept()
 
     def test_server(self):
+        def is_ipv6_addr(addr):
+            import socket
+            try:
+                socket.inet_pton(socket.AF_INET6, addr)
+                return True
+            except OSError:
+                return False
+
         prefix = self.advanced_tab.get('url_prefix') or ''
         protocol = 'https' if self.advanced_tab.has_ssl else 'http'
         lo = self.advanced_tab.get('listen_on') or '0.0.0.0'
         lo = {'0.0.0.0': '127.0.0.1', '::':'::1'}.get(lo)
+
+        if is_ipv6_addr(lo):
+            lo = f'[{lo}]'
+
         url = '{protocol}://{interface}:{port}{prefix}'.format(
             protocol=protocol, interface=lo,
             port=self.main_tab.opt_port.value(), prefix=prefix)

--- a/src/calibre/gui2/preferences/server.py
+++ b/src/calibre/gui2/preferences/server.py
@@ -1310,7 +1310,11 @@ class ConfigWidget(ConfigWidgetBase):
         prefix = self.advanced_tab.get('url_prefix') or ''
         protocol = 'https' if self.advanced_tab.has_ssl else 'http'
         lo = self.advanced_tab.get('listen_on') or '0.0.0.0'
-        lo = {'0.0.0.0': '127.0.0.1', '::':'::1'}.get(lo)
+
+        addr_map = {'0.0.0.0': '127.0.0.1',
+                    '::':      '::1'}
+        if lo in addr_map:
+            lo = addr_map[lo]
 
         if is_ipv6_addr(lo):
             lo = f'[{lo}]'

--- a/src/calibre/srv/loop.py
+++ b/src/calibre/srv/loop.py
@@ -508,13 +508,7 @@ class ServerLoop:
             self.setup_socket()
 
     def serve(self):
-        def is_ipv6_addr(addr):
-            import socket
-            try:
-                socket.inet_pton(socket.AF_INET6, addr)
-                return True
-            except OSError:
-                return False
+        from calibre.utils.network import is_ipv6_addr
 
         self.connection_map = {}
         if not self.socket_was_preactivated:

--- a/src/calibre/srv/opts.py
+++ b/src/calibre/srv/opts.py
@@ -110,8 +110,8 @@ raw_options = (
     ' there are more than this number of items. Set to zero to disable.'),
 
     _('The interface on which to listen for connections'),
-    'listen_on', '0.0.0.0',
-    _('The default is to listen on all available IPv4 interfaces. You can change this to, for'
+    'listen_on', '::',
+    _('The default is to listen on all available IPv6 and IPv4 interfaces. You can change this to, for'
     ' example, "127.0.0.1" to only listen for connections from the local machine, or'
     ' to "::" to listen to all incoming IPv6 and IPv4 connections.'),
 

--- a/src/calibre/utils/mdns.py
+++ b/src/calibre/utils/mdns.py
@@ -77,6 +77,9 @@ def _get_external_ip():
 
 
 def verify_ipV4_address(ip_address):
+    if ip_address == None:
+        return None
+
     result = None
     if ip_address != '0.0.0.0' and ip_address != '::':
         # do some more sanity checks on the address

--- a/src/calibre/utils/network.py
+++ b/src/calibre/utils/network.py
@@ -108,3 +108,11 @@ def internet_connected():
         DummyNetworkStatus()
 
     return internet_connected.checker()
+
+def is_ipv6_addr(addr):
+    import socket
+    try:
+        socket.inet_pton(socket.AF_INET6, addr)
+        return True
+    except OSError:
+        return False


### PR DESCRIPTION
Improve IPv6 support:
* Use `::` as default server address. It also accepts IPv4.
* Display as `[host addr]:port` style for IPv6 address.
