### PR TITLE
Two independent commits

### DIFF
--- a/src/calibre/library/save_to_disk.py
+++ b/src/calibre/library/save_to_disk.py
@@ -147,7 +147,7 @@ class Formatter(TemplateFormatter):
     '''
 
     def get_value(self, key, args, kwargs):
-        if key == '':
+        if not isinstance(key, str) or key == '':
             return ''
         try:
             key = key.lower()


### PR DESCRIPTION
1) Fix save-to-disk templates containing template expressions like {:'current_library_name()'} printing an exception. The exception doesn't appear to break anything, but it shouldn't be there.

2) Use a timer to debounce book details display. This makes startup faster and scrolling smoother.