### PR TITLE
LRF viewer will not start from command line

### DIFF
--- a/src/calibre/gui2/lrf_renderer/bookview.py
+++ b/src/calibre/gui2/lrf_renderer/bookview.py
@@ -8,8 +8,8 @@ class BookView(QGraphicsView):
 
     MINIMUM_SIZE = QSize(400, 500)
 
-    def __init__(self, *args):
-        QGraphicsView.__init__(self, *args)
+    def __init__(self, parent=None):
+        QGraphicsView.__init__(self, parent)
         self.preferred_size = self.MINIMUM_SIZE
 
     def minimumSizeHint(self):


### PR DESCRIPTION
LRF viewer will not start from command line.

See also: https://github.com/kovidgoyal/calibre/pull/2198

```python
Traceback (most recent call last):
  File ".../lrfviewer", line 21, in <module>
    sys.exit(main())
             ^^^^^^
  File ".../calibre/gui2/lrf_renderer/main.py", line 312, in main
    main = file_renderer(stream, opts, logger=logger)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../calibre/gui2/lrf_renderer/main.py", line 263, in file_renderer
    m = Main(logger, opts, parent=parent)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../calibre/gui2/lrf_renderer/main.py", line 72, in __init__
    self.setupUi(self)
  File ".../calibre/gui2/lrf_renderer/main_ui.py", line 35, in setupUi
    self.graphics_view = BookView(parent=self.viewer_page)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: BookView.__init__() got an unexpected keyword argument 'parent'
```