### PR TITLE
Remove user categories from the dialog Preferences / Look & feel / …

### DIFF
--- a/src/calibre/gui2/preferences/look_feel.py
+++ b/src/calibre/gui2/preferences/look_feel.py
@@ -486,7 +486,8 @@ class TBHierarchicalFields(DisplayedFields):  # {{{
 
     def initialize(self, use_defaults=False, pref_data_override=None):
         tv = self.gui.tags_view
-        cats = [k for k in tv.model().categories.keys() if k not in self.cant_make_hierarical]
+        cats = [k for k in tv.model().categories.keys() if (not k.startswith('@') and
+                                                            k not in self.cant_make_hierarical)]
         ans = []
         if use_defaults:
             ans = [[k, False] for k in cats]

--- a/src/calibre/gui2/preferences/look_feel.ui
+++ b/src/calibre/gui2/preferences/look_feel.ui
@@ -1685,7 +1685,8 @@ and 'Mystery.Thriller' will be displayed with English and Thriller
 both under 'Mystery'. If 'tags' is not checked
 then the tags will be displayed each on their own line.&lt;/p&gt;
 &lt;p&gt;The categories 'authors', 'publisher', 'news', 'formats', and 'rating'
-cannot be hierarchical.&lt;/p&gt;</string>
+cannot be hierarchical.&lt;/p&gt;
+&lt;p&gt;User categories are always hierarchical so don't appear here.&lt;/p&gt;</string>
           </property>
           <property name="text">
            <string>Select categories with &amp;hierarchical items:</string>


### PR DESCRIPTION
…Tag browser / Hierarchical categories. They are always hierarchical. Having them listed in this dialog serves no purpose.