### PR TITLE
Make template function doc more safer

### DIFF
--- a/src/calibre/gui2/dialogs/template_dialog.py
+++ b/src/calibre/gui2/dialogs/template_dialog.py
@@ -82,7 +82,7 @@ def safe_get_doc_html(ffml, func, fname, original_doc):
         error_msg = build_error_msg(str(ex))
 
     # return raw doc
-    return error_msg+'<br>'+doc.strip()
+    return error_msg+'<br>'+doc.strip().replace('\n', '<br>')
 
 
 class DocViewer(Dialog):


### PR DESCRIPTION
When calibre encounter a malformed doc for template function, it raise a error and show nothing (no doc, but no function type or code preview either).
If is annoying for a single fontion, when we try to show the full doc for all function, the exception stop the build and make render a empty page.

This commit try to solve this issue by making the build of the html doc more safer by:
1. Try with the original doc
2. Try with english doc
3. If all fail, return the raw doc

If a error occurs during the parsing of the doc, a message will will be add to the to inform the user of the error.