### PR TITLE
Two related changes

### DIFF
--- a/src/calibre/db/notes/exim.py
+++ b/src/calibre/db/notes/exim.py
@@ -25,6 +25,10 @@ def parse_html(raw):
 
 def export_note(note_doc: str, get_resource) -> str:
     root = parse_html(note_doc)
+    return html.tostring(expand_note_resources(root, get_resource), encoding='unicode')
+
+
+def expand_note_resources(root, get_resource):
     for img in root.xpath('//img[@src]'):
         img.attrib.pop('data-pre-import-src', None)
         try:
@@ -37,8 +41,6 @@ def export_note(note_doc: str, get_resource) -> str:
             if x:
                 img.set('src', data_url(guess_type(x['name'])[0], x['data']))
                 img.set('data-filename', x['name'])
-
-    return html.tostring(root, encoding='unicode')
 
 
 def import_note(shtml: str | bytes, basedir: str, add_resource) -> tuple[str, str, set[str]]:

--- a/src/calibre/ebooks/oeb/transforms/jacket.py
+++ b/src/calibre/ebooks/oeb/transforms/jacket.py
@@ -375,6 +375,13 @@ def render_jacket(mi, output_profile,
                     else:
                         val = comments_to_html(val)
                     args[dkey] = val
+                elif dt == 'composite':
+                    val = val or ''
+                    # if the column is marked as containing html, use it
+                    # unchanged. Otherwise treat it as a comment.
+                    if not m.get('display', {}).get('contains_html', False):
+                        val = comments_to_html(val)
+                    args[dkey] = val
                 else:
                     args[dkey] = escape(val)
                 args[dkey+'_label'] = escape(display_name)


### PR DESCRIPTION
Support composites in book jackets and make the template function get_note() return expanded resource urls.