### PR TITLE
Allow import of KFX files from MTP Kindle devices

### DIFF
--- a/src/calibre/devices/mtp/filesystem_cache.py
+++ b/src/calibre/devices/mtp/filesystem_cache.py
@@ -95,6 +95,17 @@ class FileOrFolder:
         self.is_ebook = (not self.is_folder and not self.is_storage and
                 self.name.rpartition('.')[-1].lower() in bexts and not self.name.startswith('._'))
 
+        # prevent supplemental KFX files from being treated as individual books
+        if self.is_ebook and self.name.lower().endswith('.kfx') and 'assets' in self.full_path:
+            self.is_ebook = False
+
+        # allow Scribe notebooks to be imported
+        if self.name == 'nbk' and not (self.is_folder or self.is_storage):
+            full_path = self.full_path
+            if len(full_path) >= 3 and full_path[-3] == '.notebooks':
+                self.name = 'Notebook %s.kfx' % full_path[-2]   # preserve notebook name
+                self.is_ebook = True
+
     def __repr__(self):
         if self.is_storage:
             name = 'Storage'


### PR DESCRIPTION
The new 2024 Kindle models use MTP for file access and no longer allow the use of "Download and Transfer via USB" to obtain books in AZW3 format from Amazon's website. This makes it difficult to import Kindle books into calibre, especially since Amazon has blocked most other methods for obtaining Kindle books.

These changes allow better display of metadata in Device view when an MTP Kindle is connected and allows the import of KFX format books and notebooks from the device. KFX is not the best format for use within calibre, but it is better than nothing.