### PR TITLE
Fix the "flash" when starting on windows (at least).

### DIFF
--- a/src/calibre/gui2/ui.py
+++ b/src/calibre/gui2/ui.py
@@ -399,9 +399,6 @@ class Main(MainWindow, MainWindowMixin, DeviceMixin, EmailMixin,  # {{{
             setattr(self, '__systray_minimized', True)
         if do_hide_windows:
             self.hide_windows()
-        if show_gui:
-            timed_print('GUI main window shown')
-            self.show()
         self.layout_container.relayout()
         QTimer.singleShot(0, self.post_initialize_actions)
         self.read_settings()
@@ -409,6 +406,10 @@ class Main(MainWindow, MainWindowMixin, DeviceMixin, EmailMixin,  # {{{
         self.finalize_layout()
         self.bars_manager.start_animation()
         self.set_window_title()
+
+        if show_gui:
+            timed_print('GUI main window shown')
+            self.show()
 
         for ac in self.iactions.values():
             try:


### PR DESCRIPTION
This differs from the patch I sent. I moved the "show()" to happen before the plugin initialization_complete() methods are called, just in case they use something like isVisible(). The view_manager plugin now works correctly, which it didn't in 7.2.

Tested with small and large libraries.