### PR TITLE
Update Economist

### DIFF
--- a/recipes/economist.recipe
+++ b/recipes/economist.recipe
@@ -197,18 +197,9 @@ class Economist(BasicNewsRecipe):
     remove_attributes = ['data-reactid', 'width', 'height']
     # economist.com has started throttling after about 60% of the total has
     # downloaded with connection reset by peer (104) errors.
-    delay = 0 if use_archive else 1
+    delay = 1
 
     needs_subscription = False
-
-    def __init__(self, *args, **kwargs):
-        BasicNewsRecipe.__init__(self, *args, **kwargs)
-        if self.output_profile.short_name.startswith('kindle'):
-            # Reduce image sizes to get file size below amazon's email
-            # sending threshold
-            self.web2disk_options.compress_news_images = True
-            self.web2disk_options.compress_news_images_auto_size = 5
-            self.log.warn('Kindle Output profile being used, reducing image quality to keep file size below amazon email threshold')
 
     def get_browser(self, *args, **kwargs):
         # Needed to bypass cloudflare
@@ -298,6 +289,16 @@ class Economist(BasicNewsRecipe):
             return soup
 
     else: # Load articles from individual article pages {{{
+
+        def __init__(self, *args, **kwargs):
+            BasicNewsRecipe.__init__(self, *args, **kwargs)
+            if self.output_profile.short_name.startswith('kindle'):
+                # Reduce image sizes to get file size below amazon's email
+                # sending threshold
+                self.web2disk_options.compress_news_images = True
+                self.web2disk_options.compress_news_images_auto_size = 5
+                self.log.warn('Kindle Output profile being used, reducing image quality to keep file size below amazon email threshold')
+
         def parse_index(self):
             # return self.economist_test_article()
             if edition_date:

--- a/recipes/economist_free.recipe
+++ b/recipes/economist_free.recipe
@@ -197,18 +197,9 @@ class Economist(BasicNewsRecipe):
     remove_attributes = ['data-reactid', 'width', 'height']
     # economist.com has started throttling after about 60% of the total has
     # downloaded with connection reset by peer (104) errors.
-    delay = 0 if use_archive else 1
+    delay = 1
 
     needs_subscription = False
-
-    def __init__(self, *args, **kwargs):
-        BasicNewsRecipe.__init__(self, *args, **kwargs)
-        if self.output_profile.short_name.startswith('kindle'):
-            # Reduce image sizes to get file size below amazon's email
-            # sending threshold
-            self.web2disk_options.compress_news_images = True
-            self.web2disk_options.compress_news_images_auto_size = 5
-            self.log.warn('Kindle Output profile being used, reducing image quality to keep file size below amazon email threshold')
 
     def get_browser(self, *args, **kwargs):
         # Needed to bypass cloudflare
@@ -298,6 +289,16 @@ class Economist(BasicNewsRecipe):
             return soup
 
     else: # Load articles from individual article pages {{{
+
+        def __init__(self, *args, **kwargs):
+            BasicNewsRecipe.__init__(self, *args, **kwargs)
+            if self.output_profile.short_name.startswith('kindle'):
+                # Reduce image sizes to get file size below amazon's email
+                # sending threshold
+                self.web2disk_options.compress_news_images = True
+                self.web2disk_options.compress_news_images_auto_size = 5
+                self.log.warn('Kindle Output profile being used, reducing image quality to keep file size below amazon email threshold')
+
         def parse_index(self):
             # return self.economist_test_article()
             if edition_date:


### PR DESCRIPTION
thought I'd test the built in recipe once, and this happen.
> Fetching https://www.economist.com/cdn-cgi/image/width=600,quality=80,format=auto/media-assets/image/20240427_INT401.png
Could not fetch image  https://www.economist.com/cdn-cgi/image/width=600,quality=80,format=auto/media-assets/image/20240427_INT401.png
Traceback (most recent call last):
  File "calibre\web\fetch\simple.py", line 281, in fetch_url
  File "mechanize\_mechanize.py", line 241, in open_novisit
  File "mechanize\_mechanize.py", line 313, in _mech_open
mechanize._response.get_seek_wrapper_class.<locals>.httperror_seek_wrapper: HTTP Error 429: Too Many Requests

this happens for sometime and whole thing stops.
also no need for image compression, images are already low res now.