### PR TITLE
Remove space on substack replacement

### DIFF
--- a/recipes/substack.recipe
+++ b/recipes/substack.recipe
@@ -94,7 +94,7 @@ class Substack(BasicNewsRecipe):
         u = self.recipe_specific_options.get('auths')
         if u and isinstance(u, str):
             for x in u.split():
-                ans.append('https://' + x.replace('@', ' ') + '.substack.com/feed')
+                ans.append('https://' + x.replace('@', '') + '.substack.com/feed')
         return ans
 
     def preprocess_html(self, soup):


### PR DESCRIPTION
Space is causing an invalid URL.

![image](https://github.com/user-attachments/assets/a062783e-55fe-437d-afc6-9c230d6ec3ec)
