### PR TITLE
fix: dateutil.parser._parser.ParserError: Unknown string format

### DIFF
--- a/src/calibre/utils/date.py
+++ b/src/calibre/utils/date.py
@@ -111,7 +111,11 @@ def parse_date(date_string, assume_utc=False, as_utc=True, default=None):
     if iso_pat().match(date_string) is not None:
         dt = parse(date_string, default=default)
     else:
-        dt = parse(date_string, default=default, dayfirst=parse_date_day_first)
+        #dt = parse(date_string, default=default, dayfirst=parse_date_day_first)
+        # fix: dateutil.parser._parser.ParserError: Unknown string format: 26. Juli 2017
+        # https://github.com/scrapinghub/dateparser
+        import dateparser
+        dt = dateparser.parse(date_string)
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=_utc_tz if assume_utc else _local_tz)
     return dt.astimezone(_utc_tz if as_utc else _local_tz)


### PR DESCRIPTION
im still "abusing" `calibre.ebooks.metadata.sources.amazon`
to parse metadata from amazon, like in #2316

currently it fails to parse the german date string `26. Juli 2017`

im calling `calibre.ebooks.metadata.sources.amazon.Worker`
with `url = ""` so it cannot get amazon domain (de) from url

[dateparser](https://github.com/scrapinghub/dateparser) seems to "just work" to parse local date strings
