### PR TITLE
Add an option to expand the tag browser tree to show the item that …

### DIFF
--- a/src/calibre/gui2/__init__.py
+++ b/src/calibre/gui2/__init__.py
@@ -411,6 +411,7 @@ def create_defs():
     defs['tag_browser_old_look'] = False
     defs['tag_browser_hide_empty_categories'] = False
     defs['tag_browser_always_autocollapse'] = False
+    defs['tag_browser_restore_tree_expansion'] = False
     defs['tag_browser_allow_keyboard_focus'] = False
     defs['book_list_tooltips'] = True
     defs['show_layout_buttons'] = False

--- a/src/calibre/gui2/preferences/look_feel.py
+++ b/src/calibre/gui2/preferences/look_feel.py
@@ -636,6 +636,7 @@ class ConfigWidget(ConfigWidgetBase, Ui_Form):
         r('tag_browser_old_look', gprefs)
         r('tag_browser_hide_empty_categories', gprefs)
         r('tag_browser_always_autocollapse', gprefs)
+        r('tag_browser_restore_tree_expansion', gprefs)
         r('tag_browser_show_tooltips', gprefs)
         r('tag_browser_allow_keyboard_focus', gprefs)
         r('bd_show_cover', gprefs)

--- a/src/calibre/gui2/preferences/look_feel.ui
+++ b/src/calibre/gui2/preferences/look_feel.ui
@@ -1426,6 +1426,18 @@ also checked then only categories containing a matched item will be shown.&lt;/p
             </property>
            </widget>
           </item>
+          <item row="3" column="0">
+           <widget class="QCheckBox" name="opt_tag_browser_restore_tree_expansion">
+            <property name="toolTip">
+             <string>&lt;p&gt;When checked, when a library is opened the Tag browser
+will expand the tree so that the last used item is visible. An item is "used" when
+it is expanded, collapsed, or clicked.&lt;/p&gt;</string>
+            </property>
+            <property name="text">
+             <string>Expand tr&amp;ee to show last used item</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </item>
         <item row="8" column="0" colspan="3">

--- a/src/calibre/gui2/tag_browser/ui.py
+++ b/src/calibre/gui2/tag_browser/ui.py
@@ -947,8 +947,26 @@ class TagBrowserWidget(QFrame):  # {{{
         self.tags_view.model().prefs['tag_browser_hide_empty_categories'] ^= True
         self.tags_view.recount_with_position_based_index()
 
-    def save_state(self):
-        gprefs.set('tag browser search box visible', self.toggle_search_button.isChecked())
+    def save_state(self, gprefs_local=None):
+        if gprefs_local is None:
+            gprefs_local = gprefs
+        gprefs_local.set('tag browser search box visible', self.toggle_search_button.isChecked())
+
+    def restore_expansion_state(self, state):
+        '''
+        Expands the tag browser tree so that the node specified in state is
+        visible. Use get_expansion_state() to get the state. The intent is that
+        a plugin could restore the state in the library_changed() method.
+        '''
+        if state is not None:
+            self.tags_view.restore_expansion(state)
+
+    def get_expansion_state(self):
+        '''
+        Returns the currently expanded node in the tag browser as a string
+        suitable for restoring using restore_expansion_state.
+        '''
+        return self.tags_view.current_expansion
 
     def toggle_item(self):
         self.tags_view.toggle_current_index()


### PR DESCRIPTION
…was current when the library was closed. The implementation provides an API for plugins to get and set the expansion state.

See https://www.mobileread.com/forums/showthread.php?t=362240