### PR TITLE
Update reuters.recipe

### DIFF
--- a/recipes/reuters.recipe
+++ b/recipes/reuters.recipe
@@ -14,7 +14,7 @@ country_defs = {
         'Business': 'business',
         'Markets': 'markets',
         'Tech': 'technology',
-        'Sports': 'lifestyle/sports',
+        # 'Sports': 'lifestyle/sports',
         'Wealth': 'markets/wealth',
     })
 }


### PR DESCRIPTION
sports section fails. I tried changing that section to 'sports' (reuters.com/sports), although it works in browser, it still fails during calibre fetch.