### PR TITLE
use ebook title (name) as the email attachment name

### DIFF
--- a/src/calibre/gui2/email.py
+++ b/src/calibre/gui2/email.py
@@ -154,7 +154,7 @@ def send_mails(jobnames, callback, attachments, to_s, subjects,
     for name, attachment, to, subject, text, aname in zip(jobnames,
             attachments, to_s, subjects, texts, attachment_names):
         description = _('Email %(name)s to %(to)s') % dict(name=name, to=to)
-        if isinstance(to, str) and (is_for_kindle(to) or '@pbsync.com' in to):
+#        if isinstance(to, str) and (is_for_kindle(to) or '@pbsync.com' in to):
             # The PocketBook service is a total joke. It cant handle
             # non-ascii, filenames that are long enough to be split up, commas, and
             # the good lord alone knows what else. So use a random filename
@@ -166,15 +166,18 @@ def send_mails(jobnames, callback, attachments, to_s, subjects,
             # these companies employ to write their code. It's the height of
             # irony that they are called "tech" companies.
             # https://bugs.launchpad.net/calibre/+bug/1989282
-            from calibre.utils.short_uuid import uuid4
-            if is_for_kindle(to):
-                # https://www.mobileread.com/forums/showthread.php?t=349290
-                from calibre.utils.filenames import ascii_filename
-                aname = ascii_filename(aname)
-            else:
-                aname = f'{uuid4()}.' + aname.rpartition('.')[-1]
-            subject = uuid4()
-            text = uuid4()
+#            from calibre.utils.short_uuid import uuid4
+#            if is_for_kindle(to):
+#                # https://www.mobileread.com/forums/showthread.php?t=349290
+#                from calibre.utils.filenames import ascii_filename
+#                aname = ascii_filename(aname)
+#            else:
+#                aname = f'{uuid4()}.' + aname.rpartition('.')[-1]
+#            subject = uuid4()
+#            text = uuid4()
+
+        aname = name + '.' + aname.rpartition('.')[-1]
+
         job = ThreadedJob('email', description, gui_sendmail, (attachment, aname, to,
                 subject, text), {}, callback)
         job_manager.run_threaded_job(job)


### PR DESCRIPTION
seems that kindle backend doesn't identify the non-utf8/non-ascii attachement file name.

we can use the utf-8 encoding "name" directly,  it can be identified by kindle backend, and more readable than the random english characters.