### PR TITLE
Viewer: add a delay/pause when scrolling through a boundary in Flow mode

### DIFF
--- a/src/pyj/read_book/flow_mode.pyj
+++ b/src/pyj/read_book/flow_mode.pyj
@@ -87,12 +87,12 @@ def _check_for_scroll_end(func, obj, args, report):
         if last_change_spine_item_request.name is csi.name and now - last_change_spine_item_request.at < 2000:
             return False
         ## delay change on boundaries
-        if opts.scroll_stop_boundaries :
-            if last_change_spine_item_request.ignoreUntil is None :
-                last_change_spine_item_request.ignoreUntil = now + 500
-            if now < last_change_spine_item_request.ignoreUntil:
+        if opts.scroll_mouse_boundary_delay > 0 :
+            if last_change_spine_item_request.denied is None :
+                last_change_spine_item_request.denied = now
+            if now - last_change_spine_item_request.denied < opts.scroll_mouse_boundary_delay * 1000 :
                 return False
-            last_change_spine_item_request.ignoreUntil = None
+            last_change_spine_item_request.denied = None
         # perform change
         last_change_spine_item_request.name = csi.name
         last_change_spine_item_request.at = now
@@ -101,7 +101,7 @@ def _check_for_scroll_end(func, obj, args, report):
             go_to_previous_page = not go_to_previous_page
         get_boss().send_message('next_spine_item', previous=go_to_previous_page)
         return False
-    last_change_spine_item_request.ignoreUntil = None
+    last_change_spine_item_request.denied = None
     if report:
         report_human_scroll(scroll_viewport.block_pos() - before)
     return True

--- a/src/pyj/read_book/flow_mode.pyj
+++ b/src/pyj/read_book/flow_mode.pyj
@@ -83,8 +83,17 @@ def _check_for_scroll_end(func, obj, args, report):
 
     if scroll_viewport.block_pos() is before:
         csi = current_spine_item()
+        ## ignore duplicate requests
         if last_change_spine_item_request.name is csi.name and now - last_change_spine_item_request.at < 2000:
             return False
+        ## delay change on boundaries
+        if opts.scroll_stop_boundaries :
+            if last_change_spine_item_request.ignoreUntil is None :
+                last_change_spine_item_request.ignoreUntil = now + 500
+            if now < last_change_spine_item_request.ignoreUntil:
+                return False
+            last_change_spine_item_request.ignoreUntil = None
+        # perform change
         last_change_spine_item_request.name = csi.name
         last_change_spine_item_request.at = now
         go_to_previous_page = args[0] < 0
@@ -92,6 +101,7 @@ def _check_for_scroll_end(func, obj, args, report):
             go_to_previous_page = not go_to_previous_page
         get_boss().send_message('next_spine_item', previous=go_to_previous_page)
         return False
+    last_change_spine_item_request.ignoreUntil = None
     if report:
         report_human_scroll(scroll_viewport.block_pos() - before)
     return True

--- a/src/pyj/read_book/prefs/scrolling.pyj
+++ b/src/pyj/read_book/prefs/scrolling.pyj
@@ -22,6 +22,9 @@ MAX_SCROLL_AUTO_DELAY = 50
 MIN_SCROLL_SPEED_SMOOTH = 5
 MAX_SCROLL_SPEED_SMOOTH = 80
 
+MIN_SCROLL_MOUSE_DELAY = 0
+MAX_SCROLL_MOUSE_DELAY = 5
+
 def restore_defaults():
     container = get_container()
     for control in container.querySelectorAll('input[name]'):
@@ -113,6 +116,14 @@ def create_scrolling_panel(container, apply_func, cancel_func):
                 step=0.25,
                 min=MIN_SCROLL_AUTO_DELAY,
                 max=MAX_SCROLL_AUTO_DELAY
+            ),
+            *spinner(
+                'scroll_mouse_boundary_delay',
+                _('Seconds to pause when mouse-scrolling past internal file boundaries'),
+                title=_('Set to zero to scroll past internal file boundaries without delay'),
+                step=0.25,
+                min=MIN_SCROLL_MOUSE_DELAY,
+                max=MAX_SCROLL_MOUSE_DELAY
             )
         )
     )

--- a/src/pyj/read_book/settings.pyj
+++ b/src/pyj/read_book/settings.pyj
@@ -29,6 +29,7 @@ def update_settings(settings):
     opts.paged_wheel_section_jumps = v'!!settings.paged_wheel_section_jumps'
     opts.paged_pixel_scroll_threshold = settings.paged_pixel_scroll_threshold
     opts.scroll_auto_boundary_delay = settings.scroll_auto_boundary_delay
+    opts.scroll_mouse_boundary_delay = settings.scroll_mouse_boundary_delay
     opts.scroll_stop_boundaries = v'!!settings.scroll_stop_boundaries'
     opts.reverse_page_turn_zones = v'!!settings.reverse_page_turn_zones'
     opts.user_stylesheet = settings.user_stylesheet

--- a/src/pyj/read_book/view.pyj
+++ b/src/pyj/read_book/view.pyj
@@ -1050,6 +1050,7 @@ class View:
             'lines_per_sec_auto': sd.get('lines_per_sec_auto'),
             'lines_per_sec_smooth': sd.get('lines_per_sec_smooth'),
             'scroll_auto_boundary_delay': sd.get('scroll_auto_boundary_delay'),
+            'scroll_mouse_boundary_delay': sd.get('scroll_mouse_boundary_delay'),
             'scroll_stop_boundaries': sd.get('scroll_stop_boundaries'),
             'reverse_page_turn_zones': sd.get('reverse_page_turn_zones'),
             'gesture_overrides': sd.get('gesture_overrides'),

--- a/src/pyj/session.pyj
+++ b/src/pyj/session.pyj
@@ -55,6 +55,7 @@ all_settings = {
     'paged_pixel_scroll_threshold': {'default': 60, 'category': 'read_book'},
     'read_mode': {'default': 'paged', 'category': 'read_book', 'is_local': True},
     'scroll_auto_boundary_delay': {'default': 5, 'category': 'read_book', 'is_local': True},
+    'scroll_mouse_boundary_delay': {'default': 0, 'category': 'read_book', 'is_local': True},
     'scroll_stop_boundaries': {'default': False, 'category': 'read_book', 'is_local': True},
     'standalone_font_settings': {'default': {}, 'category': 'read_book', 'is_local': True},
     'standalone_misc_settings': {'default': {}, 'category': 'read_book', 'is_local': True},


### PR DESCRIPTION
This change makes scrolling with the mouse wheel in Flow mode stop at a boundary/section, preventing abrupt section changes. This has been requested multiple times:
https://bugs.launchpad.net/calibre/+bug/1861630
https://bugs.launchpad.net/calibre/+bug/1853634
https://bugs.launchpad.net/calibre/+bug/1800248

**Implementation:**

A new preference 'scroll_mouse_boundary_delay' is added to specify the delay before crossing a boundary. It defaults to zero, which disables this feature. A value of 0.5 seconds works well.

When scrolling through a boundary, the page change request is ignored/cancelled at first, and only allowed if the user scrolls again after a delay. The net effect is that moving the mouse wheel multiple steps in one go will now stop at the boundary instead of unexpectedly moving to the next/prev chapter. To actually change the chapter, the user just has to scroll again after a short delay.