### PR TITLE
bypy/macos: use ULMO

### DIFF
--- a/bypy/macos/__main__.py
+++ b/bypy/macos/__main__.py
@@ -801,8 +801,8 @@ class Freeze:
             print('Signing completed in %d minutes %d seconds' % tuple(times))
         os.symlink('/Applications', join(tdir, 'Applications'))
         size_in_mb = int(subprocess.check_output(['du', '-s', '-k', tdir]).decode('utf-8').split()[0]) / 1024.
-        # UDBZ gives the best compression, better than ULFO
-        cmd = ['/usr/bin/hdiutil', 'create', '-srcfolder', tdir, '-volname', volname, '-format', 'UDBZ']
+        # ULMO (10.15+) gives the best compression, better than ULFO and better+faster than UDBZ
+        cmd = ['/usr/bin/hdiutil', 'create', '-srcfolder', tdir, '-volname', volname, '-format', 'ULMO']
         if 190 < size_in_mb < 250:
             # We need -size 255m because of a bug in hdiutil. When the size of
             # srcfolder is close to 200MB hdiutil fails with


### PR DESCRIPTION
ULMO, available in 10.15+, uses LZMA compression, which is both stronger and faster than the deprecated bzip2 (UDBZ).