### PR TITLE
Remove six dependency, it's not used in code

### DIFF
--- a/bypy/sources.json
+++ b/bypy/sources.json
@@ -648,15 +648,6 @@
     },
 
     {
-        "name": "six",
-        "unix": {
-            "filename": "six-1.16.0-py2.py3-none-any.whl",
-            "hash": "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254",
-            "urls": ["pypi"]
-        }
-    },
-
-    {
         "name": "unrardll",
         "unix": {
             "filename": "unrardll-0.1.7.tar.gz",


### PR DESCRIPTION
See https://github.com/kovidgoyal/calibre/commit/b1435f9b4441ec0d43b6d93b2d370cbc65802859