### PR TITLE
Update trim_image.py

### DIFF
--- a/src/calibre/gui2/dialogs/trim_image.py
+++ b/src/calibre/gui2/dialogs/trim_image.py
@@ -37,7 +37,7 @@ class Region(QDialog):
         h.valueChanged.connect(self.value_changed)
         l.addRow(_('&Height:'), h)
         self.ratio_input = r = QDoubleSpinBox(self)
-        r.setRange(0.0, 5.00), r.setDecimals(2), r.setValue(max_width/max_height), r.setToolTip('For example, use 0.75 for kindle devices.')
+        r.setRange(0.0, 5.00), r.setDecimals(2), r.setValue(max_width/max_height), r.setSingleStep(0.01), r.setToolTip('For example, use 0.75 for kindle devices.')
         self.m_width = max_width
         self.m_height = max_height
         r.valueChanged.connect(self.aspect_changed)


### PR DESCRIPTION
add option to adjust aspect ratio

this one works nicely.
![image](https://github.com/user-attachments/assets/303b76b8-7b6d-46c6-b1c3-9fb9f10c7d3f)
doesnt conflit with others.