### PR TITLE
Fix regexp escape sequence syntax warning

### DIFF
--- a/src/templite/__init__.py
+++ b/src/templite/__init__.py
@@ -32,7 +32,7 @@ from polyglot.builtins import unicode_type
 
 
 class Templite:
-    auto_emit = re.compile('(^[\'\"])|(^[a-zA-Z0-9_\[\]\'\"]+$)')
+    auto_emit = re.compile(r'(^[\'\"])|(^[a-zA-Z0-9_\[\]\'\"]+$)')
 
     def __init__(self, template, start='${', end='}$'):
         if len(start) != 2 or len(end) != 2:


### PR DESCRIPTION
Regexp strings are evaluated two times.
One is string literal to string object, and other is string object to Regexp object.

So, Regexps like `/\[/` is written as `"\\["` in source code to avoid from losing backslashes.
Python 3.12 will warns to avoid losing backslashes in these cases.

```python
.../calibre/templite/__init__.py:35: SyntaxWarning: invalid escape sequence '\['
  auto_emit = re.compile('(^[\'\"])|(^[a-zA-Z0-9_\[\]\'\"]+$)')
```

But this backslash hack is really annoying.
Use "r" prefix to use raw strings.
It reduces unwanted backslash escapement in string literals.

See also "re" module document in the Python Standard Library.
* https://docs.python.org/3/library/re.html