### PR TITLE
Add support for passing custom configuration to recipies

### DIFF
--- a/recipes/economist.recipe
+++ b/recipes/economist.recipe
@@ -200,6 +200,19 @@ class Economist(BasicNewsRecipe):
     delay = 1
 
     needs_subscription = False
+    
+    def __init__(self, *args, **kwargs):
+        BasicNewsRecipe.__init__(self, *args, **kwargs)
+        global edition_date
+        if self.recipe_config:
+            edition_date = self.parse_config(self.recipe_config)
+
+    def parse_config(self,config):
+        if config == 'help':
+            raise SystemExit('You can pass a past date in format "date=yyyy-mm-dd". Note that only several past issues can be downloaded at the moment.')
+       	else:
+            edition_date = config.split('=')[1]
+            return edition_date
 
     def get_browser(self, *args, **kwargs):
         # Needed to bypass cloudflare

--- a/src/calibre/ebooks/conversion/plugins/recipe_input.py
+++ b/src/calibre/ebooks/conversion/plugins/recipe_input.py
@@ -52,6 +52,8 @@ class RecipeInput(InputFormatPlugin):
             help=_('Do not download latest version of builtin recipes from the calibre server')),
         OptionRecommendation(name='lrf', recommended_value=False,
             help='Optimize fetching for subsequent conversion to LRF.'),
+        OptionRecommendation(name='recipe_config', recommended_value=None,
+            help='Pass arbitrary configuration data to a recipe.'),
         }
 
     def convert(self, recipe_or_file, opts, file_ext, log,

--- a/src/calibre/gui2/dialogs/scheduler.py
+++ b/src/calibre/gui2/dialogs/scheduler.py
@@ -359,7 +359,12 @@ class SchedulerDialog(QDialog):
         self.custom_tags = ct = QLineEdit(self)
         la.setBuddy(ct)
         g.addWidget(la), g.addWidget(ct, 1, 1)
-        t2.la2 = la = QLabel(_("&Keep at most:"))
+        t2.la2 = la = QLabel(_("&Extra configurationi:"))
+        la.setToolTip(_("Extra configuration to be passed to the recipe, if the recipe implements it."))
+        self.recipe_config = cc = QLineEdit(self)
+        la.setBuddy(cc)
+        g.addWidget(la), g.addWidget(cc, 2, 1)
+        t2.la3 = la = QLabel(_("&Keep at most:"))
         la.setToolTip(_("Maximum number of copies (issues) of this recipe to keep.  Set to 0 to keep all (disable)."))
         self.keep_issues = ki = QSpinBox(t2)
         tt.toggled['bool'].connect(self.keep_issues.setEnabled)
@@ -371,9 +376,9 @@ class SchedulerDialog(QDialog):
             " option to add the title as tag checked, above.\n<p>Also, the setting for deleting periodicals"
             " older than a number of days, below, takes priority over this setting."))
         ki.setSpecialValueText(_("all issues")), ki.setSuffix(_(" issues"))
-        g.addWidget(la), g.addWidget(ki, 2, 1)
+        g.addWidget(la), g.addWidget(ki, 3, 1)
         si = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
-        g.addItem(si, 3, 1, 1, 1)
+        g.addItem(si, 4, 1, 1, 1)
 
         # Bottom area
         self.hb = h = QHBoxLayout()
@@ -506,7 +511,8 @@ class SchedulerDialog(QDialog):
             keep_issues = str(self.keep_issues.value())
         custom_tags = str(self.custom_tags.text()).strip()
         custom_tags = [x.strip() for x in custom_tags.split(',')]
-        self.recipe_model.customize_recipe(urn, add_title_tag, custom_tags, keep_issues)
+        recipe_config = str(self.recipe_config.text()).strip()
+        self.recipe_model.customize_recipe(urn, add_title_tag, custom_tags, recipe_config, keep_issues)
         return True
 
     def initialize_detail_box(self, urn):
@@ -578,9 +584,10 @@ class SchedulerDialog(QDialog):
         rb.setChecked(True)
         self.schedule_stack.setCurrentIndex(sch_widget)
         self.schedule_stack.currentWidget().initialize(typ, sch)
-        add_title_tag, custom_tags, keep_issues = customize_info
+        add_title_tag, custom_tags, recipe_config, keep_issues = customize_info
         self.add_title_tag.setChecked(add_title_tag)
         self.custom_tags.setText(', '.join(custom_tags))
+        self.recipe_config.setText(recipe_config)
         self.last_downloaded.setText(_('Last downloaded:') + ' ' + ld_text)
         try:
             keep_issues = int(keep_issues)
@@ -687,12 +694,13 @@ class Scheduler(QObject):
             un = pw = None
             if account_info is not None:
                 un, pw = account_info
-            add_title_tag, custom_tags, keep_issues = customize_info
+            add_title_tag, custom_tags, recipe_config, keep_issues = customize_info
             arg = {
                     'username': un,
                     'password': pw,
                     'add_title_tag':add_title_tag,
                     'custom_tags':custom_tags,
+                    'recipe_config':recipe_config,
                     'title':recipe.get('title',''),
                     'urn':urn,
                     'keep_issues':keep_issues

--- a/src/calibre/web/feeds/news.py
+++ b/src/calibre/web/feeds/news.py
@@ -800,6 +800,18 @@ class BasicNewsRecipe(Recipe):
         index.sort(key=lambda x: weights[x])
         return index
 
+    def parse_config(self,config):
+        '''
+        Method that allows for arbitrary data to be passed via --parse-config
+        on the command line or through Schedule news download dialog to a recipe.
+        A possible use is for example to specify an url to a past issue
+        to download instead of the latest one.
+        The format is arbitrary but suggested to be in the form key=value.
+        It is suggested to implement it in a way that will tell the user
+        the desired format when "help" is passed as argument.
+        '''
+        raise NotImplementedError('This recipe does not implement any custom configuration.')
+
     def parse_index(self):
         '''
         This method should be implemented in recipes that parse a website
@@ -893,6 +905,7 @@ class BasicNewsRecipe(Recipe):
 
     def postprocess_book(self, oeb, opts, log):
         '''
+        self.custom_tags.setText(', '.join(custom_tags))
         Run any needed post processing on the parsed downloaded e-book.
 
         :param oeb: An OEBBook object
@@ -921,6 +934,7 @@ class BasicNewsRecipe(Recipe):
         self.password = options.password
         self.lrf = options.lrf
         self.output_profile = options.output_profile
+        self.recipe_config= options.recipe_config
         self.touchscreen = getattr(self.output_profile, 'touchscreen', False)
         if self.touchscreen:
             self.template_css += self.output_profile.touchscreen_news_css
@@ -932,6 +946,9 @@ class BasicNewsRecipe(Recipe):
         if self.debug:
             self.verbose = True
         self.report_progress = progress_reporter
+
+        if self.recipe_config:
+            self.config = self.parse_config(self.recipe_config)
 
         if self.needs_subscription and (
                 self.username is None or self.password is None or (

--- a/src/calibre/web/feeds/recipes/collection.py
+++ b/src/calibre/web/feeds/recipes/collection.py
@@ -345,7 +345,7 @@ class SchedulerConfig:
             self.write_scheduler_file()
 
     # 'keep_issues' argument for recipe-specific number of copies to keep
-    def customize_recipe(self, urn, add_title_tag, custom_tags, keep_issues):
+    def customize_recipe(self, urn, add_title_tag, custom_tags, recipe_config, keep_issues):
         with self.lock:
             for x in list(self.iter_customization()):
                 if x.get('id') == urn:
@@ -355,6 +355,7 @@ class SchedulerConfig:
                 'id' : urn,
                 'add_title_tag' : 'yes' if add_title_tag else 'no',
                 'custom_tags' : ','.join(custom_tags),
+                'recipe_config' : recipe_config
                 })
             self.root.append(cs)
             self.write_scheduler_file()
@@ -526,6 +527,7 @@ class SchedulerConfig:
         keep_issues = 0
         add_title_tag = True
         custom_tags = []
+        recipe_config = []
         with self.lock:
             for x in self.iter_customization():
                 if x.get('id', False) == urn:
@@ -533,8 +535,9 @@ class SchedulerConfig:
                     add_title_tag = x.get('add_title_tag', 'yes') == 'yes'
                     custom_tags = [i.strip() for i in x.get('custom_tags',
                         '').split(',')]
+                    recipe_config = x.get("recipe_config",'').strip()
                     break
-        return add_title_tag, custom_tags, keep_issues
+        return add_title_tag, custom_tags, recipe_config, keep_issues
 
     def get_schedule_info(self, urn):
         with self.lock:

--- a/src/calibre/web/feeds/recipes/model.py
+++ b/src/calibre/web/feeds/recipes/model.py
@@ -424,9 +424,9 @@ class RecipeModel(QAbstractItemModel, AdaptSQP):
         self.scheduler_config.schedule_recipe(self.recipe_from_urn(urn),
                 sched_type, schedule)
 
-    def customize_recipe(self, urn, add_title_tag, custom_tags, keep_issues):
+    def customize_recipe(self, urn, add_title_tag, custom_tags, recipe_config, keep_issues):
         self.scheduler_config.customize_recipe(urn, add_title_tag,
-                custom_tags, keep_issues)
+                custom_tags, recipe_config, keep_issues)
 
     def get_to_be_downloaded_recipes(self):
         ans = self.scheduler_config.get_to_be_downloaded_recipes()


### PR DESCRIPTION
This would bring the changes discussed here: https://bugs.launchpad.net/calibre/+bug/2065877

It also includes changes to the Economist recipe to use the change.

It works on my machine with

    ebook-convert recipes/economist.recipe economist.mobi  --test --recipe-config="date=2024-05-18"
    
However, while developing it, I noticed that only a couple of last issues are accessible nowadays (as of now, 2024-04-27 woks, the issue after does not, and then the later ones work - two hours ago 2024-04-27 did not work).

For some reason, while using the GUI, the config does not seem to be passed to the recipe. I have no idea why, so I acknowledge this is not ready but I think I need a hint here.

There are several more questionable points:

I had an idea that if one passes "help", one would get a message about the format. However, I am not sure how to implement this properly, so maybe it can be discarded. My idea would be that if "help" is passed, other messages from running the recipe are suppressed and just the help message is displayed, but I have no idea how to accomplish that.

I am not sure about where the parse_config function is best called. I now call it in initialization of BasicNewsRecipe, but it only accomplishes to throw an error in case the option is used and a recipe does not implement it. Also using a global variable for edition_date might not be the best idea but I did not want to rework the whole logic of using a previous date in the Economist recipe.

Any feedback is welcome!
