### PR TITLE
Two changes related to the icons in tag browser:

### DIFF
--- a/src/calibre/gui2/__init__.py
+++ b/src/calibre/gui2/__init__.py
@@ -425,6 +425,7 @@ def create_defs():
     defs['allow_keyboard_search_in_library_views'] = True
     defs['show_links_in_tag_browser'] = False
     defs['show_notes_in_tag_browser'] = False
+    defs['icons_on_right_in_tag_browser'] = True
 
     def migrate_tweak(tweak_name, pref_name):
         # If the tweak has been changed then leave the tweak in the file so

--- a/src/calibre/gui2/preferences/look_feel.py
+++ b/src/calibre/gui2/preferences/look_feel.py
@@ -648,6 +648,7 @@ class ConfigWidget(ConfigWidgetBase, Ui_Form):
         r('show_avg_rating', config)
         r('show_links_in_tag_browser', gprefs)
         r('show_notes_in_tag_browser', gprefs)
+        r('icons_on_right_in_tag_browser', gprefs)
         r('disable_animations', config)
         r('systray_icon', config, restart_required=True)
         r('show_splash_screen', gprefs)

--- a/src/calibre/gui2/preferences/look_feel.ui
+++ b/src/calibre/gui2/preferences/look_feel.ui
@@ -1370,6 +1370,21 @@ box will cause these empty categories to be hidden.&lt;/p&gt;</string>
             </property>
            </widget>
           </item>
+          <item row="2" column="1">
+           <widget class="QCheckBox" name="opt_icons_on_right_in_tag_browser">
+            <property name="text">
+             <string>Place icons on the &amp;right, in columns</string>
+            </property>
+            <property name="toolTip">
+             <string>If checked the notes and links icons will be placed at the right, after
+the count and in columns. If unchecked, the icons will be placed immediately after the text,
+to the left of the count and not in columns.</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
           <item row="2" column="2">
            <widget class="QCheckBox" name="opt_tag_browser_always_autocollapse">
             <property name="toolTip">

--- a/src/calibre/gui2/tag_browser/ui.py
+++ b/src/calibre/gui2/tag_browser/ui.py
@@ -782,10 +782,16 @@ class TagBrowserWidget(QFrame):  # {{{
         l.m.aboutToShow.connect(self.about_to_show_configure_menu)
         # Show/hide counts
         l.m.show_counts_action = ac = l.m.addAction('counts')
+        parent.keyboard.register_shortcut('tag browser toggle counts',
+                _('Toggle counts'), default_keys=(),
+                action=ac, group=_('Tag browser'))
         ac.triggered.connect(self.toggle_counts)
         # Show/hide average rating
         l.m.show_avg_rating_action = ac = l.m.addAction(QIcon.ic('rating.png'), 'avg rating')
         ac.triggered.connect(self.toggle_avg_rating)
+        parent.keyboard.register_shortcut('tag browser toggle average ratings',
+                _('Toggle average ratings'), default_keys=(),
+                action=ac, group=_('Tag browser'))
         # Show/hide notes icon
         l.m.show_notes_icon_action = ac = l.m.addAction(QIcon.ic('notes.png'), 'notes icon')
         ac.triggered.connect(self.toggle_notes_icon)


### PR DESCRIPTION
1) Add the capability to show the icons next to the text, unaligned. Set via an option in look&feel. This change required recording the icon position on a per-item basis instead of a per-category basis.
2) Add the possibility of keyboard shortcuts to "show counts" and "show average rating" so they are the same as the show icons ones.