### PR TITLE
Add custom templates for cite action

### DIFF
--- a/src/pyj/read_book/prefs/selection.pyj
+++ b/src/pyj/read_book/prefs/selection.pyj
@@ -42,6 +42,11 @@ def restore_defaults():
             control.valueAsNumber = val
         else:
             control.value = val
+
+    for ta in container.querySelectorAll('textarea[name]'):
+        val = session_defaults()[ta.getAttribute('name')]
+        ta.value = val
+
     set_actions(True)
 
 
@@ -167,6 +172,11 @@ def create_selection_panel(container, apply_func, cancel_func):
         inp.style.marginTop = '1ex'
         return E.div(style='margin-top:1ex', E.label(text, E.br(), ans))
 
+    def cite_template_textarea(name, text, title):
+        ans = E.textarea(name=name, style='width: 100%; margin-top: 1ex; box-sizing: border-box; flex-grow: 10')
+        ans.value = sd.get(name) or '[{text}]({url})'
+        return E.div(style='margin-top:1ex', E.label(text, E.br(), ans))
+
     container.appendChild(cb(
         'show_selection_bar', _('Show a popup bar with common actions next to selected text')))
     container.appendChild(url(
@@ -187,6 +197,24 @@ def create_selection_panel(container, apply_func, cancel_func):
         E.h3(_('Quick highlight actions')),
         E.div(_('Choose highlight styles that will have dedicated buttons in the selection bar to create highlights with a single click')),
         E.div(class_='quick-actions'),
+    ))
+    container.appendChild(cite_template_textarea(
+        'cite_text_template', _('Template for citing text:')))
+    container.appendChild(cite_template_textarea(
+        'cite_hl_template', _('Template for citing highlight:')))
+    container.appendChild(E.div(
+        E.div(
+            style='margin-top: 2ex',
+            _('{text} and {url} could be used in cite text template.')
+        ),
+        E.div(
+            style='margin-top: 2ex;',
+            _('{text}, {url}, {timestamp}, {chapter}, {notes}, {style_type}, {style_kind}, {style_which} could be used in cite highlight template.')
+        ),
+        E.div(
+            style='margin-top: 2ex; margin-bottom: 2ex; border-bottom: solid 1px; padding-bottom: 1ex;',
+            _('Use "}}" and "{{" to escape "}" and "{".')
+        )
     ))
     set_actions()
 
@@ -222,5 +250,13 @@ def commit_selection(onchange):
     if list(quick_highlights) != list(sd.get('selection_bar_quick_highlights')):
         changed = True
         sd.set('selection_bar_quick_highlights', quick_highlights)
+    # Save textarea
+    for ta in container.querySelectorAll('textarea[name]'):
+        name = ta.getAttribute('name')
+        val = ta.value or ''
+        old = sd.get(name)
+        if old is not val:
+            sd.set(name, val)
+            changed = True
     if changed:
         onchange()

--- a/src/pyj/read_book/selection_bar.pyj
+++ b/src/pyj/read_book/selection_bar.pyj
@@ -18,6 +18,7 @@ from read_book.shortcuts import shortcut_for_key_event
 from read_book.toc import family_for_toc_node, get_toc_nodes_bordering_spine_item
 from uuid import short_uuid
 from widgets import create_button
+from utils import parse_url_params
 
 DRAG_SCROLL_ZONE_MIN_HEIGHT = 10
 BUTTON_MARGIN = '0.5rem'
@@ -1148,15 +1149,46 @@ class SelectionBar:
         elif msg.type is 'double-click':
             self.last_double_click_at = window.performance.now()
         elif msg.type is 'cite-data':
-            spine_index = self.view.currently_showing.spine_index
-            spine_index = (1 + spine_index) * 2
-            cfi = msg.bounds.start
-            link_prefix = get_current_link_prefix()
-            if not link_prefix:
-                return self.view.show_not_a_library_book_error()
-            url = link_to_epubcfi(f'epubcfi(/{spine_index}{cfi})', link_prefix)
-            text = msg.highlighted_text.replace(/\[/g, r'\[').replace(/\]/g, r'\]')
-            ui_operations.copy_selection(f'[{text}]({url})')
+            annot_id = self.view.currently_showing.selection.annot_id
+            # If selected text is highlighted
+            if annot_id:
+                data = self.annotations_manager.data_for_highlight(annot_id)
+                spine_index = self.view.currently_showing.spine_index
+                cfi = self.annotations_manager.cfi_for_highlight(annot_id, spine_index)
+
+                if runtime.is_standalone_viewer:
+                    url = get_current_link_prefix() + "?open_at=" + cfi
+                else:
+                    url = get_current_link_prefix() + f"bookpos={cfi}" 
+                    for key, value in Object.entries(parse_url_params()):
+                        if key != "bookpos":
+                            url = url + f"&{key}={value}"
+                info = { "text" : data.highlighted_text, 
+                            "url": url,
+                            "timestamp": data.timestamp,
+                            "style_type": data.style.type,
+                            "style_kind": data.style.kind,
+                            "style_which": data.style.which,
+                            "chapter": data.toc_family_titles[0] if data.toc_family_titles[0] else "",
+                            "notes": data.notes if "notes" in data else "",
+                        }
+                copy_info = get_session_data().get('cite_hl_template').format(**info)
+            # If selected text isn't highlighted
+            else:
+                spine_index = self.view.currently_showing.spine_index
+                spine_index = (1 + spine_index) * 2
+                cfi = msg.bounds.start
+                link_prefix = get_current_link_prefix()
+                if not link_prefix:
+                    return self.view.show_not_a_library_book_error()
+                text = msg.highlighted_text.replace(/\[/g, r'\[').replace(/\]/g, r'\]')
+                url = link_to_epubcfi(f'epubcfi(/{spine_index}{cfi})', link_prefix)
+                info = { "text" : text,
+                            "url": url,
+                        }
+                copy_info = get_session_data().get('cite_text_template').format(**info)
+  
+            ui_operations.copy_selection(copy_info)
         else:
             print('Ignoring annotations message with unknown type:', msg.type)
 

--- a/src/pyj/session.pyj
+++ b/src/pyj/session.pyj
@@ -77,6 +77,8 @@ all_settings = {
     'book_search_case_sensitive': {'default': False, 'category': 'read_book', 'is_local': True},
     'reverse_page_turn_zones': {'default': False, 'category': 'read_book', 'is_local': True},
     'gesture_overrides': {'default': {}, 'category': 'read_book'},
+    'cite_text_template': {'default': '[{text}]({url})', 'category': 'read_book'},
+    'cite_hl_template': {'default': '[{text}]({url})', 'category': 'read_book'},
 }
 
 defaults = {}


### PR DESCRIPTION
I would like to add an option to selection-bar to copy highlight information using a template. This way user could easily define a template and paste their highlights into a markdown for example with readily available links to the source. 

The behavior is as follow: 
![calibre-custom-hl](https://github.com/kovidgoyal/calibre/assets/56506156/c4f62f53-ac3b-4cbb-bf03-72d109e475a6)
