### PR TITLE
Fix various typos in codebase

### DIFF
--- a/recipes/high_country_news.recipe
+++ b/recipes/high_country_news.recipe
@@ -17,7 +17,7 @@ class HighCountryNews(BasicNewsRecipe):
     #               Update language to fix how it appears in UI tree
     #               Version 2.2
     #               Update RSS feeds to hcn.org and keep the old feedburner feeds still in place
-    #               as there are some old articles available only at feedburner adress
+    #               as there are some old articles available only at feedburner address
     #               2019-07-04
     #               Version 2.3
     #               New Page design at HighCountryNews

--- a/recipes/theoldie.recipe
+++ b/recipes/theoldie.recipe
@@ -59,7 +59,7 @@ class PrivateEyeRecipe(BasicNewsRecipe):
     def abs_url(self, url):
         return self.web_root + url if url.startswith('/') else url
 
-    # Create a correctly formated DICT entry for Calibre parse_index return
+    # Create a correctly formatted DICT entry for Calibre parse_index return
     def article_entry(self, title, url, author=None):
         article = {
             'title': title,

--- a/src/calibre/customize/conversion.py
+++ b/src/calibre/customize/conversion.py
@@ -221,7 +221,7 @@ class InputFormatPlugin(Plugin):
                          by this plugin.
         :param log: A :class:`calibre.utils.logging.Log` object. All output
                     should use this object.
-        :param accelarators: A dictionary of various information that the input
+        :param accelerators: A dictionary of various information that the input
                              plugin can get easily that would speed up the
                              subsequent stages of the conversion.
 

--- a/src/calibre/gui2/markdown_syntax_highlighter.py
+++ b/src/calibre/gui2/markdown_syntax_highlighter.py
@@ -130,7 +130,7 @@ class MarkdownHighlighter(QSyntaxHighlighter):
         cursor = QTextCursor(self.document())
         bf = cursor.blockFormat()
 
-        #Block quotes can contain all elements so process it first, internaly process recusively and return
+        #Block quotes can contain all elements so process it first, internally process recursively and return
         if self.highlightBlockQuote(text, cursor, bf):
             return
 

--- a/src/calibre/gui2/preferences/create_custom_column.py
+++ b/src/calibre/gui2/preferences/create_custom_column.py
@@ -426,7 +426,7 @@ class CreateCustomColumn(QDialog):
                       _('Choose whether or not the column heading is shown in the Book '
                       'details panel and, if shown, where. Setting this to '
                       "'Show heading to the side of the text' moves the information "
-                      "from dislayed with other comments to displayed with the "
+                      "from displayed with other comments to displayed with the "
                       "non-comments columns.") + '</p>')
         self.comments_heading_position_label = add_row(_('Heading position:'), ct)
 

--- a/src/calibre/linux.py
+++ b/src/calibre/linux.py
@@ -1199,7 +1199,7 @@ def get_appdata():
 
 def changelog_bullet_to_text(bullet):
     # It would be great if we could use any fancier formatting here, but the
-    # only allowed inline formattings within the AppData description bullet
+    # only allowed inline formatting within the AppData description bullet
     # points are emphasis (italics) and code (monospaced font)
     text = [bullet['title']]
     if 'author' in bullet:

--- a/src/calibre/utils/threadpool.py
+++ b/src/calibre/utils/threadpool.py
@@ -73,7 +73,7 @@ class WorkerThread(threading.Thread):
     """
 
     def __init__(self, requestsQueue, resultsQueue, **kwds):
-        """Set up thread in daemonic mode and start it immediatedly.
+        """Set up thread in daemonic mode and start it immediately.
 
         requestsQueue and resultQueue are instances of queue.Queue passed
         by the ThreadPool class when it creates a new worker thread.

--- a/src/calibre/web/feeds/news.py
+++ b/src/calibre/web/feeds/news.py
@@ -515,7 +515,7 @@ class BasicNewsRecipe(Recipe):
     def image_url_processor(cls, baseurl, url):
         '''
         Perform some processing on image urls (perhaps removing size restrictions for
-        dynamically generated images, etc.) and return the precessed URL. Return None
+        dynamically generated images, etc.) and return the processed URL. Return None
         or an empty string to skip fetching the image.
         '''
         return url


### PR DESCRIPTION
Foiund via `codespell -q 3 -S "./Changelog.*,./resources/dictionaries" -L alo,ans,bu,fo,lokale,lokales,nd,pard,ro,tha,te,ths,ue,vai `