### PR TITLE
tests: refactor out speech-related Qt tests to distinct testcase

### DIFF
--- a/src/calibre/test_build.py
+++ b/src/calibre/test_build.py
@@ -319,10 +319,21 @@ class BuildTest(unittest.TestCase):
         conn.close()
 
     @unittest.skipIf('SKIP_QT_BUILD_TEST' in os.environ, 'Skipping Qt build test as it causes crashes in the macOS VM')
+    def test_qtspeech(self):
+        if is_sanitized:
+            raise unittest.SkipTest('Skipping Qt build test as sanitizer is enabled')
+
+        from qt.core import QMediaDevices, QTextToSpeech
+
+        available_tts_engines = tuple(x for x in QTextToSpeech.availableEngines() if x != 'mock')
+        self.assertTrue(available_tts_engines)
+        QMediaDevices.audioOutputs()
+
+    @unittest.skipIf('SKIP_QT_BUILD_TEST' in os.environ, 'Skipping Qt build test as it causes crashes in the macOS VM')
     def test_qt(self):
         if is_sanitized:
             raise unittest.SkipTest('Skipping Qt build test as sanitizer is enabled')
-        from qt.core import QApplication, QFontDatabase, QImageReader, QLoggingCategory, QMediaDevices, QNetworkAccessManager, QSslSocket, QTextToSpeech, QTimer
+        from qt.core import QApplication, QFontDatabase, QImageReader, QLoggingCategory, QNetworkAccessManager, QSslSocket, QTimer
         QLoggingCategory.setFilterRules('''qt.webenginecontext.debug=true''')
         if hasattr(os, 'geteuid') and os.geteuid() == 0:
             # likely a container build, webengine cannot run as root with sandbox
@@ -356,10 +367,6 @@ class BuildTest(unittest.TestCase):
         try:
             ensure_app()
             self.assertGreaterEqual(len(QFontDatabase.families()), 5, 'The QPA headless plugin is not able to locate enough system fonts via fontconfig')
-            available_tts_engines = tuple(x for x in QTextToSpeech.availableEngines() if x != 'mock')
-            self.assertTrue(available_tts_engines)
-
-            QMediaDevices.audioOutputs()
 
             self.assertGreaterEqual
             from calibre.ebooks.oeb.transforms.rasterize import rasterize_svg


### PR DESCRIPTION
TTS support can be gated on e.g. Gentoo's USE=speech, so we don't want to run the basic selfcheck of speech support if this is disabled. We do want to run the general Qt checks, though (and also do a selfcheck of speech support if the USE=speech is enabled!) -- this is much more conveniently done if there is a distinct testcase for it that can be passed into --exclude-test-name.