### PR TITLE
Plugin results are not limited to a single relevant result

### DIFF
--- a/src/calibre/customize/__init__.py
+++ b/src/calibre/customize/__init__.py
@@ -89,6 +89,10 @@ class Plugin:  # {{{
     #: care.
     can_be_disabled = True
 
+    #: The maximum number of results which can be returned by the plugin
+    #: Default relevant results is 1.
+    maximum_relevant_results = 1
+
     #: The type of this plugin. Used for categorizing plugins in the
     #: GUI
     type = _('Base')

--- a/src/calibre/ebooks/metadata/sources/identify.py
+++ b/src/calibre/ebooks/metadata/sources/identify.py
@@ -161,14 +161,17 @@ class ISBNMerge:
         # result with an ISBN
         results = [r for r in results if r.identify_plugin not in isbn_sources or not r.identify_plugin.prefer_results_with_isbn]
         if results:
-            # Pick only the most relevant result from each source
+            # By default, pick only the most relevant result from each source
             seen = set()
+            results_added = 0
             for result in results:
                 if msprefs['keep_dups'] or result.identify_plugin not in seen:
-                    seen.add(result.identify_plugin)
-                    self.results.append(result)
-                    result.average_source_relevance = \
-                        result.relevance_in_source
+                    if results_added < result.identify_plugin.maximum_relevant_results:
+                        self.results.append(result)
+                        result.average_source_relevance = result.relevance_in_source
+                        results_added += 1
+                    else:
+                        seen.add(result.identify_plugin)
 
         self.merge_metadata_results()
 


### PR DESCRIPTION
Background:
I recently started using Calibre to organize my TTRPG PDFs and found a plugin which connects to RPGGeek to download additional metadata for individual books. However, in many cases I found that the top search result was incorrect and in looking at the data returned, found that the correct book was further down the list. Because plugins are limited to a single relevant result, I was only seeing that top result in the metadata dialog.

Fix:
Add an additional property to the plugin configuration, "maximum_relevant_results" which allows the plugin author to override the default (1) and return show those additional results in the download metadata dialog.

RPGGeek Plugin: https://github.com/ErikLevin/calibre_rpggeek_plugin