### PR TITLE
Fix invalid escape sequence error

### DIFF
--- a/src/templite/__init__.py
+++ b/src/templite/__init__.py
@@ -32,7 +32,7 @@ from polyglot.builtins import unicode_type
 
 
 class Templite:
-    auto_emit = re.compile(r'''(^['"])|(^[a-zA-Z0-9_\[\]'"]+$)''')
+    auto_emit = re.compile(r'''(^['"])|(^[a-zA-Z0-9_[]'"]+$)''')
 
     def __init__(self, template, start='${', end='}$'):
         if len(start) != 2 or len(end) != 2:


### PR DESCRIPTION
I observed this invalid sequence error is visible during installation of calibre on Ubuntu 22.04. It appears to be visible for other users as well as seen in [invalid escape sequence when installing package](https://forums.linuxmint.com/viewtopic.php?t=425483&sid=a36fe93170b18bc7493173dc567acfd5).