### PR TITLE
Fix Content Server Web Interface unhandled error when sorting books (Launchpad Bug #2054170)

### DIFF
--- a/src/pyj/session.pyj
+++ b/src/pyj/session.pyj
@@ -326,7 +326,7 @@ def get_translations(newval):
 def is_setting_local(name):
     m = all_settings[name]
     return m.is_local if m else True
-
+     
 
 class UserSessionData(SessionData):
 
@@ -361,19 +361,19 @@ class UserSessionData(SessionData):
             defval = session_defaults()[key]
         return self.get(lkey, defval)
 
-    def set(self, key, value):
+    def set(self, library_id, key, value):
         if self.echo_changes and self.has_user and not is_setting_local(key):
-            self.changes[key] = value
+            self.changes[key + '-||-' + library_id] = value
             self.has_changes = True
             if self.push_timer_id is not None:
                 clearTimeout(self.push_timer_id)
             self.push_timer_id = setTimeout(self.push_to_server.bind(self), 1000)
-        return SessionData.set(self, (self.prefix + key), value)
+        return SessionData.set(self, (self.prefix + key + '-||-' + library_id), value)
 
     def set_library_option(self, library_id, key, value):
         if library_id:
-            key = key + '-||-' + library_id
-        return self.set(key, value)
+            return self.set(library_id, key, value)
+        return self.set(library_id, key, value)
 
     def push_to_server(self):
         if self.has_changes:


### PR DESCRIPTION
When sorting, the UserSessionData.set function was using the key 'key-||-library_id'  to search the all_settings dictionary and determine if it is set locally. However, since all_settings doesn't seem to keep track of the user's settings with the library_id in the key, the resulting value was undefined and an error was thrown upon attempting to use .local on it. To address this issue, I made sure the library_id was ignored for that check.