### PR TITLE
Use canonical method to invoke sip-build tool

### DIFF
--- a/setup/build.py
+++ b/setup/build.py
@@ -721,8 +721,8 @@ sip-file = {os.path.basename(sipf)!r}
             self.create_sip_build_skeleton(src_dir, ext)
             cwd = src_dir
             cmd = [
-                sys.executable, '-c',
-                '''from sipbuild.tools.build import main; main();''',
+                sys.executable,
+                '-m', 'sipbuild.tools.build',
                 '--verbose', '--no-make', '--qmake', QMAKE
             ]
         return cmd, sbf, cwd


### PR DESCRIPTION
Use canonical method to invoke sip-build tool

https://www.riverbankcomputing.com/static/Docs/sip/command_line_tools.html
> The build tools can also be invoked using the -m command line
> option of the Python interpreter. For example, the following
> two command lines are equivalent:
>   sip-build -h
>   python -m sipbuild.tools.build -h