### PR TITLE
Fix various typos

### DIFF
--- a/recipes/nbonline.recipe
+++ b/recipes/nbonline.recipe
@@ -12,7 +12,7 @@ class NBOnline(BasicNewsRecipe):
     remove_tags_before = dict(id='kanban')
     remove_tags = [dict(name='div', id='footer')]
 
-    feeds = [('Nikkei Buisiness Online',
+    feeds = [('Nikkei Business Online',
               'http://business.nikkeibp.co.jp/rss/all_nbo.rdf')]
 
     def get_cover_url(self):

--- a/recipes/ncrnext.recipe
+++ b/recipes/ncrnext.recipe
@@ -53,7 +53,7 @@ class NrcNextRecipe(BasicNewsRecipe):
                 '''
 
     def parse_index(self):
-        # Use the wesbite as an index. Their RSS feeds can be out of date.
+        # Use the website as an index. Their RSS feeds can be out of date.
         feeds = {}
         feeds[u'columnisten'] = u'http://www.nrcnext.nl/columnisten/'
         feeds[u'koken'] = u'http://www.nrcnext.nl/koken/'
@@ -67,7 +67,7 @@ class NrcNextRecipe(BasicNewsRecipe):
         for index, feed in feeds.items():
             soup = self.index_to_soup(feed)
             for post in soup.findAll(True, attrs={'class': 'post '}):
-                # Find the links to the actual articles and rember the location
+                # Find the links to the actual articles and remember the location
                 # they're pointing to and the title
                 a = post.find('a', attrs={'rel': 'bookmark'})
                 href = a['href']

--- a/src/calibre/gui2/actions/__init__.py
+++ b/src/calibre/gui2/actions/__init__.py
@@ -440,10 +440,10 @@ class InterfaceAction(QObject):
 
 class InterfaceActionWithLibraryDrop(InterfaceAction):
     '''
-    Subclass of InterfaceAction that implemente methods to execute the default action
+    Subclass of InterfaceAction that implements methods to execute the default action
     by drop some books from the library.
 
-    Inside the do_drop() method, the ids of the droped books are provided
+    Inside the do_drop() method, the ids of the dropped books are provided
     by the attribute self.dropped_ids
     '''
 

--- a/src/calibre/gui2/actions/next_match.py
+++ b/src/calibre/gui2/actions/next_match.py
@@ -18,7 +18,7 @@ class NextMatchAction(InterfaceAction):
     def genesis(self):
         '''
         Setup this plugin. Only called once during initialization. self.gui is
-        available. The action secified by :attr:`action_spec` is available as
+        available. The action specified by :attr:`action_spec` is available as
         ``self.qaction``.
         '''
         self.can_move = None

--- a/src/calibre/gui2/metadata/diff.py
+++ b/src/calibre/gui2/metadata/diff.py
@@ -707,7 +707,7 @@ class CompareMany(QDialog):
             self.action_button_action = action_button[2]
             b.clicked.connect(self.action_button_clicked)
 
-        # Add a Back button, wich allows the user to go back to the previous book cancel any reject/edit/accept that was done to it, and review it again
+        # Add a Back button, which allows the user to go back to the previous book cancel any reject/edit/accept that was done to it, and review it again
         # create a Back action that will be triggered when the user presses the back button or the back shortcut
         self.back_action = QAction(self)
         self.back_action.setShortcut(QKeySequence(Qt.KeyboardModifier.AltModifier | Qt.Key.Key_Left))
@@ -834,7 +834,7 @@ class CompareMany(QDialog):
             elif last_previous_item in self.accepted:
                 self.accepted.pop(last_previous_item)
 
-            # move the last previous item to the begining of the pending list
+            # move the last previous item to the beginning of the pending list
             self.ids.insert(0, last_previous_item)
             self.show_current_item()
 

--- a/src/calibre/gui2/tag_browser/view.py
+++ b/src/calibre/gui2/tag_browser/view.py
@@ -1200,7 +1200,7 @@ class TagsView(QTreeView):  # {{{
                 self.context_menu.addSeparator()
             add_show_hidden_categories()
 
-        # partioning. If partitioning is active, provide a way to turn it on or
+        # partitioning. If partitioning is active, provide a way to turn it on or
         # off for this category.
         if gprefs['tags_browser_partition_method'] != 'disable' and key is not None:
             m = self.context_menu


### PR DESCRIPTION
Found via `codespell -q 3 -S "./Changelog.*,./resources/dictionaries" -L alo,ans,nd,pard,ro`