### PR TITLE
move debug_print into prints module

### DIFF
--- a/src/calibre/devices/kobo/bookmark.py
+++ b/src/calibre/devices/kobo/bookmark.py
@@ -4,7 +4,7 @@ __docformat__ = 'restructuredtext en'
 
 import os
 
-from calibre.devices.usbms.driver import debug_print
+from calibre.prints import debug_print
 
 
 class Bookmark():  # {{{

--- a/src/calibre/devices/kobo/books.py
+++ b/src/calibre/devices/kobo/books.py
@@ -9,10 +9,10 @@ from calibre import isbytestring
 from calibre.constants import DEBUG, preferred_encoding
 from calibre.devices.usbms.books import Book as Book_
 from calibre.devices.usbms.books import CollectionsBookList
-from calibre.devices.usbms.driver import debug_print
 from calibre.ebooks.metadata import author_to_author_sort
 from calibre.ebooks.metadata.book.base import Metadata
 from calibre.ebooks.metadata.book.formatter import SafeFormat
+from calibre.prints import debug_print
 from calibre.utils.config_base import prefs
 
 

--- a/src/calibre/devices/kobo/driver.py
+++ b/src/calibre/devices/kobo/driver.py
@@ -25,10 +25,11 @@ from calibre.constants import DEBUG
 from calibre.devices.kobo.books import Book, ImageWrapper, KTCollectionsBookList
 from calibre.devices.mime import mime_type_ext
 from calibre.devices.usbms.books import BookList, CollectionsBookList
-from calibre.devices.usbms.driver import USBMS, debug_print
+from calibre.devices.usbms.driver import USBMS
 from calibre.ebooks.metadata import authors_to_string
 from calibre.ebooks.metadata.book.base import Metadata
 from calibre.ebooks.metadata.utils import normalize_languages
+from calibre.prints import debug_print
 from calibre.ptempfile import PersistentTemporaryFile, better_mktemp
 from calibre.utils.config_base import prefs
 from calibre.utils.date import parse_date

--- a/src/calibre/devices/kobo/kobotouch_config.py
+++ b/src/calibre/devices/kobo/kobotouch_config.py
@@ -8,12 +8,12 @@ import textwrap
 
 from qt.core import QCheckBox, QDialog, QDialogButtonBox, QGridLayout, QLabel, QLineEdit, QPushButton, QVBoxLayout, QWidget
 
-from calibre.devices.usbms.driver import debug_print
 from calibre.gui2 import error_dialog
 from calibre.gui2.device_drivers.tabbed_device_config import DeviceConfigTab, DeviceOptionsGroupBox, TabbedDeviceConfig
 from calibre.gui2.dialogs.template_dialog import TemplateDialog
 from calibre.gui2.dialogs.template_line_editor import TemplateLineEditor
 from calibre.gui2.widgets2 import ColorButton
+from calibre.prints import debug_print
 
 
 def wrap_msg(msg):

--- a/src/calibre/devices/paladin/driver.py
+++ b/src/calibre/devices/paladin/driver.py
@@ -14,7 +14,8 @@ from contextlib import closing
 from calibre.devices.errors import DeviceError
 from calibre.devices.mime import mime_type_ext
 from calibre.devices.usbms.books import BookList, CollectionsBookList
-from calibre.devices.usbms.driver import USBMS, debug_print
+from calibre.devices.usbms.driver import USBMS
+from calibre.prints import debug_print
 
 DBPATH = 'paladin/database/books.db'
 

--- a/src/calibre/devices/prs505/driver.py
+++ b/src/calibre/devices/prs505/driver.py
@@ -13,7 +13,8 @@ import time
 from calibre import __appname__, fsync, prints
 from calibre.devices.prs505 import CACHE_EXT, CACHE_THUMBNAIL, CACHE_XML, MEDIA_EXT, MEDIA_THUMBNAIL, MEDIA_XML
 from calibre.devices.usbms.books import CollectionsBookList
-from calibre.devices.usbms.driver import USBMS, debug_print
+from calibre.devices.usbms.driver import USBMS
+from calibre.prints import debug_print
 
 
 class PRS505(USBMS):

--- a/src/calibre/devices/prs505/sony_cache.py
+++ b/src/calibre/devices/prs505/sony_cache.py
@@ -12,9 +12,9 @@ from datetime import date
 from calibre import fsync, guess_type, isbytestring, prints
 from calibre.constants import DEBUG, preferred_encoding
 from calibre.devices.errors import DeviceError
-from calibre.devices.usbms.driver import debug_print
 from calibre.ebooks.chardet import xml_to_unicode
 from calibre.ebooks.metadata import authors_to_sort_string, authors_to_string, title_sort
+from calibre.prints import debug_print
 from polyglot.binary import from_base64_bytes
 
 '''

--- a/src/calibre/devices/prst1/driver.py
+++ b/src/calibre/devices/prst1/driver.py
@@ -21,8 +21,9 @@ from calibre.devices.errors import DeviceError
 from calibre.devices.mime import mime_type_ext
 from calibre.devices.usbms.books import BookList, CollectionsBookList
 from calibre.devices.usbms.device import USBDevice
-from calibre.devices.usbms.driver import USBMS, debug_print
+from calibre.devices.usbms.driver import USBMS
 from calibre.ebooks.metadata import authors_to_sort_string, authors_to_string
+from calibre.prints import debug_print
 from polyglot.builtins import long_type
 
 DBPATH = 'Sony_Reader/database/books.db'

--- a/src/calibre/devices/usbms/books.py
+++ b/src/calibre/devices/usbms/books.py
@@ -14,6 +14,7 @@ from calibre.devices.interface import BookList as _BookList
 from calibre.devices.mime import mime_type_ext
 from calibre.ebooks.metadata import title_sort
 from calibre.ebooks.metadata.book.base import Metadata
+from calibre.prints import debug_print
 from calibre.utils.config_base import tweaks
 from calibre.utils.icu import sort_key
 from polyglot.builtins import cmp, iteritems, itervalues, string_or_bytes
@@ -158,7 +159,6 @@ class CollectionsBookList(BookList):
         return cat_name.strip()
 
     def get_collections(self, collection_attributes):
-        from calibre.devices.usbms.driver import debug_print
         from calibre.utils.config import device_prefs
         debug_print('Starting get_collections:', device_prefs['manage_device_metadata'])
         debug_print('Renaming rules:', tweaks['sony_collection_renaming_rules'])

--- a/src/calibre/devices/usbms/driver.py
+++ b/src/calibre/devices/usbms/driver.py
@@ -11,50 +11,16 @@ for a particular device.
 import json
 import os
 import shutil
-import time
 from itertools import cycle
 
 from calibre import fsync, isbytestring, prints
-from calibre.constants import filesystem_encoding, is_debugging, ismacos, numeric_version
+from calibre.constants import filesystem_encoding, ismacos, numeric_version
 from calibre.devices.usbms.books import Book, BookList
 from calibre.devices.usbms.cli import CLI
 from calibre.devices.usbms.device import Device
 from calibre.ebooks.metadata.book.json_codec import JsonCodec
+from calibre.prints import debug_print
 from polyglot.builtins import itervalues, string_or_bytes
-
-
-def debug_print(*args, **kw):
-    '''
-    Prints debug information to the console if debugging is enabled.
-
-    This function prints a message prefixed with a timestamp showing the elapsed time
-    since the first call to this function. The message is printed only if debugging is enabled.
-
-    Parameters:
-    *args : tuple
-        Variable length argument list to be printed.
-    **kw : dict
-        Arbitrary keyword arguments to be passed to the `print` function.
-
-    Attributes:
-    base_time : float
-        The timestamp of the first call to this function. Stored as an attribute of the function.
-
-    Behavior:
-    - On the first call, initializes `base_time` to the current time using `time.monotonic()`.
-    - If `is_debugging()` returns True, prints the elapsed time since `base_time` along with the provided arguments.
-    '''
-
-    # Get the base_time attribute, initializing it on the first call
-    base_time = getattr(debug_print, 'base_time', None)
-    if base_time is None:
-        # Set base_time to the current monotonic time if it hasn't been set
-        debug_print.base_time = base_time = time.monotonic()
-
-    # Check if debugging is enabled
-    if is_debugging():
-        # Print the elapsed time and the provided arguments if debugging is enabled
-        prints('DEBUG: %6.1f' % (time.monotonic() - base_time), *args, **kw)
 
 
 def safe_walk(top, topdown=True, onerror=None, followlinks=False, maxdepth=128):

--- a/src/calibre/ebooks/metadata/sources/update.py
+++ b/src/calibre/ebooks/metadata/sources/update.py
@@ -13,10 +13,11 @@ from threading import Thread
 
 import calibre.ebooks.metadata.sources.search_engines as builtin_search_engines
 from calibre import as_unicode, prints
-from calibre.constants import DEBUG, numeric_version
+from calibre.constants import numeric_version
 from calibre.ebooks.metadata.sources.base import Source
 from calibre.utils.config import JSONConfig
 from calibre.utils.https import get_https_resource_securely
+from calibre.prints import debug_print
 from polyglot.builtins import iteritems, itervalues
 
 cache = JSONConfig('metadata-sources-cache.json')
@@ -28,11 +29,6 @@ current_search_engines = builtin_search_engines
 
 def search_engines_module():
     return current_search_engines
-
-
-def debug_print(*args, **k):
-    if DEBUG:
-        prints(*args, **k)
 
 
 def load_plugin(src):

--- a/src/calibre/gui2/device.py
+++ b/src/calibre/gui2/device.py
@@ -30,7 +30,7 @@ from calibre.devices.errors import (
 from calibre.devices.folder_device.driver import FOLDER_DEVICE
 from calibre.devices.interface import DevicePlugin, currently_connected_device
 from calibre.devices.scanner import DeviceScanner
-from calibre.devices.usbms.driver import debug_print
+from calibre.prints import debug_print
 from calibre.ebooks.covers import cprefs, generate_cover, override_prefs, scale_cover
 from calibre.ebooks.metadata import authors_to_string
 from calibre.gui2 import (

--- a/src/calibre/gui2/device_drivers/tabbed_device_config.py
+++ b/src/calibre/gui2/device_drivers/tabbed_device_config.py
@@ -23,7 +23,7 @@ from qt.core import (
     QWidget,
 )
 
-from calibre.devices.usbms.driver import debug_print
+from calibre.prints import debug_print
 from calibre.ebooks import BOOK_EXTENSIONS
 from calibre.gui2.device_drivers.mtp_config import FormatsConfig, TemplateConfig
 

--- a/src/calibre/prints.py
+++ b/src/calibre/prints.py
@@ -3,6 +3,7 @@
 
 import io
 import sys
+import time
 
 from polyglot.builtins import as_bytes, as_unicode
 
@@ -44,3 +45,37 @@ def prints(*a, **kw):
             stream.flush()
         except Exception:
             pass
+
+def debug_print(*args, **kw):
+    '''
+    Prints debug information to the console if debugging is enabled.
+
+    This function prints a message prefixed with a timestamp showing the elapsed time
+    since the first call to this function. The message is printed only if debugging is enabled.
+
+    Parameters:
+    *args : tuple
+        Variable length argument list to be printed.
+    **kw : dict
+        Arbitrary keyword arguments to be passed to the `print` function.
+
+    Attributes:
+    base_time : float
+        The timestamp of the first call to this function. Stored as an attribute of the function.
+
+    Behavior:
+    - On the first call, initializes `base_time` to the current time using `time.monotonic()`.
+    - If `is_debugging()` returns True, prints the elapsed time since `base_time` along with the provided arguments.
+    '''
+    from calibre.constants import is_debugging
+
+    # Get the base_time attribute, initializing it on the first call
+    base_time = getattr(debug_print, 'base_time', None)
+    if base_time is None:
+        # Set base_time to the current monotonic time if it hasn't been set
+        debug_print.base_time = base_time = time.monotonic()
+
+    # Check if debugging is enabled
+    if is_debugging():
+        # Print the elapsed time and the provided arguments if debugging is enabled
+        prints('DEBUG: %6.1f' % (time.monotonic() - base_time), *args, **kw)


### PR DESCRIPTION
debug_print could be useful in many more places than just for the devices, so move debug_print into the more generic prints module