### PR TITLE
support building from git source without internet

### DIFF
--- a/setup/browser_data.py
+++ b/setup/browser_data.py
@@ -23,9 +23,15 @@ def filter_ans(ans):
 
 def common_user_agents():
     print('Getting recent UAs...')
-    raw = download_from_calibre_server('https://code.calibre-ebook.com/ua-popularity')
+    ua_env = os.getenv('UA_POPULARITY')
+    if ua_env:
+        with open(ua_env, 'r') as f:
+            content = f.read()
+    else:
+        raw = download_from_calibre_server('https://code.calibre-ebook.com/ua-popularity')
+        content = bz2.decompress(raw).decode('utf-8')
     ans = {}
-    for line in bz2.decompress(raw).decode('utf-8').splitlines():
+    for line in content.splitlines():
         count, ua = line.partition(':')[::2]
         count = int(count.strip())
         ua = ua.strip()

--- a/setup/hyphenation.py
+++ b/setup/hyphenation.py
@@ -83,7 +83,7 @@ class Hyphenation(ReVendor):
     description = 'Download the hyphenation dictionaries'
     NAME = 'hyphenation'
     TAR_NAME = 'hyphenation dictionaries'
-    VERSION = 'master'
+    VERSION = 'libreoffice-7.6.5.2'
     DOWNLOAD_URL = 'https://github.com/LibreOffice/dictionaries/archive/%s.tar.gz' % VERSION
     CAN_USE_SYSTEM_VERSION = False
 

--- a/setup/install.py
+++ b/setup/install.py
@@ -366,21 +366,25 @@ class Bootstrap(Command):
 
     def pre_sub_commands(self, opts):
         tdir = self.j(self.d(self.SRC), 'translations')
-        clone_cmd = [
-            'git', 'clone', f'https://github.com/{self.TRANSLATIONS_REPO}.git', 'translations']
-        if opts.ephemeral:
-            if os.path.exists(tdir):
-                shutil.rmtree(tdir)
-
-            st = time.time()
-            clone_cmd.insert(2, '--depth=1')
-            subprocess.check_call(clone_cmd, cwd=self.d(self.SRC))
-            print('Downloaded translations in %d seconds' % int(time.time() - st))
+        env = os.getenv('TRANSLATIONS')
+        if env:
+            subprocess.check_call(['cp', '-r', '--no-preserve=mode,ownership', env, 'translations'])
         else:
-            if os.path.exists(tdir):
-                subprocess.check_call(['git', 'pull'], cwd=tdir)
-            else:
+            clone_cmd = [
+                'git', 'clone', f'https://github.com/{self.TRANSLATIONS_REPO}.git', 'translations']
+            if opts.ephemeral:
+                if os.path.exists(tdir):
+                    shutil.rmtree(tdir)
+
+                st = time.time()
+                clone_cmd.insert(2, '--depth=1')
                 subprocess.check_call(clone_cmd, cwd=self.d(self.SRC))
+                print('Downloaded translations in %d seconds' % int(time.time() - st))
+            else:
+                if os.path.exists(tdir):
+                    subprocess.check_call(['git', 'pull'], cwd=tdir)
+                else:
+                    subprocess.check_call(clone_cmd, cwd=self.d(self.SRC))
 
     def run(self, opts):
         self.info('\n\nAll done! You should now be able to run "%s setup.py install" to install calibre' % sys.executable)

--- a/setup/resources.py
+++ b/setup/resources.py
@@ -143,9 +143,14 @@ class CACerts(Command):  # {{{
             if err.errno != errno.ENOENT:
                 raise
             raw = b''
-        nraw = download_securely('https://curl.haxx.se/ca/cacert.pem')
-        if not nraw:
-            raise RuntimeError('Failed to download CA cert bundle')
+        env = os.getenv('CACERT')
+        if env:
+            with open(env, 'rb') as f:
+                nraw = f.read()
+        else:
+            nraw = download_securely('https://curl.haxx.se/ca/cacert.pem')
+            if not nraw:
+                raise RuntimeError('Failed to download CA cert bundle')
         if nraw != raw:
             self.info('Updating Mozilla CA certificates')
             with open(self.CA_PATH, 'wb') as f:


### PR DESCRIPTION
Currently, bootstrap of calibre need access to internet, which makes it hard to build it from git source in sandbox (Here `sandbox` means an environment without internet access) such as nix build environment.

This PR make it possible to build calibre without internet access, as long as we have downloaded needed resources and pass them to calibre bootstrap using environment variable. Now calibre can be built from git source without internet (In https://github.com/NixOS/nixpkgs/pull/289684, I build calibre from git source by patching this PR to calibre source code).