### PR TITLE
Fixed "[Errno 36] File name too long" error during eBook registration

### DIFF
--- a/src/calibre/db/cli/cmd_add.py
+++ b/src/calibre/db/cli/cmd_add.py
@@ -4,6 +4,7 @@
 
 import os
 import sys
+import hashlib
 from contextlib import contextmanager
 from optparse import OptionGroup, OptionValueError
 
@@ -154,7 +155,8 @@ def format_group(db, notify_changes, is_remote, args):
         if is_remote:
             paths = []
             for name, data in formats:
-                with open(os.path.join(tdir, os.path.basename(name)), 'wb') as f:
+                hname = hashlib.sha256(name.encode()).hexdigest() + os.path.splitext(name)[1]
+                with open(os.path.join(tdir, str(hname)), 'wb') as f:
                     f.write(data)
                 paths.append(f.name)
         else:


### PR DESCRIPTION
I have encountered an error in my environment and have corrected it. Please merge if there is no problem.

I am running calibre-server on Linux in my environment.
When I used calibredb on Windows to register ebooks to calibre-server, the following error occurred.

````
> . \calibredb.exe add --with-library=“http://192.0.2.1:8080” --username=abc --password=password 'C:\Users\Administrator\Documents\ CalibreLibrary' -r
Traceback (most recent call last):.
  File “calibre/srv/cdb.py”, line 59, in cdb_run
  File “calibre/db/cli/cmd_add.py”, line 177, in implementation
  File “calibre/db/cli/cmd_add.py”, line 157, in format_group
OSError: [Errno 36] File name too long: '/tmp/calibre_7.22.0_tmp_ej9j0yfy/7j70wum3add-multiple/C:\\Users\\Administrator\\Documents\\ CalibreLibrary\\Directory\SubDirectory\Example E-Book.opf''

[Errno 36] File name too long: '/tmp/calibre_7.22.0_tmp_ej9j0yfy/7j70wum3add-multiple/C:\\Users\\\Administrator\\Documents\\\ CalibreLibrary\\Directory\SubDirectory\\Example E-Book.opf'
````

The file name created under the temporary directory is the full path on Windows, which can easily exceed the maximum length of the file name.
The filename under the temporary directory is determined by the following code, which I read as intending to use a filename that does not contain a directory (folder). However, this did not work correctly across different operating systems.

```
open(os.path.join(tdir, os.path.basename(name)), 'wb')
```

So I adopted a hash for filenames under temporary directories so that the filenames would have a fixed length.
This modification seems to work well in my environment.

Best regards.