### PR TITLE
Fix wrong resolved translation strings & add 'INT' to Ruff settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ quote-style = 'single'
 
 [tool.ruff.lint]
 ignore = ['E402', 'E722', 'E741', 'E401']
-select = ['E', 'F', 'I', 'W']
+select = ['E', 'F', 'I', 'W', 'INT']
 
 [tool.ruff.lint.per-file-ignores]
 "src/calibre/ebooks/unihandecode/*codepoints.py" = ['E501', 'W191']

--- a/src/calibre/db/cli/cmd_catalog.py
+++ b/src/calibre/db/cli/cmd_catalog.py
@@ -43,8 +43,7 @@ def option_parser(get_parser, args):  # {{{
 
     # Entry point
     parser = get_parser(
-        _(
-            '''\
+        _('''\
 %prog catalog /path/to/destination.(csv|epub|mobi|xml...) [options]
 
 Export a catalog in format specified by path/to/destination extension.
@@ -52,8 +51,7 @@ Options control how entries are displayed in the generated catalog output.
 Note that different catalog formats support different sets of options. To
 see the different options, specify the name of the output file and then the
 {} option.
-'''.format('--help')
-        )
+''').format('--help')
     )
 
     # Add options common to all catalog plugins

--- a/src/calibre/db/cli/cmd_set_metadata.py
+++ b/src/calibre/db/cli/cmd_set_metadata.py
@@ -160,7 +160,7 @@ def main(opts, args, dbctx):
             if field == 'sort':
                 field = 'title_sort'
             if field not in fields:
-                raise SystemExit(_('%s is not a known field' % field))
+                raise SystemExit(_('{} is not a known field'))
             if field == 'cover':
                 val = dbctx.path(os.path.abspath(os.path.expanduser(val)))
             else:

--- a/src/calibre/gui2/add.py
+++ b/src/calibre/gui2/add.py
@@ -240,7 +240,7 @@ class Adder(QObject):
                     else:
                         a = self.report.append
                         for f in unreadable_files:
-                            a(_('Could not add %s as you do not have permission to read the file' % f))
+                            a(_('Could not add {} as you do not have permission to read the file').format(f))
                             a('')
         except Exception:
             self.scan_error = traceback.format_exc()

--- a/src/calibre/gui2/dialogs/custom_recipes.py
+++ b/src/calibre/gui2/dialogs/custom_recipes.py
@@ -435,7 +435,7 @@ class BasicRecipe(QWidget):  # {{{
             compile_recipe(self.recipe_source)
         except Exception as err:
             error_dialog(self, _('Invalid recipe'), _(
-                'Failed to compile the recipe, with syntax error: %s' % err), show=True)
+                'Failed to compile the recipe, with syntax error: {}').format(err), show=True)
             return False
         return True
 
@@ -488,7 +488,7 @@ class AdvancedRecipe(QWidget):  # {{{
             compile_recipe(src)
         except Exception as err:
             error_dialog(self, _('Invalid recipe'), _(
-                'Failed to compile the recipe, with syntax error: %s' % err), show=True)
+                'Failed to compile the recipe, with syntax error: {}' ).format(err), show=True)
             return False
         return True
 

--- a/src/calibre/gui2/tweak_book/diff/view.py
+++ b/src/calibre/gui2/tweak_book/diff/view.py
@@ -272,7 +272,7 @@ class TextBrowser(PlainTextEdit):  # {{{
             break
         else:
             info_dialog(self, _('No matches found'), _(
-                'No matches found for query: %s' % query), show=True)
+                'No matches found for query: {}').format(query), show=True)
 
     def clear(self):
         PlainTextEdit.clear(self)

--- a/src/calibre/gui2/tweak_book/polish.py
+++ b/src/calibre/gui2/tweak_book/polish.py
@@ -204,7 +204,7 @@ class LossyCompression(QWidget):
         image_type = image_type.upper()
         self.enable_lossy = el = QCheckBox(_('Enable &lossy compression of {} images').format(image_type))
         el.setToolTip(_('This allows you to change the quality factor used for {} images.\nBy lowering'
-                        ' the quality you can greatly reduce file size, at the expense of the image looking blurred.'.format(image_type)))
+                        ' the quality you can greatly reduce file size, at the expense of the image looking blurred.').format(image_type))
         l.addWidget(el)
         self.h2 = h = QHBoxLayout()
         l.addLayout(h)

--- a/src/calibre/library/catalogs/epub_mobi.py
+++ b/src/calibre/library/catalogs/epub_mobi.py
@@ -200,8 +200,8 @@ class EPUB_MOBI(CatalogPlugin):
             available_presets = JSONConfig("catalog_presets")
             if opts.preset not in available_presets:
                 if available_presets:
-                    print(_('Error: Preset "%s" not found.' % opts.preset))
-                    print(_('Stored presets: %s' % ', '.join([p for p in sorted(available_presets.keys())])))
+                    print(_('Error: Preset "{}" not found.').format(opts.preset))
+                    print(_('Stored presets: {}').format(', '.join([p for p in sorted(available_presets.keys())])))
                 else:
                     print(_('Error: No stored presets.'))
                 return 1

--- a/src/calibre/utils/formatter_functions.py
+++ b/src/calibre/utils/formatter_functions.py
@@ -2533,8 +2533,7 @@ on a device has its own device name. The ``storage_location_key`` names are
             try:
                 if storage_location not in {'main', 'carda', 'cardb'}:
                     raise ValueError(
-                         _('connected_device_name: invalid storage location "{}"'
-                                    .format(storage_location)))
+                         _('connected_device_name: invalid storage location "{}"').format(storage_location))
                 info = info['info'][4]
                 if storage_location not in info:
                     return ''
@@ -2571,8 +2570,7 @@ only in the GUI.
             try:
                 if storage_location not in {'main', 'carda', 'cardb'}:
                     raise ValueError(
-                         _('connected_device_name: invalid storage location "{}"'
-                                    .format(storage_location)))
+                         _('connected_device_name: invalid storage location "{}"').format(storage_location))
                 info = info['info'][4]
                 if storage_location not in info:
                     return ''


### PR DESCRIPTION
Add 'INT' rule to errors checking to catch wrong resolved translation strings.