### PR TITLE
Support for new (2024) tolino devices

### DIFF
--- a/src/calibre/devices/kobo/driver.py
+++ b/src/calibre/devices/kobo/driver.py
@@ -3709,13 +3709,13 @@ class KOBOTOUCH(KOBO):
         elif self.isShine5():
             _cover_file_endings = self.TOLINO_COVER_FILE_ENDINGS
         elif self.isShineColor():
-            _cover_file_endings = self.GLO_HD_COVER_FILE_ENDINGS
+            _cover_file_endings = self.TOLINO_COVER_FILE_ENDINGS
         elif self.isTouch():
             _cover_file_endings = self.LEGACY_COVER_FILE_ENDINGS
         elif self.isTouch2():
             _cover_file_endings = self.LEGACY_COVER_FILE_ENDINGS
         elif self.isVisionColor():
-            _cover_file_endings = self.LIBRA_H2O_COVER_FILE_ENDINGS
+            _cover_file_endings = self.TOLINO_COVER_FILE_ENDINGS
         else:
             _cover_file_endings = self.LEGACY_COVER_FILE_ENDINGS
 

--- a/src/calibre/devices/kobo/driver.py
+++ b/src/calibre/devices/kobo/driver.py
@@ -3086,10 +3086,7 @@ class KOBOTOUCH(KOBO):
         if not self.supports_bookshelves:
             return bookshelves
 
-        if self.dbversion >= 188:
-            query = 'SELECT Name FROM Shelf WHERE _IsDeleted = false'
-        else:
-            query = 'SELECT Name FROM Shelf WHERE _IsDeleted = "false"'
+        query = "SELECT Name FROM Shelf WHERE _IsDeleted = 'false'"
 
         cursor = connection.cursor()
         cursor.execute(query)

--- a/src/calibre/devices/kobo/driver.py
+++ b/src/calibre/devices/kobo/driver.py
@@ -3086,7 +3086,7 @@ class KOBOTOUCH(KOBO):
         if not self.supports_bookshelves:
             return bookshelves
 
-        # No idea why, but the newer database version seems to make this necessary
+        # No idea why, but the newer database version seems to make this distinction necessary
         if self.dbversion >= 188:
             query = 'SELECT Name FROM Shelf WHERE _IsDeleted = false'
         else:

--- a/src/calibre/devices/kobo/driver.py
+++ b/src/calibre/devices/kobo/driver.py
@@ -3086,7 +3086,10 @@ class KOBOTOUCH(KOBO):
         if not self.supports_bookshelves:
             return bookshelves
 
-        query = "SELECT Name FROM Shelf WHERE _IsDeleted = 'false'"
+        if self.dbversion >= 188:
+            query = 'SELECT Name FROM Shelf WHERE _IsDeleted = false'
+        else:
+            query = 'SELECT Name FROM Shelf WHERE _IsDeleted = "false"'
 
         cursor = connection.cursor()
         cursor.execute(query)

--- a/src/calibre/devices/kobo/driver.py
+++ b/src/calibre/devices/kobo/driver.py
@@ -1411,7 +1411,7 @@ class KOBOTOUCH(KOBO):
     min_dbversion_keywords          = 82
     min_dbversion_seriesid          = 136
     min_dbversion_bookstats         = 168
-    min_dbversion_real_bools        = 188
+    min_dbversion_real_bools        = 188 # newer (tolino) 5.x fw uses 0 and 1 as boolean values
 
     # Starting with firmware version 3.19.x, the last number appears to be is a
     # build number. A number will be recorded here but it can be safely ignored
@@ -1938,8 +1938,6 @@ class KOBOTOUCH(KOBO):
                 return bookshelves
 
             cursor = connection.cursor()
-            # No idea why, but the newer database version seems to make this distinction necessary
-            # (to minimise the risk of a regression bug, only do this - for now - if device is a tolino)
             if self.dbversion >= self.min_dbversion_real_bools and self.isTolinoDevice():
                 query = "select ShelfName "     \
                     "from ShelfContent "        \
@@ -3049,8 +3047,6 @@ class KOBOTOUCH(KOBO):
             debug_print("KoboTouch:delete_empty_bookshelves - ignore_collections_in=", ignore_collections_placeholder)
             debug_print("KoboTouch:delete_empty_bookshelves - ignore_collections=", ignore_collections_values)
 
-        # No idea why, but the newer database version seems to make this distinction necessary
-        # (to minimise the risk of a regression bug, only do this - for now - if device is a tolino)
         if self.dbversion >= self.min_dbversion_real_bools and self.isTolinoDevice():
             delete_query = ("DELETE FROM Shelf "
                         "WHERE Shelf._IsSynced = false "
@@ -3071,8 +3067,6 @@ class KOBOTOUCH(KOBO):
                         "AND c._IsDeleted <> 'true')")
         debug_print("KoboTouch:delete_empty_bookshelves - delete_query=", delete_query)
 
-        # No idea why, but the newer database version seems to make this distinction necessary
-        # (to minimise the risk of a regression bug, only do this - for now - if device is a tolino)
         if self.dbversion >= self.min_dbversion_real_bools and self.isTolinoDevice():
             update_query = ("UPDATE Shelf "
                         "SET _IsDeleted = true "
@@ -3095,8 +3089,6 @@ class KOBOTOUCH(KOBO):
                         "AND c._IsDeleted <> 'true')")
         debug_print("KoboTouch:delete_empty_bookshelves - update_query=", update_query)
 
-        # No idea why, but the newer database version seems to make this distinction necessary
-        # (to minimise the risk of a regression bug, only do this - for now - if device is a tolino)
         if self.dbversion >= self.min_dbversion_real_bools and self.isTolinoDevice():
             delete_activity_query = ("DELETE FROM Activity "
                                  "WHERE Type = 'Shelf' "
@@ -3132,8 +3124,6 @@ class KOBOTOUCH(KOBO):
         if not self.supports_bookshelves:
             return bookshelves
 
-        # No idea why, but the newer database version seems to make this distinction necessary
-        # (to minimise the risk of a regression bug, only do this - for now - if device is a tolino)
         if self.dbversion >= self.min_dbversion_real_bools and self.isTolinoDevice():
             query = 'SELECT Name FROM Shelf WHERE _IsDeleted = false'
         else:
@@ -3164,15 +3154,11 @@ class KOBOTOUCH(KOBO):
 
         test_query = 'SELECT _IsDeleted FROM ShelfContent WHERE ShelfName = ? and ContentId = ?'
         test_values = (shelfName, book.contentID, )
-        # No idea why, but the newer database version seems to make this distinction necessary
-        # (to minimise the risk of a regression bug, only do this - for now - if device is a tolino)
         if self.dbversion >= self.min_dbversion_real_bools and self.isTolinoDevice():
             addquery = 'INSERT INTO ShelfContent ("ShelfName","ContentId","DateModified","_IsDeleted","_IsSynced") VALUES (?, ?, ?, false, false)'
         else:
             addquery = 'INSERT INTO ShelfContent ("ShelfName","ContentId","DateModified","_IsDeleted","_IsSynced") VALUES (?, ?, ?, "false", "false")'
         add_values = (shelfName, book.contentID, time.strftime(self.TIMESTAMP_STRING, time.gmtime()), )
-        # No idea why, but the newer database version seems to make this distinction necessary
-        # (to minimise the risk of a regression bug, only do this - for now - if device is a tolino)
         if self.dbversion >= self.min_dbversion_real_bools and self.isTolinoDevice():
             updatequery = 'UPDATE ShelfContent SET _IsDeleted = false WHERE ShelfName = ? and ContentId = ?'
         else:
@@ -3206,8 +3192,6 @@ class KOBOTOUCH(KOBO):
         test_query = 'SELECT InternalName, Name, _IsDeleted FROM Shelf WHERE Name = ?'
         test_values = (bookshelf_name, )
         addquery = 'INSERT INTO "main"."Shelf"'
-        # No idea why, but the newer database version seems to make this distinction necessary
-        # (to minimise the risk of a regression bug, only do this - for now - if device is a tolino)
         if self.dbversion >= self.min_dbversion_real_bools and self.isTolinoDevice():
             add_values = (time.strftime(self.TIMESTAMP_STRING, time.gmtime()),
                       bookshelf_name,
@@ -3238,8 +3222,6 @@ class KOBOTOUCH(KOBO):
         if show_debug:
             debug_print('KoboTouch:check_for_bookshelf addquery=', addquery)
             debug_print('KoboTouch:check_for_bookshelf add_values=', add_values)
-        # No idea why, but the newer database version seems to make this distinction necessary
-        # (to minimise the risk of a regression bug, only do this - for now - if device is a tolino)
         if self.dbversion >= self.min_dbversion_real_bools and self.isTolinoDevice():
             updatequery = 'UPDATE Shelf SET _IsDeleted = false WHERE Name = ?'
         else:

--- a/src/calibre/devices/kobo/driver.py
+++ b/src/calibre/devices/kobo/driver.py
@@ -3086,6 +3086,7 @@ class KOBOTOUCH(KOBO):
         if not self.supports_bookshelves:
             return bookshelves
 
+        # No idea why, but the newer database version seems to make this necessary
         if self.dbversion >= 188:
             query = 'SELECT Name FROM Shelf WHERE _IsDeleted = false'
         else:

--- a/src/calibre/devices/kobo/driver.py
+++ b/src/calibre/devices/kobo/driver.py
@@ -1565,10 +1565,15 @@ class KOBOTOUCH(KOBO):
                           # Used for screensaver, home screen
                           ' - N3_FULL.parsed':        [(1264,1680), 0, 200,True,],
                           }
-    TOLINO_COVER_FILE_ENDINGS = {
+    TOLINO_SHINE_COVER_FILE_ENDINGS = {
                           # Used for ???
                           # There's probably only one ending used
                           '':                         [(1072,1448), 0, 200,True,],
+    }
+    TOLINO_VISION_COVER_FILE_ENDINGS = {
+                          # Used for ???
+                          # There's probably only one ending used
+                          '':                         [(1264,1680), 0, 200,True,],
     }
     # Following are the sizes used with pre2.1.4 firmware
 #    COVER_FILE_ENDINGS = {
@@ -3710,15 +3715,15 @@ class KOBOTOUCH(KOBO):
         elif self.isSage():
             _cover_file_endings = self.FORMA_COVER_FILE_ENDINGS
         elif self.isShine5():
-            _cover_file_endings = self.TOLINO_COVER_FILE_ENDINGS
+            _cover_file_endings = self.TOLINO_SHINE_COVER_FILE_ENDINGS
         elif self.isShineColor():
-            _cover_file_endings = self.TOLINO_COVER_FILE_ENDINGS
+            _cover_file_endings = self.TOLINO_SHINE_COVER_FILE_ENDINGS
         elif self.isTouch():
             _cover_file_endings = self.LEGACY_COVER_FILE_ENDINGS
         elif self.isTouch2():
             _cover_file_endings = self.LEGACY_COVER_FILE_ENDINGS
         elif self.isVisionColor():
-            _cover_file_endings = self.TOLINO_COVER_FILE_ENDINGS
+            _cover_file_endings = self.TOLINO_VISION_COVER_FILE_ENDINGS
         else:
             _cover_file_endings = self.LEGACY_COVER_FILE_ENDINGS
 

--- a/src/calibre/devices/kobo/driver.py
+++ b/src/calibre/devices/kobo/driver.py
@@ -1411,6 +1411,7 @@ class KOBOTOUCH(KOBO):
     min_dbversion_keywords          = 82
     min_dbversion_seriesid          = 136
     min_dbversion_bookstats         = 168
+    min_dbversion_real_bools        = 188
 
     # Starting with firmware version 3.19.x, the last number appears to be is a
     # build number. A number will be recorded here but it can be safely ignored
@@ -1939,7 +1940,7 @@ class KOBOTOUCH(KOBO):
             cursor = connection.cursor()
             # No idea why, but the newer database version seems to make this distinction necessary
             # (to minimise the risk of a regression bug, only do this - for now - if device is a tolino)
-            if self.dbversion >= 188 and self.isTolinoDevice():
+            if self.dbversion >= self.min_dbversion_real_bools and self.isTolinoDevice():
                 query = "select ShelfName "     \
                     "from ShelfContent "        \
                     "where ContentId = ? "      \
@@ -3050,7 +3051,7 @@ class KOBOTOUCH(KOBO):
 
         # No idea why, but the newer database version seems to make this distinction necessary
         # (to minimise the risk of a regression bug, only do this - for now - if device is a tolino)
-        if self.dbversion >= 188 and self.isTolinoDevice():
+        if self.dbversion >= self.min_dbversion_real_bools and self.isTolinoDevice():
             delete_query = ("DELETE FROM Shelf "
                         "WHERE Shelf._IsSynced = false "
                         "AND Shelf.InternalName not in ('Shortlist', 'Wishlist'" + ignore_collections_placeholder + ") "
@@ -3072,7 +3073,7 @@ class KOBOTOUCH(KOBO):
 
         # No idea why, but the newer database version seems to make this distinction necessary
         # (to minimise the risk of a regression bug, only do this - for now - if device is a tolino)
-        if self.dbversion >= 188 and self.isTolinoDevice():
+        if self.dbversion >= self.min_dbversion_real_bools and self.isTolinoDevice():
             update_query = ("UPDATE Shelf "
                         "SET _IsDeleted = true "
                         "WHERE Shelf._IsSynced = true "
@@ -3096,7 +3097,7 @@ class KOBOTOUCH(KOBO):
 
         # No idea why, but the newer database version seems to make this distinction necessary
         # (to minimise the risk of a regression bug, only do this - for now - if device is a tolino)
-        if self.dbversion >= 188 and self.isTolinoDevice():
+        if self.dbversion >= self.min_dbversion_real_bools and self.isTolinoDevice():
             delete_activity_query = ("DELETE FROM Activity "
                                  "WHERE Type = 'Shelf' "
                                  "AND NOT EXISTS "
@@ -3133,7 +3134,7 @@ class KOBOTOUCH(KOBO):
 
         # No idea why, but the newer database version seems to make this distinction necessary
         # (to minimise the risk of a regression bug, only do this - for now - if device is a tolino)
-        if self.dbversion >= 188 and self.isTolinoDevice():
+        if self.dbversion >= self.min_dbversion_real_bools and self.isTolinoDevice():
             query = 'SELECT Name FROM Shelf WHERE _IsDeleted = false'
         else:
             query = 'SELECT Name FROM Shelf WHERE _IsDeleted = "false"'
@@ -3165,14 +3166,14 @@ class KOBOTOUCH(KOBO):
         test_values = (shelfName, book.contentID, )
         # No idea why, but the newer database version seems to make this distinction necessary
         # (to minimise the risk of a regression bug, only do this - for now - if device is a tolino)
-        if self.dbversion >= 188 and self.isTolinoDevice():
+        if self.dbversion >= self.min_dbversion_real_bools and self.isTolinoDevice():
             addquery = 'INSERT INTO ShelfContent ("ShelfName","ContentId","DateModified","_IsDeleted","_IsSynced") VALUES (?, ?, ?, false, false)'
         else:
             addquery = 'INSERT INTO ShelfContent ("ShelfName","ContentId","DateModified","_IsDeleted","_IsSynced") VALUES (?, ?, ?, "false", "false")'
         add_values = (shelfName, book.contentID, time.strftime(self.TIMESTAMP_STRING, time.gmtime()), )
         # No idea why, but the newer database version seems to make this distinction necessary
         # (to minimise the risk of a regression bug, only do this - for now - if device is a tolino)
-        if self.dbversion >= 188 and self.isTolinoDevice():
+        if self.dbversion >= self.min_dbversion_real_bools and self.isTolinoDevice():
             updatequery = 'UPDATE ShelfContent SET _IsDeleted = false WHERE ShelfName = ? and ContentId = ?'
         else:
             updatequery = 'UPDATE ShelfContent SET _IsDeleted = "false" WHERE ShelfName = ? and ContentId = ?'
@@ -3207,7 +3208,7 @@ class KOBOTOUCH(KOBO):
         addquery = 'INSERT INTO "main"."Shelf"'
         # No idea why, but the newer database version seems to make this distinction necessary
         # (to minimise the risk of a regression bug, only do this - for now - if device is a tolino)
-        if self.dbversion >= 188 and self.isTolinoDevice():
+        if self.dbversion >= self.min_dbversion_real_bools and self.isTolinoDevice():
             add_values = (time.strftime(self.TIMESTAMP_STRING, time.gmtime()),
                       bookshelf_name,
                       time.strftime(self.TIMESTAMP_STRING, time.gmtime()),
@@ -3239,7 +3240,7 @@ class KOBOTOUCH(KOBO):
             debug_print('KoboTouch:check_for_bookshelf add_values=', add_values)
         # No idea why, but the newer database version seems to make this distinction necessary
         # (to minimise the risk of a regression bug, only do this - for now - if device is a tolino)
-        if self.dbversion >= 188 and self.isTolinoDevice():
+        if self.dbversion >= self.min_dbversion_real_bools and self.isTolinoDevice():
             updatequery = 'UPDATE Shelf SET _IsDeleted = false WHERE Name = ?'
         else:
             updatequery = 'UPDATE Shelf SET _IsDeleted = "false" WHERE Name = ?'

--- a/src/calibre/devices/kobo/driver.py
+++ b/src/calibre/devices/kobo/driver.py
@@ -1567,12 +1567,10 @@ class KOBOTOUCH(KOBO):
                           ' - N3_FULL.parsed':        [(1264,1680), 0, 200,True,],
                           }
     TOLINO_SHINE_COVER_FILE_ENDINGS = {
-                          # Used for ???
                           # There's probably only one ending used
                           '':                         [(1072,1448), 0, 200,True,],
     }
     TOLINO_VISION_COVER_FILE_ENDINGS = {
-                          # Used for ???
                           # There's probably only one ending used
                           '':                         [(1264,1680), 0, 200,True,],
     }

--- a/src/calibre/devices/kobo/driver.py
+++ b/src/calibre/devices/kobo/driver.py
@@ -3081,7 +3081,10 @@ class KOBOTOUCH(KOBO):
         if not self.supports_bookshelves:
             return bookshelves
 
-        query = 'SELECT Name FROM Shelf WHERE _IsDeleted = "false"'
+        if self.dbversion >= 188:
+            query = 'SELECT Name FROM Shelf WHERE _IsDeleted = false'
+        else:
+            query = 'SELECT Name FROM Shelf WHERE _IsDeleted = "false"'
 
         cursor = connection.cursor()
         cursor.execute(query)

--- a/src/calibre/devices/kobo/driver.py
+++ b/src/calibre/devices/kobo/driver.py
@@ -1751,7 +1751,7 @@ class KOBOTOUCH(KOBO):
                 # - FW2.0.0, DBVersion 53,55 accessibility == 1
                 # - FW2.1.2 beta, DBVersion == 56, accessibility == -1:
                 # So, the following should be OK
-                if isdownloaded == 'false':
+                if isdownloaded == 'false' or isdownloaded == False:
                     if self.dbversion < 56 and accessibility <= 1 or self.dbversion >= 56 and accessibility == -1:
                         playlist_map[lpath].append('Deleted')
                         allow_shelves = False
@@ -2267,7 +2267,10 @@ class KOBOTOUCH(KOBO):
             try:
                 with closing(self.device_database_connection()) as connection:
                     cursor = connection.cursor()
-                    cleanup_query = "DELETE FROM content WHERE ContentID = ? AND Accessibility = 1 AND IsDownloaded = 'false'"
+                    if self.dbversion >= self.min_dbversion_real_bools and self.isTolinoDevice():
+                        cleanup_query = "DELETE FROM content WHERE ContentID = ? AND Accessibility = 1 AND IsDownloaded = false"
+                    else:
+                        cleanup_query = "DELETE FROM content WHERE ContentID = ? AND Accessibility = 1 AND IsDownloaded = 'false'"
 
                     for fname, cycle in result:
                         show_debug = self.is_debugging_title(fname)

--- a/src/calibre/devices/kobo/driver.py
+++ b/src/calibre/devices/kobo/driver.py
@@ -3087,7 +3087,8 @@ class KOBOTOUCH(KOBO):
             return bookshelves
 
         # No idea why, but the newer database version seems to make this distinction necessary
-        if self.dbversion >= 188:
+        # (to minimise the risk of a regression bug, only do this - for now - if device is a tolino)
+        if self.dbversion >= 188 and self.isTolinoDevice():
             query = 'SELECT Name FROM Shelf WHERE _IsDeleted = false'
         else:
             query = 'SELECT Name FROM Shelf WHERE _IsDeleted = "false"'


### PR DESCRIPTION
This should add support for tolino shine (5th Gen.), shine color and vision color, but has only been tested with the shine 5.

Please note that the new tolino firmware 5.x uses 0 and 1 instead of "false" and "true" for boolean values. For now, I adapted the queries only if db version is >=188 _and_ device is tolino.

There's only one cover image extension used, and no folder tree. I tweaked the code to match.