### PR TITLE
fix ctypes AttributeError in pre_activated.py

### DIFF
--- a/src/calibre/srv/pre_activated.py
+++ b/src/calibre/srv/pre_activated.py
@@ -35,7 +35,8 @@ if islinux:
         return addr.nl_family
 
     try:
-        systemd = ctypes.CDLL(ctypes.util.find_library('systemd'))
+        from ctypes.util import find_library
+        systemd = ctypes.CDLL(find_library('systemd'))
         systemd.sd_listen_fds
     except Exception:
         pass


### PR DESCRIPTION
In my debian testing setup, I found that the systemd socket activation of calibre-server doesn't work (calibre 7.11, python 3.11.9).

When troubleshooting, I narrowed down to pre_activated.py.

https://github.com/kovidgoyal/calibre/blob/22ce34442c38e7182653a32978a124aef89b760c/src/calibre/srv/pre_activated.py#L37-L41

There is a hidden error:
```text
AttributeError: module 'ctypes' has no attribute 'util'
```

There are already places in [gui_launch.py](https://github.com/kovidgoyal/calibre/blob/22ce34442c38e7182653a32978a124aef89b760c/src/calibre/gui_launch.py#L78) and [scanner.py](https://github.com/kovidgoyal/calibre/blob/22ce34442c38e7182653a32978a124aef89b760c/src/calibre/utils/fonts/scanner.py#L39) using `from ctypes.util import find_library`, so I think this fix is fairly safe to change.

After this fix, the systemd socket activation works as expected.