### PR TITLE
Fix EPUB conversion: Use bytes replacement pattern for bytes-based re.sub

### DIFF
--- a/src/calibre/ebooks/oeb/polish/container.py
+++ b/src/calibre/ebooks/oeb/polish/container.py
@@ -1006,7 +1006,7 @@ class Container(ContainerBase):  # {{{
         if name == self.opf_name and root.nsmap.get(None) == OPF2_NS:
             # Needed as I can't get lxml to output opf:role and
             # not output <opf:metadata> as well
-            data = re.sub(br'(<[/]{0,1})opf:', r'\1', data)
+            data = re.sub(br'(<[/]{0,1})opf:', br'\1', data)
         return data
 
     def commit_item(self, name, keep_parsed=False):


### PR DESCRIPTION
In this case data and regex are bytes, so repl argument should be bytes as well. Before this fix, we would sometimes get this error:

```
calibre, version 7.3.0 (linux, embedded-python: False)
Conversion error: Failed: Convert book 1 of 1 (xxxxxxxxxx)
--- snip ---
2024-03-24 23:43:49 [INFO] Upgrading to EPUB 3...
Traceback (most recent call last):
  File "/usr/bin/calibre-parallel", line 21, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/lib64/calibre/calibre/utils/ipc/worker.py", line 214, in main
    result = func(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/calibre/calibre/gui2/convert/gui_conversion.py", line 38, in gui_convert_override
    gui_convert(input, output, recommendations, notification=notification,
  File "/usr/lib64/calibre/calibre/gui2/convert/gui_conversion.py", line 25, in gui_convert
    plumber.run()
  File "/usr/lib64/calibre/calibre/ebooks/conversion/plumber.py", line 1281, in run
    self.output_plugin.convert(self.oeb, self.output, self.input_plugin,
  File "calibre_plugins.kepubout.conversion.kepub_output", line 146, in convert
  File "/usr/lib64/calibre/calibre/ebooks/conversion/plugins/epub_output.py", line 275, in convert
    encryption = self.upgrade_to_epub3(tdir, opf, encryption)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/calibre/calibre/ebooks/conversion/plugins/epub_output.py", line 319, in upgrade_to_epub3
    container.commit()
  File "/usr/lib64/calibre/calibre/ebooks/oeb/polish/container.py", line 1360, in commit
    super().commit(keep_parsed=keep_parsed)
  File "/usr/lib64/calibre/calibre/ebooks/oeb/polish/container.py", line 1073, in commit
    self.commit_item(name, keep_parsed=keep_parsed)
  File "/usr/lib64/calibre/calibre/ebooks/oeb/polish/container.py", line 1017, in commit_item
    data = self.serialize_item(name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/calibre/calibre/ebooks/oeb/polish/container.py", line 1008, in serialize_item
    data = re.sub(br'(<[/]{0,1})opf:', r'\1', data)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/re/__init__.py", line 186, in sub
    return _compile(pattern, flags).sub(repl, string, count)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: sequence item 1: expected str instance, bytes found
```

In my case, the error would show up when converting EPUBs to KEBPUBs.