### PR TITLE
append oeb.polish.tests.structure to CLI test

### DIFF
--- a/src/calibre/utils/run_tests.py
+++ b/src/calibre/utils/run_tests.py
@@ -226,6 +226,8 @@ def find_tests(which_tests=None, exclude_tests=None):
     if ok('polish'):
         from calibre.ebooks.oeb.polish.tests.main import find_tests
         a(find_tests())
+        from calibre.ebooks.oeb.polish.tests.structure import find_tests
+        a(find_tests())
     if ok('opf'):
         from calibre.ebooks.metadata.opf2 import suite
         a(suite())


### PR DESCRIPTION
Append the test oeb.polish.tests.structure to the CLI.

The oeb.polish.tests.structure is already implemented, but never callable.