### PR TITLE
Improve Windows Build Instructions and Fix Some Compatibility Issues

### DIFF
--- a/bypy/sources.json
+++ b/bypy/sources.json
@@ -67,8 +67,8 @@
     {
         "name": "zlib",
         "unix": {
-            "filename": "zlib-1.3.tar.xz",
-            "hash": "sha256:8a9ba2898e1d0d774eca6ba5b4627a11e5588ba85c8851336eb38de4683050a7",
+            "filename": "zlib-1.3.1.tar.xz",
+            "hash": "sha256:38ef96b8dfe510d42707d9c781877914792541133e1870841463bfa73f883e32",
             "urls": ["https://zlib.net/{filename}"]
         }
     },

--- a/bypy/windows.conf
+++ b/bypy/windows.conf
@@ -1,7 +1,26 @@
 # Requires installation of Visual Studio 2022 Community Edition, .NET SDK, WiX Toolset, Git, Ruby (without devkit), NodeJS, Python and Perl
+#
+# Visual Studio 2022 Components:
+# .NET SDK
+# C++ ATL for latest vXXX build tools (x86 & x64)
+# C++ Clang Compiler for Windows
+# C++ CMake tools for Windows
+# C++/CLI support for vXXX build tools
+# Git for Windows (can also be installed from web)
+# MSBuild
+# MSBuild support for LLVM (clang-cl) toolset
+# MSVC vXXX - VS 2022 C++ x64/x86 build tools
+# Python 3 (can also be installed from web)
+# Windows 11 SDK
+#
+# Add the following directories to ENV Path:
+# C:\Program Files (x86)\Microsoft Visual Studio\Installer
+# C:\Program Files\Microsoft Visual Studio\VC\Tools\MSVC\14.40.33807\bin\Hostx64\x64
+# C:\Program Files\Microsoft Visual Studio\VC\Tools\Llvm\bin
+#
 # git.exe must be in PATH. Must have ~120GB available disk space and 24GB RAM to build Qt WebEngine
-# Install certifi in python 3 with:
-# py.exe -m pip install certifi
+# Install certifi and html5lib in python 3 with:
+# py.exe -m pip install certifi html5lib
 # Copy opengl32sw.dll from
 # https://download.qt.io/development_releases/prebuilt/llvmpipe/windows/
 # to C:/mesa/64

--- a/bypy/windows/wix.py
+++ b/bypy/windows/wix.py
@@ -37,6 +37,12 @@ def create_installer(env, compression_level='9'):
     with open(j(d(__file__), 'wix-template.xml'), 'rb') as f:
         template = f.read().decode('utf-8')
 
+    cmd = [WIX, '--version']
+    WIXVERSION = run(*cmd, get_output=True).decode('utf-8').split('.')[0]
+    if int(WIXVERSION) >= 5:
+        # Virtual Symbol "WixUISupportPerUser" needs to be overridden in WIX V5 https://wixtoolset.org/docs/fivefour/
+        template = template.replace('WixUISupportPerUser', 'override WixUISupportPerUser')
+
     components, smap = get_components_from_files(env)
     wxs = template.format(
         app=calibre_constants['appname'],


### PR DESCRIPTION
Was trying to build a Windows binary and had some difficulties. I figured out how to get it to build, but I think the instructions could be updated to make it easier for others. Done in conjunction with https://github.com/kovidgoyal/bypy/pull/12

Bump ZLIB to 1.3.1
- Version 1.3 is no longer available at the link in sources.json

Support WIX Version 5
- Virtual Symbol "WixUISupportPerUser" needs to be overridden in WIX V5 https://wixtoolset.org/docs/fivefour/

Improve Windows VM Setup Instructions
- Add Specific VS Packages Required for Building Deps
- Add instruction to include cl.exe, nmake.exe and vswhere.exe in path
- Add html5lib as a Python Package for Qt-WebEngine Build

Add --dont-notarize to Window Build Steps
- Without disabling notarize, the script still attempts to sign the build