### PR TITLE
Changes to eliminate the black box cover_flow flash. The important …

### DIFF
--- a/src/calibre/gui2/cover_flow.py
+++ b/src/calibre/gui2/cover_flow.py
@@ -20,7 +20,7 @@ from qt.core import (
 
 from calibre.constants import islinux
 from calibre.ebooks.metadata import authors_to_string, rating_to_stars
-from calibre.gui2 import config, gprefs, rating_font
+from calibre.gui2 import config, gprefs, rating_font, timed_print
 from calibre_extensions import pictureflow
 
 
@@ -208,6 +208,13 @@ class CoverFlow(pictureflow.PictureFlow):
             p.end()
         else:
             super().paintEvent(ev)
+
+    def resizeEvent(self, ev):
+        timed_print('cover flow resize_event', ev.oldSize())
+        if ev.oldSize() == QSize(-1, -1):
+            timed_print(f'cover flow reset counter - reset self.created_at: old={self.created_at} new={time.monotonic()}')
+            self.created_at = time.monotonic()
+        super().resizeEvent(ev)
 
     def __init__(self, parent=None):
         pictureflow.PictureFlow.__init__(self, parent,

--- a/src/calibre/gui2/ui.py
+++ b/src/calibre/gui2/ui.py
@@ -428,7 +428,6 @@ class Main(MainWindow, MainWindowMixin, DeviceMixin, EmailMixin,  # {{{
             QTimer.singleShot(10, self.show_gui_debug_msg)
 
         self.iactions['Connect Share'].check_smartdevice_menus()
-        QTimer.singleShot(1, self.start_smartdevice)
         QTimer.singleShot(100, self.update_toggle_to_tray_action)
 
     def post_initialize_actions(self, show_gui, do_hide_windows):
@@ -451,6 +450,10 @@ class Main(MainWindow, MainWindowMixin, DeviceMixin, EmailMixin,  # {{{
         # Force repaint of the book details splitter because it otherwise ends
         # up with the wrong size. I don't know why.
         self.bd_splitter.repaint()
+
+        # Start the smartdevice later so that the network time doesn't affect
+        # the gui repaint debouncing. Wait 2 seconds before starting.
+        QTimer.singleShot(2000, self.start_smartdevice)
 
     def start_quickview(self):
         from calibre.gui2.actions.show_quickview import get_quickview_action_plugin
@@ -490,7 +493,9 @@ class Main(MainWindow, MainWindowMixin, DeviceMixin, EmailMixin,  # {{{
         message = None
         if self.device_manager.get_option('smartdevice', 'autostart'):
             try:
+                timed_print('Starting smartdevice')
                 message = self.device_manager.start_plugin('smartdevice')
+                timed_print('Finished starting smartdevice')
             except:
                 message = 'start smartdevice unknown exception'
                 prints(message)


### PR DESCRIPTION
…ones are in ui.py. The changes in cover_flow.py are for timed logging.

Attached is a debug log showing the startup on my Win10 machine. You can see that resetting self.created_at has no effect. The old and new values are the same.

[debug_log.txt](https://github.com/kovidgoyal/calibre/files/13536590/debug_log.txt)

Note that all flashing goes away if the setMinimumSize on line 223 in cover_flow.py is removed. Another debug log is attached showing that run. The timings are rather different. This change (deletion) is not included in this PR.

[debug_log no setMinimumSize.txt](https://github.com/kovidgoyal/calibre/files/13536602/debug_log.no.setMinimumSize.txt)

