### PR TITLE
Show menu if the plugin self implement a menu without `action_add_menu`

### DIFF
--- a/src/calibre/gui2/actions/all_actions.py
+++ b/src/calibre/gui2/actions/all_actions.py
@@ -125,7 +125,7 @@ class AllGUIActions(InterfaceAction):
             menu_text = f'{display_name}{shortcuts}'
             icon = name_data[display_name]['icon']
             if act.popup_type == QToolButton.ToolButtonPopupMode.MenuButtonPopup:
-                if act.action_add_menu:
+                if act.action_add_menu or act.qaction.menu() and act.qaction.menu().children():
                     # The action offers both a 'click' and a menu. Use the menu.
                     menu.addAction(icon, menu_text, partial(self._do_menu, display_name, act))
                 else:


### PR DESCRIPTION
User plugin can self implement a menu without using the attibute `action_add_menu`. In this case, the menu is not detected by "All Actions" and don't show them when the plugin entry is selected.

A sizeable number of actuals user plugins do that.