### PR TITLE
Fix book store chooser error

### DIFF
--- a/src/calibre/gui2/store/config/chooser/results_view.py
+++ b/src/calibre/gui2/store/config/chooser/results_view.py
@@ -13,8 +13,8 @@ from calibre.gui2.store.config.chooser.models import Matches, Delegate
 
 class ResultsView(QTreeView):
 
-    def __init__(self, *args):
-        QTreeView.__init__(self,*args)
+    def __init__(self, parent=None):
+        QTreeView.__init__(self,parent)
 
         self._model = Matches([p for p in store_plugins()])
         self.setModel(self._model)


### PR DESCRIPTION
Book store chooser dialog can't open.
This dialog was opened by "Get Books" -> "Choose Stores" from tool button bar.

```Python traceback
Traceback (most recent call last):
  File ".../calibre/gui2/actions/store.py", line 116, in choose
    d = StoreChooserDialog(self.gui)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../calibre/gui2/store/config/chooser/chooser_dialog.py", line 21, in __init__
    self.config_widget = StoreChooserWidget()
                         ^^^^^^^^^^^^^^^^^^^^
  File ".../calibre/gui2/store/config/chooser/chooser_widget.py", line 15, in __init__
    self.setupUi(self)
  File ".../calibre/gui2/store/config/chooser/chooser_widget_ui.py", line 35, in setupUi
    self.results_view = ResultsView(parent=Form)
                        ^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: ResultsView.__init__() got an unexpected keyword argument 'parent'
```