### PR TITLE
tts: gracefully handle the lack of a speechd module

### DIFF
--- a/src/calibre/gui2/tts/types.py
+++ b/src/calibre/gui2/tts/types.py
@@ -221,13 +221,17 @@ def available_engines() -> dict[str, EngineMetadata]:
             'for natural sounding voices. The neural network is run locally on your computer, it is fairly resource intensive to run.'
         ), TrackingCapability.Sentence, can_change_pitch=False, voices_have_quality_metadata=True, has_managed_voices=True)
     if islinux:
-        from speechd.paths import SPD_SPAWN_CMD
-        cmd = os.getenv("SPEECHD_CMD", SPD_SPAWN_CMD)
-        if cmd and os.access(cmd, os.X_OK) and os.path.isfile(cmd):
-            ans['speechd'] = EngineMetadata('speechd', _('The Speech Dispatcher Engine'), _(
-                'The "speechd" engine can usually track the currently spoken word on screen, however, it depends on the'
-                ' underlying output module. The default espeak output module does support it.'
-            ), TrackingCapability.WordByWord, allows_choosing_audio_device=False, has_multiple_output_modules=True)
+        try:
+            from speechd.paths import SPD_SPAWN_CMD
+        except ImportError:
+            pass
+        else:
+            cmd = os.getenv("SPEECHD_CMD", SPD_SPAWN_CMD)
+            if cmd and os.access(cmd, os.X_OK) and os.path.isfile(cmd):
+                ans['speechd'] = EngineMetadata('speechd', _('The Speech Dispatcher Engine'), _(
+                    'The "speechd" engine can usually track the currently spoken word on screen, however, it depends on the'
+                    ' underlying output module. The default espeak output module does support it.'
+                ), TrackingCapability.WordByWord, allows_choosing_audio_device=False, has_multiple_output_modules=True)
 
     return ans
 


### PR DESCRIPTION
We already gracefully handle the lack of speechd having the `speech-dispatcher` command utility available, and respond by disabling that backend. Go one step further, and disable it if the module is missing too.

It's not even the default engine. It seems fair for piper users to not require having this installed. The build tests will assert its presence either way so it's not like it will go unnoticed.