### PR TITLE
Update New Yorker: Remove svg tags

### DIFF
--- a/recipes/new_yorker.recipe
+++ b/recipes/new_yorker.recipe
@@ -58,6 +58,7 @@ class NewYorker(BasicNewsRecipe):
         ),
         prefixed_classes('ConsentBannerWrapper- ResponsiveCartoonCTA-'),
         dict(childtypes='iframe'),
+        dict(name='svg'),
     ]
     remove_attributes = ['style']
 


### PR DESCRIPTION
Today's download of the New Yorker fails to import via Send to Kindle and opening the epub in calibre I see this error:

```Parsing failed: redefinition of the xmlns prefix is forbidden```

which is fixed by adding `svg` to `remove_tags` as was suggested here a few years ago:

[Parsing failed: redefinition of the xmlns prefix is forbidden
](https://www.mobileread.com/forums/showpost.php?p=4178438&postcount=8)

After applying this fix, Send to Kindle was successful.