### PR TITLE
Replace deprecated urlopen cafile parameter

### DIFF
--- a/setup/browser_data.py
+++ b/setup/browser_data.py
@@ -5,14 +5,16 @@
 import bz2
 import os
 import sys
+import ssl
 from datetime import datetime, timezone
 from urllib.request import urlopen
 
 
 def download_from_calibre_server(url):
     ca = os.path.join(sys.resources_location, 'calibre-ebook-root-CA.crt')
-    with urlopen(url, cafile=ca) as f:
-        return f.read()
+    ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    ssl_context.load_verify_locations(ca)
+    return urlopen(url, context=ssl_context).read()
 
 
 def filter_ans(ans):

--- a/setup/resources.py
+++ b/setup/resources.py
@@ -166,8 +166,8 @@ class RecentUAs(Command):  # {{{
     def run(self, opts):
         from setup.browser_data import get_data
         data = get_data()
-        with open(self.UA_PATH, 'wb') as f:
-            f.write(json.dumps(data, indent=2, ensure_ascii=False, sort_keys=True).encode('utf-8'))
+        with open(self.UA_PATH, 'w', encoding='utf-8') as f:
+            json.dump(data, f, indent=2, ensure_ascii=False, sort_keys=True)
 # }}}
 
 


### PR DESCRIPTION
The `cafile` parameter of `urlopen` has been deprecated since python 3.6, and is [removed in the upcoming 3.13](https://docs.python.org/3.13/whatsnew/3.13.html#urllib).

It's used in the `setup.py recent_uas` command. I replaced it with an SSL context, and cleaned up the json dumping code.

Note: I don't really use this feature - I just searched for deprecated functions.