### PR TITLE
tests: add variable to suppress TTS tests

### DIFF
--- a/src/calibre/utils/run_tests.py
+++ b/src/calibre/utils/run_tests.py
@@ -190,6 +190,8 @@ class TestImports(unittest.TestCase):
                 'calibre.utils.linux_trash', 'calibre.utils.open_with.linux',
                 'calibre.gui2.linux_file_dialogs',
             }
+        if 'SKIP_SPEECH_TESTS' in os.environ:
+            exclude_packages.add('calibre.gui2.tts')
         if not isbsd:
             exclude_modules.add('calibre.devices.usbms.hal')
         d = os.path.dirname


### PR DESCRIPTION
TTS support can be gated on e.g. Gentoo's USE=speech, so we don't want to run the basic selfcheck of speech support if this is disabled. We do want to run the general Qt checks, though (and also do a selfcheck of speech support if the USE=speech is enabled!) -- so add a sneaky environment variable that we can use to conditionally skip running those parts.