### PR TITLE
Add an option to prevent a composite column having its value stored …

### DIFF
--- a/src/calibre/ebooks/metadata/opf2.py
+++ b/src/calibre/ebooks/metadata/opf2.py
@@ -529,6 +529,9 @@ def serialize_user_metadata(metadata_elem, all_user_metadata, tail='\n'+(' '*8))
     for name, fm in all_user_metadata.items():
         try:
             fm = copy.copy(fm)
+            if not (fm.get('datatype', 'text') == 'composite' and
+                    fm.get('display', {}).get('composite_store_template_value_in_opf', True)):
+                fm['#value#'] = ''
             encode_is_multiple(fm)
             fm = object_to_unicode(fm)
             fm = json.dumps(fm, default=to_json, ensure_ascii=False)

--- a/src/calibre/ebooks/metadata/opf3.py
+++ b/src/calibre/ebooks/metadata/opf3.py
@@ -951,6 +951,9 @@ def set_user_metadata(root, prefixes, refines, val):
         nval = {}
         for name, fm in val.items():
             fm = fm.copy()
+            if not (fm.get('datatype', 'text') == 'composite' and
+                    fm.get('display', {}).get('composite_store_template_value_in_opf', True)):
+                fm['#value#'] = ''
             encode_is_multiple(fm)
             nval[name] = fm
         set_user_metadata3(root, prefixes, refines, nval)

--- a/src/calibre/gui2/preferences/create_custom_column.py
+++ b/src/calibre/gui2/preferences/create_custom_column.py
@@ -169,6 +169,7 @@ class CreateCustomColumn(QDialog):
                 self.format_box.setText(c['display'].get('date_format', ''))
         elif ct in ['composite', '*composite']:
             self.composite_box.setText(c['display'].get('composite_template', ''))
+            self.store_template_value_in_opf.setChecked(c['display'].get('composite_store_template_value_in_opf', True))
             if c['display'].get('composite_show_in_comments', ''):
                 self.composite_in_comments_box.setChecked(True)
                 idx = max(0, self.composite_heading_position.findData(c['display'].get('heading_position', 'hide')))
@@ -510,6 +511,16 @@ class CreateCustomColumn(QDialog):
         l.addWidget(la), l.addWidget(chp)
         l.addStretch()
         add_row(None, l)
+        l = QHBoxLayout()
+        self.store_template_value_in_opf = cmc = QCheckBox(_("Store this column's value in an OPF"))
+        cmc.setToolTip('<p>' + _('If you check this box then the result of '
+             "evaluating this column's template will be stored in the backup OPF "
+             'stored in the library. The same is true when sending to a device, '
+             'assuming the format has an OPF. One reason to uncheck this box is '
+             'that the column contains large images.') + '</p>')
+        l.addWidget(cmc)
+        l.addStretch()
+        add_row(None, l)
 
         # Default value
         self.default_value = dv = QLineEdit(self)
@@ -610,6 +621,7 @@ class CreateCustomColumn(QDialog):
                   'make_category', 'contains_html'):
             getattr(self, 'composite_'+x).setVisible(col_type in ('composite', '*composite'))
         self.composite_heading_position.setEnabled(False)
+        self.store_template_value_in_opf.setVisible(col_type == 'composite')
 
         for x in ('box', 'default_label',  'colors', 'colors_label'):
             getattr(self, 'enum_'+x).setVisible(col_type == 'enumeration')
@@ -708,6 +720,7 @@ class CreateCustomColumn(QDialog):
                                 'contains_html': self.composite_contains_html.isChecked(),
                                 'composite_show_in_comments': False,
                             }
+            display_dict['composite_store_template_value_in_opf'] = self.store_template_value_in_opf.isChecked()
 
         elif col_type == 'enumeration':
             if not str(self.enum_box.text()).strip():


### PR DESCRIPTION
…in an OPF. This is useful if the composite contains a large amount of data, for example images, and the value of the composite isn't needed for a client. The option is in the column definition, stored in "display" for the column.

The option removes one of the penalties of creating composites for the booklist that show notes when the user hovers over the column.

Risks: near zero. Nothing changes unless the option is changed from its default. If the option is changed then there is a risk that in some context the option will be ignored, resulting in the same behavior as before.