### PR TITLE
amazon parser: store all product details

### DIFF
--- a/src/calibre/ebooks/metadata/book/base.py
+++ b/src/calibre/ebooks/metadata/book/base.py
@@ -767,7 +767,7 @@ class Metadata:
         if self.title_sort:
             fmt('Title sort', self.title_sort)
         if self.authors:
-            fmt('Author(s)',  authors_to_string(self.authors) +
+            fmt('Authors',  authors_to_string(self.authors) +
                ((' [' + self.author_sort + ']')
                 if self.author_sort and self.author_sort != _('Unknown') else ''))
         if self.publisher:
@@ -809,7 +809,7 @@ class Metadata:
         from calibre.ebooks.metadata import authors_to_string
         from calibre.utils.date import isoformat
         ans = [(_('Title'), str(self.title))]
-        ans += [(_('Author(s)'), (authors_to_string(self.authors) if self.authors else _('Unknown')))]
+        ans += [(_('Authors'), (authors_to_string(self.authors) if self.authors else _('Unknown')))]
         ans += [(_('Publisher'), str(self.publisher))]
         ans += [(_('Producer'), str(self.book_producer))]
         ans += [(_('Comments'), str(self.comments))]

--- a/src/calibre/ebooks/metadata/sources/amazon.py
+++ b/src/calibre/ebooks/metadata/sources/amazon.py
@@ -372,7 +372,7 @@ class Worker(Thread):  # Get details {{{
             'eng': ('English', 'Englisch', 'Engels', 'Engelska'),
             'fra': ('French', 'Français'),
             'ita': ('Italian', 'Italiano'),
-            'deu': ('German', 'Deutsch'),
+            'ger': ('German', 'Deutsch'),
             'spa': ('Spanish', 'Espa\xf1ol', 'Espaniol'),
             'jpn': ('Japanese', '日本語'),
             'por': ('Portuguese', 'Português'),

--- a/src/calibre/ebooks/metadata/sources/amazon.py
+++ b/src/calibre/ebooks/metadata/sources/amazon.py
@@ -568,14 +568,16 @@ class Worker(Thread):  # Get details {{{
 
         mi.source_relevance = self.relevance
 
-        if self.amazon_id:
-            if self.isbn:
-                self.plugin.cache_isbn_to_identifier(self.isbn, self.amazon_id)
-            if self.cover_url:
-                self.plugin.cache_identifier_to_cover_url(self.amazon_id,
-                                                          self.cover_url)
+        if self.plugin:
 
-        self.plugin.clean_downloaded_metadata(mi)
+            if self.amazon_id:
+                if self.isbn:
+                    self.plugin.cache_isbn_to_identifier(self.isbn, self.amazon_id)
+                if self.cover_url:
+                    self.plugin.cache_identifier_to_cover_url(self.amazon_id,
+                                                              self.cover_url)
+
+            self.plugin.clean_downloaded_metadata(mi)
 
         if self.filter_result(mi, self.log):
             self.result_queue.put(mi)

--- a/src/calibre/ebooks/metadata/sources/amazon.py
+++ b/src/calibre/ebooks/metadata/sources/amazon.py
@@ -476,7 +476,7 @@ class Worker(Thread):  # Get details {{{
             return
 
         mi = Metadata(title, authors)
-        idtype = 'amazon' if self.domain == 'com' else 'amazon_' + self.domain
+        idtype = 'amazon' if (self.domain == 'com' or self.domain == None) else 'amazon_' + self.domain
         mi.set_identifier(idtype, asin)
         self.amazon_id = asin
 

--- a/src/calibre/ebooks/metadata/sources/amazon.py
+++ b/src/calibre/ebooks/metadata/sources/amazon.py
@@ -648,10 +648,14 @@ class Worker(Thread):  # Get details {{{
             if ratings:
                 break
 
+        # note: we convert from stars to rating
+        # stars: 0 to 5
+        # rating: 0 to 10
+
         def parse_ratings_text(text):
             try:
                 m = self.ratings_pat.match(text)
-                return float(m.group(1).replace(',', '.')) / float(m.group(3)) * 5
+                return float(m.group(1).replace(',', '.')) / float(m.group(3)) * 10
             except Exception:
                 pass
 
@@ -662,11 +666,11 @@ class Worker(Thread):  # Get details {{{
                 if self.domain == 'cn':
                     m = self.ratings_pat_cn.match(t)
                     if m is not None:
-                        return float(m.group(1))
+                        return float(m.group(1)) * 2
                 elif self.domain == 'jp':
                     m = self.ratings_pat_jp.match(t)
                     if m is not None:
-                        return float(m.group(1))
+                        return float(m.group(1)) * 2
                 else:
                     ans = parse_ratings_text(t)
                     if ans is not None:
@@ -684,7 +688,7 @@ class Worker(Thread):  # Get details {{{
                 if spans:
                     txt = self.tostring(spans[0], method='text', encoding='unicode', with_tail=False).strip()
                     try:
-                        return float(txt.replace(',', '.'))
+                        return float(txt.replace(',', '.')) * 2
                     except Exception:
                         pass
 

--- a/src/calibre/ebooks/metadata/sources/amazon.py
+++ b/src/calibre/ebooks/metadata/sources/amazon.py
@@ -520,6 +520,7 @@ class Worker(Thread):  # Get details {{{
         mi._details = dict()
         if detail_bullets:
             self.parse_detail_bullets(root, mi, detail_bullets[0])
+            self.parse_best_sellers_rank(root, mi)
         elif non_hero:
             try:
                 self.parse_new_details(root, mi, non_hero[0])
@@ -1054,6 +1055,26 @@ class Worker(Thread):  # Get details {{{
             from calibre.utils.date import parse_only_date
             date = self.delocalize_datestr(val)
             mi.pubdate = parse_only_date(date, assume_utc=True)
+
+    def parse_best_sellers_rank(self, root, mi):
+        if "Best Sellers Rank" in mi._details:
+            # best seller rank is part of new format product details
+            return
+        # parse old format best seller rank, add to new format product details
+        result = mi._details["Best Sellers Rank"] = list()
+        # first rank
+        elem1 = root.xpath('//*[@id="detailBulletsWrapper_feature_div"]/ul[1]/li/span/text()[2]')
+        # other ranks
+        elem2 = root.xpath('//*[@id="detailBulletsWrapper_feature_div"]/ul[1]/li/span/ul/descendant::li/span')
+        if elem1:
+            text = elem1[0].strip()
+            if text.endswith(" ("):
+                text = text[:-2]
+            result.append(text)
+        if elem2:
+            for span in elem2:
+                text = self.totext(span).strip()
+                result.append(text)
 
     def parse_isbn(self, pd):
         items = pd.xpath(

--- a/src/calibre/ebooks/metadata/sources/amazon.py
+++ b/src/calibre/ebooks/metadata/sources/amazon.py
@@ -517,6 +517,7 @@ class Worker(Thread):  # Get details {{{
             'div#bookDetails_container_div div#nonHeroSection')) or tuple(self.selector(
                 '#productDetails_techSpec_sections'))
         feature_and_detail_bullets = root.xpath('//*[@data-feature-name="featureBulletsAndDetailBullets"]')
+        mi._details = dict()
         if detail_bullets:
             self.parse_detail_bullets(root, mi, detail_bullets[0])
         elif non_hero:
@@ -1025,6 +1026,7 @@ class Worker(Thread):  # Get details {{{
         val = val.replace('\u200e', '').replace('\u200f', '')
         if not val:
             return
+        mi._details[name] = val
         if name in self.language_names:
             ans = self.lang_map.get(val)
             if not ans:

--- a/src/calibre/gui2/convert/metadata.ui
+++ b/src/calibre/gui2/convert/metadata.ui
@@ -146,7 +146,7 @@
        <item row="1" column="0">
         <widget class="QLabel" name="label_2">
          <property name="text">
-          <string>&amp;Author(s):</string>
+          <string>&amp;Authors:</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/src/calibre/gui2/dialogs/metadata_bulk.ui
+++ b/src/calibre/gui2/dialogs/metadata_bulk.ui
@@ -48,7 +48,7 @@
           <item row="0" column="0">
            <widget class="QLabel" name="label_2">
             <property name="text">
-             <string>&amp;Author(s): </string>
+             <string>&amp;Authors: </string>
             </property>
             <property name="alignment">
              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/src/calibre/gui2/library/models.py
+++ b/src/calibre/gui2/library/models.py
@@ -188,7 +188,7 @@ class BooksModel(QAbstractTableModel):  # {{{
         self.orig_headers = {
                         'title'     : _("Title"),
                         'ondevice'   : _("On Device"),
-                        'authors'   : _("Author(s)"),
+                        'authors'   : _("Authors"),
                         'size'      : _("Size (MB)"),
                         'timestamp' : _("Date"),
                         'pubdate'   : _('Published'),
@@ -1456,7 +1456,7 @@ class DeviceBooksModel(BooksModel):  # {{{
         self.headers = {
                 'inlibrary'   : _('In Library'),
                 'title'       : _('Title'),
-                'authors'     : _('Author(s)'),
+                'authors'     : _('Authors'),
                 'timestamp'   : _('Date'),
                 'size'        : _('Size'),
                 'collections' : _('Collections')

--- a/src/calibre/gui2/metadata/basic_widgets.py
+++ b/src/calibre/gui2/metadata/basic_widgets.py
@@ -363,7 +363,7 @@ class TitleSortEdit(TitleEdit, ToMetadataMixin, LineEditIndicators):
 class AuthorsEdit(EditWithComplete, ToMetadataMixin):
 
     TOOLTIP = ''
-    LABEL = _('&Author(s):')
+    LABEL = _('&Authors:')
     FIELD_NAME = 'authors'
     data_changed = pyqtSignal()
 

--- a/src/calibre/gui2/store/stores/mobileread/models.py
+++ b/src/calibre/gui2/store/stores/mobileread/models.py
@@ -19,7 +19,7 @@ class BooksModel(QAbstractItemModel):
 
     total_changed = pyqtSignal(int)
 
-    HEADERS = [_('Title'), _('Author(s)'), _('Format')]
+    HEADERS = [_('Title'), _('Authors'), _('Format')]
 
     def __init__(self, all_books):
         QAbstractItemModel.__init__(self)

--- a/src/calibre/utils/date.py
+++ b/src/calibre/utils/date.py
@@ -218,6 +218,8 @@ def isoformat(date_time, assume_utc=False, as_utc=True, sep='T'):
         date_time = date_time.replace(tzinfo=_utc_tz if assume_utc else
                 _local_tz)
     date_time = date_time.astimezone(_utc_tz if as_utc else _local_tz)
+    if 0 == date_time.hour == date_time.minute == date_time.second:
+        return date_time.strftime("%F")
     # native_string_type(sep) because isoformat barfs with unicode sep on python 2.x
     return str(date_time.isoformat(native_string_type(sep)))
 


### PR DESCRIPTION
i needed a generic amazon parser to get all product details
so these are now stored in `mi._details`

also fixed some other stuff, probably not all will be merged


<details>
<summary>
example use
</summary>

```py
#!/usr/bin/env python3

# based on /nix/store/q220vq57bgpijr7qbymhcv8b26jb861n-calibre-7.10.0/bin/.calibre-wrapped

import sys, os



# set calibre paths

calibre_source = os.path.dirname(__file__) + "/calibre"
calibre_prefix = "/nix/store/q220vq57bgpijr7qbymhcv8b26jb861n-calibre-7.10.0"

#path = os.environ.get('CALIBRE_PYTHON_PATH', calibre_prefix + '/lib/calibre')
path = os.environ.get('CALIBRE_PYTHON_PATH', calibre_source + "/src")
if path not in sys.path:
    sys.path.insert(0, path)

#sys.resources_location = os.environ.get('CALIBRE_RESOURCES_PATH', calibre_prefix + "/share/calibre")
sys.resources_location = os.environ.get('CALIBRE_RESOURCES_PATH', calibre_source + "/resources")

sys.extensions_location = os.environ.get('CALIBRE_EXTENSIONS_PATH', calibre_prefix + '/lib/calibre/calibre/plugins')

sys.executables_location = os.environ.get('CALIBRE_EXECUTABLES_PATH', calibre_prefix + '/bin')

sys.system_plugins_location = None



#from calibre.gui_launch import calibre
#sys.exit(calibre())

url = sys.argv[1]
cache_path = sys.argv[2]

import calibre.ebooks.metadata.sources.amazon

import calibre.utils.browser

import calibre.utils.logging

log = calibre.utils.logging.Log()

#import traceback

def log_exception(self, *args, **kwargs):
    limit = kwargs.pop('limit', None)
    print(*args, **kwargs)
    #print(traceback.format_exc(limit))
    raise

log.exception = log_exception

import queue
result_queue = queue.Queue()

# Get book details from amazons book page
worker = calibre.ebooks.metadata.sources.amazon.Worker(
    url,
    result_queue,
    browser=calibre.utils.browser.Browser(),
    log=log,
    relevance=None,
    domain=None,
    plugin=None,
    #timeout=20,
    #testing=False,
    #preparsed_root=None,
    #cover_url_processor=None,
    #filter_result=None
    cache_path=cache_path,
)

worker.run()
print("result_queue", result_queue)

mi = result_queue.get()
print("mi")
print(mi)
print("details")
for key, val in mi._details.items():
    print(f"{key}: {val}")
```

</details>
