### PR TITLE
Add -O3 to extension compile flags

### DIFF
--- a/setup/build.py
+++ b/setup/build.py
@@ -353,6 +353,9 @@ def init_env(debug=False, sanitize=False, compiling_for='native'):
         else:
             cflags.extend('-I' + x for x in get_python_include_paths())
             ldflags.append('/LIBPATH:'+os.path.join(sysconfig.get_config_var('prefix'), 'libs'))
+
+    cflags.append('-O3')
+
     return Environment(
         platform_name=platform_name, dest_ext=dest_ext, std_prefix=std_prefix,
         base_cflags=base_cflags, base_cxxflags=base_cxxflags, base_ldflags=base_ldflags,
@@ -541,7 +544,6 @@ class Build(Command):
                 cflags = [
                     '-DCALIBRE_MODINIT_FUNC='
                     '{} __attribute__ ((visibility ("default"))) {}'.format(extern_decl, return_type)]
-                cflags.append('-O3')
             if ext.needs_cxx and ext.needs_cxx_std:
                 if env.cc_output_flag.startswith('/') and ext.needs_cxx == "11":
                     ext.needs_cxx = "14"

--- a/setup/build.py
+++ b/setup/build.py
@@ -541,6 +541,7 @@ class Build(Command):
                 cflags = [
                     '-DCALIBRE_MODINIT_FUNC='
                     '{} __attribute__ ((visibility ("default"))) {}'.format(extern_decl, return_type)]
+                cflags.append('-O3')
             if ext.needs_cxx and ext.needs_cxx_std:
                 if env.cc_output_flag.startswith('/') and ext.needs_cxx == "11":
                     ext.needs_cxx = "14"


### PR DESCRIPTION
This speeds up .mobi/.azw3 conversions by quite a bit; around 30-50% on the lengthy .epub to .azw3 conversions I tested with:

<table>
<tr>
 <td>Title
 <td>previous conversion time (under -O2)
 <td>new conversion time (with -O3)
 <td>speedup
<tr>
 <td>A Tale of Two Cities
 <td>5s
 <td>3.87s
 <td>1.3x
<tr>
 <td>Les Misérables
 <td>22.8s
 <td>15.42s
 <td>1.5x
<tr>
 <td>War and Peace
 <td>21s
 <td>14.3s
 <td>1.5x
</table>

<details>
<summary>Benchmarking details</summary>

Books: [epubs.zip](https://github.com/kovidgoyal/calibre/files/13789869/epubs.zip)

Simple script written by ChatGPT:

```bash
#!/bin/bash

if [ $# -ne 1 ]; then
    echo "Usage: $0 <directory>"
    exit 1
fi

directory="$1"

if [ ! -d "$directory" ]; then
    echo "Error: $directory is not a directory."
    exit 1
fi

for file in "$directory"/*; do
    if [ -f "$file" ]; then
        echo "Benchmarking $file..."
        # Redirect stdout to /dev/null and measure the time taken
        time ./ebook-convert "$file" "~/temp/${file%.*}.azw3" > /dev/null 2>&1
        echo "----------------------------------------"
    fi
done

echo "Benchmarking complete."
```
</details>

-----------------------------------

Not sure if where I added the flag is the best place to put it, please let me know if there's a more appropriate place.