### PR TITLE
Make the attributes id and has_cover 'official' calibre metadata …

### DIFF
--- a/src/calibre/ebooks/metadata/book/__init__.py
+++ b/src/calibre/ebooks/metadata/book/__init__.py
@@ -85,8 +85,8 @@ CALIBRE_METADATA_FIELDS = frozenset((
     # a dict of user category names, where the value is a list of item names
     # from the book that are in that category
     'user_categories',
-    # a dict of items to associated hyperlink
-    'link_maps',
+    'link_maps',        # a dict of items to associated hyperlink
+    'id',               # the database book id
 ))
 
 ALL_METADATA_FIELDS =      SOCIAL_METADATA_FIELDS.union(


### PR DESCRIPTION
…attributes. This allows them to be copied by mi.deepcopy_metadata().

The problem was exposed by a kiwidude plugin "Search the Internet". After a deepcopy_metadata() a template using '{id}' failed with 'unknown field'.

I don't think this change will break anything. If you are worried then reject the PR. The problem has been there since forever, so it clearly is not a burning problem.