### PR TITLE
tests: fix SSL test on python 3.13 by being more lenient about VERIFY_X509_STRICT

### DIFF
--- a/src/calibre/srv/tests/loop.py
+++ b/src/calibre/srv/tests/loop.py
@@ -201,6 +201,8 @@ class LoopTest(BaseTest):
             cert_file, key_file, ca_file = map(lambda x:os.path.join(tdir, x), 'cka')
             create_server_cert(address, ca_file, cert_file, key_file, key_size=2048)
             ctx = ssl.create_default_context(cafile=ca_file)
+            # python 3.13 added this flag to validate stricter RFC compliance. It is unneeded complexity for the testsuite.
+            ctx.verify_flags &= ~ssl.VERIFY_X509_STRICT
             with TestServer(
                     lambda data:(data.path[0] + data.read().decode('utf-8')),
                     ssl_certfile=cert_file, ssl_keyfile=key_file, listen_on=address, port=0) as server:


### PR DESCRIPTION
In python 3.13, this flag was added to the default created ctx. This seems reasonable for production validation, but the unittest code generates a certificate that fails this. Inside test code, it seems fine to relax the constraints again. Our goal is to test the server itself, anyway, not the ssl module.

See also: https://github.com/python/cpython/issues/107361