### PR TITLE
Ensure that mi.deepcopy_metadata() keeps the top-level attributes …

### DIFF
--- a/src/calibre/ebooks/metadata/book/base.py
+++ b/src/calibre/ebooks/metadata/book/base.py
@@ -231,6 +231,9 @@ class Metadata:
         # are returning a "real" Metadata instance that has __get_attribute__.
         m = Metadata(None)
         object.__setattr__(m, '_data', copy.deepcopy(object.__getattribute__(self, '_data')))
+        # Also copy these two top-level attributes as they can appear in templates.
+        object.__setattr__(m, 'id', copy.copy(self.get('id')))
+        object.__setattr__(m, 'has_cover', copy.copy(self.get('has_cover')))
         return m
 
     def get(self, field, default=None):


### PR DESCRIPTION
…'id' and 'has_cover'