### PR TITLE
WSJ Redirect Workaround

### DIFF
--- a/recipes/wsj.recipe
+++ b/recipes/wsj.recipe
@@ -92,7 +92,9 @@ class WSJ(BasicNewsRecipe):
         try:
             br.open(url)
         except Exception as e:
-            url = e.hdrs.get('location')
+            hdrs_location = e.hdrs.get('location')
+            if hdrs_location:
+                url = e.hdrs.get('location')
         raw = read_url(self.storage, 'https://archive.is/latest/' + url)
         pt = PersistentTemporaryFile('.html')
         pt.write(raw.encode('utf-8'))


### PR DESCRIPTION
Currently the WSJ recipe runs into an error on every article download:

```Failed to download article: Goldman Scores a Win With Sharply Higher Earnings from https://www.wsj.com/articles/goldman-sachs-reports-sharply-higher-earnings-helped-by-asset-and-wealth-management-58b28520
Traceback (most recent call last):
  File "calibre/utils/threadpool.py", line 99, in run
  File "calibre/web/feeds/news.py", line 1205, in fetch_obfuscated_article
  File "<string>", line 96, in get_obfuscated_article
TypeError: can only concatenate str (not "NoneType") to str
```

This causes the script to fail and generate an empty epub:

<img width="1136" alt="image" src="https://github.com/kovidgoyal/calibre/assets/5853497/9f587729-42bd-4ae5-9730-68ec187d6902">

The WSJ recently implemented a captcha when visiting articles without JS:

<img width="558" alt="Screenshot 2024-01-17 at 5 11 19 PM" src="https://github.com/kovidgoyal/calibre/assets/5853497/cc7660a1-6a2d-4df8-8af7-94754e6ddd2b">

Because of this the recipe always gets a 401 error when checking for redirects. A 401 error causes `e.hdrs.get('location')` to return `None` which leads to the error above.

My workaround uses the original URL when a redirect is not found.

After workaround:

<img width="1136" alt="image" src="https://github.com/kovidgoyal/calibre/assets/5853497/0c17e7e2-1e3a-462c-a8c0-fa612e5be0a7">


