### PR TITLE
Add an option to choose where to show the cover browser when using …

### DIFF
--- a/src/calibre/gui2/__init__.py
+++ b/src/calibre/gui2/__init__.py
@@ -426,6 +426,7 @@ def create_defs():
     defs['show_links_in_tag_browser'] = False
     defs['show_notes_in_tag_browser'] = False
     defs['icons_on_right_in_tag_browser'] = True
+    defs['cover_browser_on_right'] = True
 
     def migrate_tweak(tweak_name, pref_name):
         # If the tweak has been changed then leave the tweak in the file so

--- a/src/calibre/gui2/central.py
+++ b/src/calibre/gui2/central.py
@@ -365,12 +365,20 @@ class CentralContainer(QWidget):
         self.top_handle = h(Qt.Orientation.Horizontal)
         self.bottom_handle = h(Qt.Orientation.Horizontal)
 
+    _last_cb_on_right = None
+
     @property
     def narrow_cb_on_top(self):
-        from calibre.gui2.ui import get_gui
-        gui = get_gui()
-        ratio = self.width() / self.height() if gui is None else gui.width() / gui.height()
-        return ratio <= 1.4
+        from calibre.gui2 import gui_prefs
+        prefs = gui_prefs()
+        self._last_cb_on_right = prefs['cover_browser_on_right']
+        return not self._last_cb_on_right
+
+    @property
+    def cb_on_top_changed(self):
+        from calibre.gui2 import gui_prefs
+        prefs = gui_prefs()
+        return self._last_cb_on_right is None or prefs['cover_browser_on_right'] != self._last_cb_on_right
 
     @property
     def is_visible(self):
@@ -404,7 +412,7 @@ class CentralContainer(QWidget):
 
     def change_layout(self, gui, is_wide):
         layout = Layout.wide if is_wide else Layout.narrow
-        if layout is self.layout:
+        if layout is self.layout and not self.cb_on_top_changed:
             return False
         ss = self.serialized_settings()
         before = ss[self.layout.name + '_visibility']

--- a/src/calibre/gui2/preferences/look_feel.py
+++ b/src/calibre/gui2/preferences/look_feel.py
@@ -608,6 +608,7 @@ class ConfigWidget(ConfigWidgetBase, Ui_Form):
 
         r('cover_flow_queue_length', config, restart_required=True)
         r('cover_browser_reflections', gprefs)
+        r('cover_browser_on_right', gprefs)
         r('cover_browser_title_template', db.prefs)
         fm = db.field_metadata
         r('cover_browser_subtitle_field', db.prefs, choices=[(_('No subtitle'), 'none')] + sorted(
@@ -833,6 +834,15 @@ class ConfigWidget(ConfigWidgetBase, Ui_Form):
         self.opt_gui_layout.addItem(_('Wide'), 'wide')
         self.opt_gui_layout.addItem(_('Narrow'), 'narrow')
         self.opt_gui_layout.currentIndexChanged.connect(self.changed_signal)
+        self.opt_gui_layout.currentIndexChanged.connect(self.gui_layout_changed)
+
+    def set_cover_browser_on_right_enabled(self, is_wide):
+        self.opt_cover_browser_on_right.setEnabled(not is_wide)
+        if is_wide:
+            self.opt_cover_browser_on_right.setChecked(True)
+
+    def gui_layout_changed(self, dex):
+        self.set_cover_browser_on_right_enabled(dex == 0) #0 == wide
 
     def initial_tab_changed(self):
         self.sections_view.setCurrentRow(self.tabWidget.currentIndex())
@@ -1041,6 +1051,7 @@ class ConfigWidget(ConfigWidgetBase, Ui_Form):
         self.tb_focus_label.setVisible(self.opt_tag_browser_allow_keyboard_focus.isChecked())
         self.update_color_palette_state()
         self.opt_gui_layout.setCurrentIndex(0 if self.gui.layout_container.is_wide else 1)
+        self.set_cover_browser_on_right_enabled(self.gui.layout_container.is_wide)
 
     def open_cg_cache(self):
         open_local_file(self.gui.grid_view.thumbnail_cache.location)

--- a/src/calibre/gui2/preferences/look_feel.ui
+++ b/src/calibre/gui2/preferences/look_feel.ui
@@ -1846,7 +1846,7 @@ that don't have children.&lt;/p&gt;</string>
        <string>Cover &amp;browser</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_11">
-       <item row="1" column="0">
+       <item row="0" column="1" colspan="2">
         <widget class="QCheckBox" name="opt_cb_fullscreen">
          <property name="text">
           <string>When showing in a separate window, show it &amp;fullscreen</string>
@@ -1860,10 +1860,10 @@ that don't have children.&lt;/p&gt;</string>
          </property>
         </widget>
        </item>
-       <item row="3" column="1" colspan="2">
+       <item row="6" column="1" colspan="2">
         <widget class="QSpinBox" name="opt_cover_flow_queue_length"/>
        </item>
-       <item row="3" column="0">
+       <item row="6" column="0">
         <widget class="QLabel" name="label_6">
          <property name="text">
           <string>&amp;Number of covers to show in browse mode (needs restart):</string>
@@ -1904,7 +1904,19 @@ empty template for no text.&lt;/p&gt;</string>
          </property>
         </widget>
        </item>
-       <item row="4" column="0" colspan="3">
+       <item row="4" column="0">
+        <widget class="QCheckBox" name="opt_cover_browser_on_right">
+         <property name="text">
+          <string>Show the cover &amp;browser on the right</string>
+         </property>
+         <property name="toolTip">
+          <string>When using the Narrow user interface layout, when this option
+is checked the cover browser is shown to the right the book list instead of on
+top of it. This option cannot be changed when using the Wide layout.</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1" colspan="2">
         <widget class="QCheckBox" name="opt_cover_browser_reflections">
          <property name="text">
           <string>Show &amp;reflections</string>
@@ -1945,7 +1957,7 @@ them to all have the same width and height</string>
          </property>
         </widget>
        </item>
-       <item row="2" column="0">
+       <item row="1" column="1" colspan="2">
         <widget class="QLabel" name="fs_help_msg">
          <property name="styleSheet">
           <string notr="true">margin-left: 1.5em</string>
@@ -1984,7 +1996,7 @@ them to all have the same width and height</string>
          </property>
         </widget>
        </item>
-       <item row="6" column="0" colspan="2">
+       <item row="5" column="1" colspan="2">
         <widget class="QCheckBox" name="opt_cb_double_click_to_activate">
          <property name="text">
           <string>&amp;Double click to view the central book, instead of single click</string>


### PR DESCRIPTION
…the narrow layout.

The change is more complicated because the cover browser cannot be shown on the right while in wide mode.

Note: there is a problem with the cover browser splitter when using the CB on top in narrow mode. If you use the the splitter handle to make the CB disappear then the splitter doesn't come back when you use the layout button to show the CB. You must hide the CB then find the handle and drag it open.

Steps:
1. Set the CB to show on top.
2. Lift the splitter handle until the CB disappears.
3. Click the CB layout button to redisplay the CB.

The splitter is gone. To get the splitter back:
1. Use the layout button to hide the CB.
2. Search with the mouse until you find the well-hidden splitter above the book list.
3. Pull that splitter down until the CB reappears.

The splitter is again shown.

I looked for how to redisplay the splitter when the CB is displayed with the button but was foiled. 