### PR TITLE
Full text search: imporve <ruby> parsing when indexing books

### DIFF
--- a/src/calibre/db/fts/text.py
+++ b/src/calibre/db/fts/text.py
@@ -20,7 +20,7 @@ class SimpleContainer(ContainerBase):
     tweak_mode = True
 
 
-skipped_tags = frozenset({'style', 'title', 'script', 'head', 'img', 'svg', 'math', 'ruby'})
+skipped_tags = frozenset({'style', 'title', 'script', 'head', 'img', 'svg', 'math', 'rt', 'rp', 'rtc'})
 
 
 def tag_to_text(tag):


### PR DESCRIPTION
Following the spec of the \<ruby\> tag, it's better to ignore only the sub-tags \<rt\>, \<rp\> and \<rtc\>, because the root text inside the \<ruby\> tag is what we want indexing.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ruby