### PR TITLE
Fix for the cover render hang discussed in …

### DIFF
--- a/src/calibre/db/tests/utils.py
+++ b/src/calibre/db/tests/utils.py
@@ -4,6 +4,7 @@
 __license__ = 'GPL v3'
 __copyright__ = '2013, Kovid Goyal <kovid at kovidgoyal.net>'
 
+import os
 import shutil
 
 from calibre import walk
@@ -71,12 +72,12 @@ class UtilsTest(BaseTest):
         c.empty()
         self.assertEqual(c.total_size, 0)
         self.assertEqual(len(c), 0)
-        self.assertEqual(tuple(walk(c.location)), ())
+        self.assertEqual(tuple(walk(c.location)), (os.path.join(c.location, 'version'),))
         c = self.init_tc()
         self.basic_fill(c)
         self.assertEqual(len(c), 5)
         c.set_thumbnail_size(200, 201)
         self.assertIsNone(c[1][0])
         self.assertEqual(len(c), 0)
-        self.assertEqual(tuple(walk(c.location)), ())
+        self.assertEqual(tuple(walk(c.location)), (os.path.join(c.location, 'version'),))
     # }}}

--- a/src/calibre/gui2/library/caches.py
+++ b/src/calibre/gui2/library/caches.py
@@ -15,8 +15,9 @@ from polyglot.builtins import itervalues
 
 class ThumbnailCache(TC):
 
-    def __init__(self, max_size=1024, thumbnail_size=(100, 100)):
-        TC.__init__(self, name='gui-thumbnail-cache', min_disk_cache=100, max_size=max_size, thumbnail_size=thumbnail_size)
+    def __init__(self, max_size=1024, thumbnail_size=(100, 100), version=0):
+        TC.__init__(self, name='gui-thumbnail-cache', min_disk_cache=100, max_size=max_size,
+                    thumbnail_size=thumbnail_size, version=version)
 
     def set_database(self, db):
         TC.set_group_id(self, db.library_id)


### PR DESCRIPTION
… https://www.mobileread.com/forums/showthread.php?t=358705.

- All Qt operations are now done on the GUI thread. File operations are done on a separate thread.
- QPixmap is used instead of QImage.
- The ThumbnailCache is now versioned.

The rendering operations are done using a FunctionDispatcher instead of a Qt signal to avoid a possible long queue of render operations causing the UI to be sluggish.

Emblems etc aren't rendered if the cover cache hasn't been set for the book. This reduces some subtle flashing as the cover is repainted. However, covers are seen as empty regions until the cover is actually rendered.

I also fixed a bug where the wrong cache would be used after a switch library. The UUID used for the cache was set at thread creation time instead of set_database time.