### PR TITLE
Fix bug where the option "recognize numbers inside text" wasn't used …

### DIFF
--- a/src/calibre/db/cache.py
+++ b/src/calibre/db/cache.py
@@ -1542,12 +1542,13 @@ class Cache:
 
     @api
     def get_categories(self, sort='name', book_ids=None, already_fixed=None,
-                       first_letter_sort=False):
+                       first_letter_sort=False, uncollapsed_categories=None):
         ' Used internally to implement the Tag Browser '
         try:
             with self.safe_read_lock:
                 return get_categories(self, sort=sort, book_ids=book_ids,
-                                      first_letter_sort=first_letter_sort)
+                                      first_letter_sort=first_letter_sort,
+                                      uncollapsed_categories=uncollapsed_categories)
         except InvalidLinkTable as err:
             bad_field = err.field_name
             if bad_field == already_fixed:

--- a/src/calibre/db/categories.py
+++ b/src/calibre/db/categories.py
@@ -193,7 +193,7 @@ category_sort_keys[False]['name'] = sort_key_for_name
 # dict being in the default display order: standard fields, custom in alpha order,
 # user categories, then saved searches. This works because the backend adds
 # custom columns to field metadata in the right order.
-def get_categories(dbcache, sort='name', book_ids=None, first_letter_sort=False):
+def get_categories(dbcache, sort='name', book_ids=None, first_letter_sort=False, uncollapsed_categories=None):
     if sort not in CATEGORY_SORTS:
         raise ValueError('sort ' + sort + ' not a valid value')
 
@@ -213,9 +213,10 @@ def get_categories(dbcache, sort='name', book_ids=None, first_letter_sort=False)
         return ans
 
     bids = None
-    first_letter_sort = bool(first_letter_sort)
+    uncollapsed_categories = () if uncollapsed_categories is None else uncollapsed_categories
 
     for category, is_multiple, is_composite in find_categories(fm):
+        fl_sort = False if category in uncollapsed_categories else bool(first_letter_sort)
         tag_class = create_tag_class(category, fm)
         sort_on, reverse = sort, False
         if is_composite:
@@ -240,7 +241,7 @@ def get_categories(dbcache, sort='name', book_ids=None, first_letter_sort=False)
                 cat['is_multiple'] and cat['display'].get('is_names', False)):
                 for item in cats:
                     item.sort = author_to_author_sort(item.sort)
-        cats.sort(key=partial(category_sort_keys[first_letter_sort][sort_on],
+        cats.sort(key=partial(category_sort_keys[fl_sort][sort_on],
                               hierarchical_categories=hierarchical_categories),
                   reverse=reverse)
         categories[category] = cats

--- a/src/calibre/gui2/tag_browser/model.py
+++ b/src/calibre/gui2/tag_browser/model.py
@@ -1274,6 +1274,12 @@ class TagsModel(QAbstractItemModel):  # {{{
         self.row_map = []
         self.categories = OrderedDict()
 
+        # We need to pass this to get_categories so it can adjust how it sorts
+        # the values. The "first_letter_sort" argument is the default. It is
+        # changed to False by get_categories() if the category is not collapsed
+        uncollapsed_categories = self.db.prefs.get('tag_browser_dont_collapse',
+                                                   self.prefs['tag_browser_dont_collapse'])
+
         # Get the categories
         try:
             # We must disable the in_tag_browser ids because we want all the
@@ -1283,12 +1289,14 @@ class TagsModel(QAbstractItemModel):  # {{{
             self.db.data.set_in_tag_browser(None)
             data = self.db.new_api.get_categories(sort=sort,
                     book_ids=self.get_book_ids_to_use(),
-                    first_letter_sort=self.collapse_model == 'first letter')
+                    first_letter_sort=(self.collapse_model == 'first letter'),
+                    uncollapsed_categories=uncollapsed_categories)
             self.db.data.set_in_tag_browser(old_in_tb)
         except Exception as e:
             traceback.print_exc()
             data = self.db.new_api.get_categories(sort=sort,
-                    first_letter_sort=self.collapse_model == 'first letter')
+                    first_letter_sort=(self.collapse_model == 'first letter'),
+                    uncollapsed_categories=uncollapsed_categories)
             self.restriction_error.emit(str(e))
 
         if self.filter_categories_by:


### PR DESCRIPTION
…when first-letter-sorting is turned on but the column isn't partitioned.

The problem will continue to exist for users that don't include the new parameter.