### PR TITLE
Cosmetic Enhancement 2084133: Holding Ctrl and clicking twice adds 2 …

### DIFF
--- a/src/calibre/gui2/tag_browser/model.py
+++ b/src/calibre/gui2/tag_browser/model.py
@@ -1847,7 +1847,7 @@ class TagsModel(QAbstractItemModel):  # {{{
                 if tag.state != TAG_SEARCH_STATES['clear']:
                     if tag.state == TAG_SEARCH_STATES['mark_minus'] or \
                             tag.state == TAG_SEARCH_STATES['mark_minusminus']:
-                        prefix = ' not '
+                        prefix = 'not '
                     else:
                         prefix = ''
                     if node.is_gst:


### PR DESCRIPTION
…spaces to the search in the search bar.

In fact, every "not" was preceded with an extra space, which had no effect on the parsing of the search string.