### PR TITLE
fix(bypy/macos/__main__): Use -Os

### DIFF
--- a/bypy/macos/__main__.py
+++ b/bypy/macos/__main__.py
@@ -59,7 +59,7 @@ def compile_launcher_lib(contents_dir, gcc, base, pyver, inc_dir):
 
     dest = join(contents_dir, 'Frameworks', 'calibre-launcher.dylib')
     src = join(base, 'util.c')
-    cmd = [gcc] + ARCH_FLAGS + '-Wall -dynamiclib -std=gnu99'.split() + [src] + \
+    cmd = [gcc] + ARCH_FLAGS + CFLAGS + '-Wall -dynamiclib -std=gnu99'.split() + [src] + \
         ['-I' + base] + '-DPY_VERSION_MAJOR={} -DPY_VERSION_MINOR={}'.format(*pyver.split('.')).split() + \
         [f'-I{path_to_freeze_dir()}', f'-I{inc_dir}'] + \
         [f'-DENV_VARS={env}', f'-DENV_VAR_VALS={env_vals}'] + \
@@ -82,6 +82,7 @@ def compile_launcher_lib(contents_dir, gcc, base, pyver, inc_dir):
 
 
 gcc = os.environ.get('CC', 'clang')
+CFLAGS = os.environ.get('CFLAGS', '-Os')
 
 
 def compile_launchers(contents_dir, inc_dir, xprograms, pyver):
@@ -95,7 +96,7 @@ def compile_launchers(contents_dir, inc_dir, xprograms, pyver):
         out = join(contents_dir, 'MacOS', program)
         programs.append(out)
         is_gui = 'true' if ptype == 'gui' else 'false'
-        cmd = [gcc] + ARCH_FLAGS + [
+        cmd = [gcc] + ARCH_FLAGS + CFLAGS + [
             '-Wall', f'-DPROGRAM=L"{program}"', f'-DMODULE=L"{module}"', f'-DFUNCTION=L"{func}"', f'-DIS_GUI={is_gui}',
             '-I' + base, src, lib, '-o', out, '-headerpad_max_install_names',
         ]
@@ -707,7 +708,7 @@ class Freeze:
                 plist['CFBundleExecutable'] = exe + '-placeholder-for-codesigning'
                 nexe = join(exe_dir, plist['CFBundleExecutable'])
                 base = os.path.dirname(abspath(__file__))
-                cmd = [gcc] + ARCH_FLAGS + [
+                cmd = [gcc] + ARCH_FLAGS + CFLAGS + [
                     '-Wall', '-Werror', '-DEXE_NAME="%s"' % exe, '-DREL_PATH="%s"' % rel_path,
                     join(base, 'placeholder.c'), '-o', nexe, '-headerpad_max_install_names'
                 ]


### PR DESCRIPTION
The launchers were getting compiled with no optimization at all. If one runs `objdump --disassemble calibre-launcher.dylib --no-show-raw-insn`, the result is a lot of loads and stores from the stack. Probably not critical at all for performance, but ugly and silly nevertheless.

```as
calibre-launcher.dylib:
(__TEXT,__text) section
_run:
    2f30:       pushq   %rbp
    2f31:       movq    %rsp, %rbp
    2f34:       subq    $48, %rsp
    2f38:       movb    %cl, %al
    2f3a:       movq    16(%rbp), %rcx
    2f3e:       movq    %rdi, -8(%rbp)
    2f42:       movq    %rsi, -16(%rbp)
    2f46:       movq    %rdx, -24(%rbp)
    2f4a:       andb    $1, %al
    2f4c:       movb    %al, -25(%rbp)
    2f4f:       movl    %r8d, -32(%rbp)
    2f53:       movq    %r9, -40(%rbp)
    2f57:       movl    -32(%rbp), %eax
    2f5a:       movl    %eax, 380680(%rip)
    2f60:       movq    -40(%rbp), %rax
    2f64:       movq    %rax, 413469(%rip)
    2f6b:       movq    -8(%rbp), %rax
    2f6f:       movq    %rax, 413434(%rip)
    2f76:       movq    -16(%rbp), %rax
    2f7a:       movq    %rax, 413431(%rip)
```