### PR TITLE
Bug #2049992: `unknown function` when referencing stored template …

### DIFF
--- a/src/calibre/library/save_to_disk.py
+++ b/src/calibre/library/save_to_disk.py
@@ -20,6 +20,7 @@ from calibre.utils.filenames import (
     ascii_filename, make_long_path_useable, shorten_components_to,
 )
 from calibre.utils.formatter import TemplateFormatter
+from calibre.utils.formatter_functions import load_user_template_functions
 from calibre.utils.localization import _
 
 plugboard_any_device_value = 'any device'
@@ -439,8 +440,10 @@ def read_serialized_metadata(data):
 
 
 def update_serialized_metadata(book, common_data=None):
+    # This is called from a worker process. It must not open the database.
     result = []
-    plugboard_cache = common_data
+    plugboard_cache = common_data['plugboard_cache']
+    load_user_template_functions(common_data['library_id'], common_data['template_functions'])
     from calibre.customize.ui import apply_null_metadata
     with apply_null_metadata:
         fmts = [fp.rpartition(os.extsep)[-1] for fp in book['fmts']]


### PR DESCRIPTION
…"function" in `epub:save_to_disk` plugboard template

The comments in Saver.__init__ are there in case there is some reason to not remove the load_user_template_functions() call. They can be removed.