### PR TITLE
Set focus on jobs_view table when "Show jobs detail" is clicked

### DIFF
--- a/src/calibre/gui2/jobs.py
+++ b/src/calibre/gui2/jobs.py
@@ -686,6 +686,7 @@ class JobsDialog(QDialog, Ui_JobsDialog):
             d.timer.stop()
 
     def show_details(self, *args):
+        self.jobs_view.setFocus()
         index = self.jobs_view.currentIndex()
         if index.isValid():
             self.show_job_details(index)


### PR DESCRIPTION
This prevents the job details dialog not being opened as otherwise the currentIndex returns -1, preventing the dialog opening.