### PR TITLE
drop fallbacks for people running from source with outdated binaries

### DIFF
--- a/src/calibre/ebooks/chardet.py
+++ b/src/calibre/ebooks/chardet.py
@@ -109,14 +109,7 @@ _CHARSET_ALIASES = {"macintosh" : "mac-roman", "x-sjis" : "shift-jis"}
 def detect(bytestring):
     if isinstance(bytestring, str):
         bytestring = bytestring.encode('utf-8', 'replace')
-    try:
-        from calibre_extensions.uchardet import detect as implementation
-    except ImportError:
-        # People running from source without updated binaries
-        from cchardet import detect as cdi
-
-        def implementation(x):
-            return cdi(x).get('encoding') or ''
+    from calibre_extensions.uchardet import detect as implementation
     enc = implementation(bytestring).lower()
     return {'encoding': enc, 'confidence': 1 if enc else 0}
 

--- a/src/calibre/gui2/progress_indicator/__init__.py
+++ b/src/calibre/gui2/progress_indicator/__init__.py
@@ -4,34 +4,9 @@
 from qt.core import QDialog, QLabel, QObject, QSizePolicy, QStackedLayout, QStackedWidget, Qt, QVBoxLayout, QWidget, pyqtSignal
 
 from calibre_extensions.progress_indicator import QProgressIndicator as ProgressIndicator
-from calibre_extensions.progress_indicator import draw_snake_spinner
+from calibre_extensions.progress_indicator import SpinAnimator, draw_snake_spinner
 
 draw_snake_spinner
-
-try:
-    from calibre_extensions.progress_indicator import SpinAnimator
-except ImportError:
-    # dummy class for people running from source without updated binaries
-    class SpinAnimator(QObject):
-
-        updated = pyqtSignal()
-
-        def __init__(self, parent):
-            QObject.__init__(self, parent)
-            self.running = False
-
-        def draw(self, *a):
-            pass
-
-        def start(self):
-            self.running = True
-
-        def stop(self):
-            self.running = False
-
-        def is_running(self):
-            return self.running
-
 
 class WaitPanel(QWidget):
 
@@ -117,7 +92,6 @@ def develop():
     from qt.core import QPainter, QPalette
 
     from calibre.gui2 import Application
-    from calibre_extensions.progress_indicator import SpinAnimator
 
     class Widget(QWidget):
 

--- a/src/calibre/utils/icu.py
+++ b/src/calibre/utils/icu.py
@@ -83,10 +83,7 @@ def collator(strength=None, numeric=None, ignore_alternate_chars=None, upper_fir
         if upper_first is not None:
             ans.upper_first = upper_first
         if ignore_alternate_chars is not None:
-            try:
-                ans.set_attribute(_icu.UCOL_ALTERNATE_HANDLING, _icu.UCOL_SHIFTED if ignore_alternate_chars else _icu.UCOL_NON_IGNORABLE)
-            except AttributeError:
-                pass  # people running from source without latest binary
+            ans.set_attribute(_icu.UCOL_ALTERNATE_HANDLING, _icu.UCOL_SHIFTED if ignore_alternate_chars else _icu.UCOL_NON_IGNORABLE)
 
     thread_local_collator_cache.cache[key] = ans
     return ans


### PR DESCRIPTION
Specifically, these fallbacks exist for people running from source with binaries so outdated they are older than 6.2.