### PR TITLE
Two small changes:

### DIFF
--- a/src/calibre/gui2/central.py
+++ b/src/calibre/gui2/central.py
@@ -330,6 +330,7 @@ class CentralContainer(QWidget):
         self.narrow_desires = NarrowDesires()
         self.wide_is_visible = Visibility()
         self.narrow_is_visible = Visibility()
+        self._last_cb_position = self.gui = None
         super().__init__(parent)
         self.action_toggle_layout = QAction(self)
         self.action_toggle_layout.triggered.connect(self.toggle_layout)
@@ -364,8 +365,6 @@ class CentralContainer(QWidget):
         self.right_handle = h()
         self.top_handle = h(Qt.Orientation.Horizontal)
         self.bottom_handle = h(Qt.Orientation.Horizontal)
-
-    _last_cb_position = gui = None
 
     @property
     def narrow_cb_on_top(self):

--- a/src/calibre/gui2/preferences/look_feel.py
+++ b/src/calibre/gui2/preferences/look_feel.py
@@ -1049,10 +1049,11 @@ class ConfigWidget(ConfigWidgetBase, Ui_Form):
         self.update_color_palette_state()
         self.opt_gui_layout.setCurrentIndex(0 if self.gui.layout_container.is_wide else 1)
         set_help_tips(self.opt_cover_browser_narrow_view_position, _(
-            'This option controls the position of the cover browser when using the Narrow user interface layout.'
-            ' "Automatic" will place the cover browser on top or on the right of the book list depending on the'
-            ' aspect ratio of the calibre window. "On top" places it over the book list, and "On right" places'
-            ' it to the right of the book list. This option cannot be changed when using the Wide user interface layout.'))
+            'This option controls the position of the cover browser when using the Narrow user '
+            'interface layout.  "Automatic" will place the cover browser on top or on the right '
+            'of the book list depending on the aspect ratio of the calibre window. "On top" '
+            'places it over the book list, and "On right" places it to the right of the book '
+            'list. This option has no effect when using the Wide user interface layout.'))
 
     def open_cg_cache(self):
         open_local_file(self.gui.grid_view.thumbnail_cache.location)


### PR DESCRIPTION
1) In the central widget, use instance variables instead of class variables. I don't think this matters now, but it might if central can ever be reinstantiated. 
2) Slight wording change on the new option's help text.