### PR TITLE
Fix minimum required Python version for ruff, black and pyupgrade

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.ruff]
 line-length = 160
-target-version = 'py37'
+target-version = 'py38'
 select = ['E', 'F']
 ignore = ['E741', 'E402', 'E722', 'E401']
 builtins = ['_']
@@ -10,7 +10,7 @@ builtins = ['_']
 "src/qt/__init__.py" = ["E501"]
 
 [tool.black]
-target-version = ['py37']
+target-version = ['py38']
 
 [tool.isort]
 profile = "black"

--- a/setup/check.py
+++ b/setup/check.py
@@ -137,4 +137,4 @@ class UpgradeSourceCode(Command):
             if '/metadata/sources/' in q or '/store/stores/' in q:
                 continue
             files.append(q)
-        subprocess.call(['pyupgrade', '--py37-plus'] + files)
+        subprocess.call(['pyupgrade', '--py38-plus'] + files)


### PR DESCRIPTION
In the update [commit](https://github.com/kovidgoyal/calibre/commit/6bc1831a84be2045406bde7ba47b60e957e9c4cb) of the minimum Python version required by `setup.py`, we forgot to also align `ruff`, `black` and `pyupgrade`.