### PR TITLE
Add menu action "Reverse current search" to the search bar context menu.

### DIFF
--- a/src/calibre/gui2/search_box.py
+++ b/src/calibre/gui2/search_box.py
@@ -57,12 +57,23 @@ class SearchLineEdit(QLineEdit):  # {{{
         else:
             menu.addAction(ac)
         menu.addSeparator()
+        ac = menu.addAction(_('Reverse current search'))
+        ac.setEnabled(bool(self.text()))
+        ac.setIcon(QIcon.ic('search.png'))
+        ac.triggered.connect(self.reverse_search)
+        menu.addAction(ac)
+        menu.addSeparator()
         if self.as_url is not None:
             url = self.as_url(self.text())
             if url:
                 menu.addAction(_('Copy search as URL'), lambda : QApplication.clipboard().setText(url))
         menu.addAction(_('&Clear search history')).triggered.connect(self.clear_history)
         menu.exec(ev.globalPos())
+
+    def reverse_search(self):
+        self.setText(f'NOT ( {self.text()} )')
+        ev = QKeyEvent(QEvent.Type.KeyPress, Qt.Key.Key_Enter, Qt.KeyboardModifier.NoModifier)
+        self.keyPressEvent(ev)
 
     def paste_and_search(self):
         self.paste()


### PR DESCRIPTION
Reason: it is sometimes easier to reason about searches as "I want whatever this doesn't match". In addition, most calibre search tools are "positive", returning matches. This context menu action lets you easily reverse a search, returning everything that doesn't match.

NB: "Reverse" could be "Invert". I don't know which is the better word.