### PR TITLE
Re string changes commit: all the search types are capitalized except…

### DIFF
--- a/src/calibre/gui2/dialogs/search.py
+++ b/src/calibre/gui2/dialogs/search.py
@@ -275,7 +275,7 @@ def create_template_tab(self):
                     "With Text comparisons you can use contains (T), exact (=T), "
                     "or regular expression matches (~T), where T is your text. "
                     "With Date you can use today, yesterday, etc. When checking for "
-                    "Set use 'true' or 'yes'. When checking for not set use 'false' "
+                    "Set use 'true' or 'yes'. When checking for Not set use 'false' "
                     "or 'no'") + '</p>')
     l.addRow(_('Template &value:'), le)
 


### PR DESCRIPTION
… the one that was changed. I changed it to capitalize the "Not". Alternative change I didn't make: uncapitalize all of them.