### PR TITLE
Automatically inserting page-progression-direction="rtl" in rtl languages ​​(Arabic and Hebrew)

### DIFF
--- a/src/calibre/ebooks/conversion/plugins/epub_output.py
+++ b/src/calibre/ebooks/conversion/plugins/epub_output.py
@@ -197,6 +197,14 @@ class EPUBOutput(OutputFormatPlugin):
             opts.mobi_passthrough = False
             opts.no_inline_toc = False
             TOCAdder(oeb, opts, replace_previous_inline_toc=True, ignore_existing_toc=True)
+        
+        try:
+            lang = self.oeb.metadata.language[0]
+            lang = lang.value
+            if lang[:2].lower() in {'he', 'ar'} and self.oeb.spine.page_progression_direction is None:
+               self.oeb.spine.page_progression_direction = "rtl"
+        except IndexError:
+            pass
 
         if self.opts.epub_flatten:
             from calibre.ebooks.oeb.transforms.filenames import FlatFilenames

--- a/src/calibre/ebooks/conversion/plugins/mobi_output.py
+++ b/src/calibre/ebooks/conversion/plugins/mobi_output.py
@@ -183,6 +183,14 @@ class MOBIOutput(OutputFormatPlugin):
         from calibre.ebooks.mobi.writer2.resources import Resources
         self.log, self.opts, self.oeb = log, opts, oeb
 
+        try:
+            lang = self.oeb.metadata.language[0]
+            lang = lang.value
+            if lang[:2].lower() in {'he', 'ar'} and self.oeb.spine.page_progression_direction is None:
+               self.oeb.spine.page_progression_direction = "rtl"
+        except IndexError:
+            pass
+
         mobi_type = opts.mobi_file_type
         if self.is_periodical:
             mobi_type = 'old'  # Amazon does not support KF8 periodicals
@@ -311,6 +319,15 @@ class AZW3Output(OutputFormatPlugin):
         from calibre.ebooks.mobi.writer8.main import create_kf8_book
 
         self.oeb, self.opts, self.log = oeb, opts, log
+        
+        try:
+            lang = self.oeb.metadata.language[0]
+            lang = lang.value
+            if lang[:2].lower() in {'he', 'ar'} and self.oeb.spine.page_progression_direction is None:
+               self.oeb.spine.page_progression_direction = "rtl"
+        except IndexError:
+            pass
+
         opts.mobi_periodical = self.is_periodical
         passthrough = getattr(opts, 'mobi_passthrough', False)
         remove_duplicate_anchors(oeb)

--- a/src/calibre/ebooks/metadata/opf2.py
+++ b/src/calibre/ebooks/metadata/opf2.py
@@ -1594,8 +1594,6 @@ class OPFCreator(Metadata):
             spine.set('toc', 'ncx')
         if self.page_progression_direction is not None:
             spine.set('page-progression-direction', self.page_progression_direction)
-        elif langs[0][:2].lower() in {'he', 'ar'}:
-             spine.set('page-progression-direction', "rtl")
         if self.spine is not None:
             for ref in self.spine:
                 if ref.id is not None:

--- a/src/calibre/ebooks/oeb/base.py
+++ b/src/calibre/ebooks/oeb/base.py
@@ -1985,14 +1985,6 @@ class OEBBook:
             results[PAGE_MAP_MIME] = (href, self.pages.to_page_map())
         if self.spine.page_progression_direction in {'ltr', 'rtl'}:
             spine.attrib['page-progression-direction'] = self.spine.page_progression_direction
-        else:
-            try:
-                lang = str(self.metadata.language[0])
-            except IndexError:
-                lang = 'en'
-            lang = lang.replace('_', '-')
-            if lang[:2].lower() in {'he', 'ar'}:
-                spine.attrib['page-progression-direction'] = "rtl"
         return results
 
 

--- a/src/calibre/library/catalogs/epub_mobi_builder.py
+++ b/src/calibre/library/catalogs/epub_mobi_builder.py
@@ -31,7 +31,7 @@ from calibre.utils.formatter import TemplateFormatter
 from calibre.utils.icu import capitalize, collation_order, sort_key
 from calibre.utils.icu import title_case as icu_title
 from calibre.utils.icu import upper as icu_upper
-from calibre.utils.localization import _, get_lang, lang_as_iso639_1, ngettext
+from calibre.utils.localization import _, get_lang, lang_as_iso639_1, ngettext, is_rtl
 from calibre.utils.resources import get_image_path as I
 from calibre.utils.resources import get_path as P
 from calibre.utils.xml_parse import safe_xml_fromstring
@@ -3641,14 +3641,15 @@ class CatalogBuilder:
         <meta name="calibre:publication_type" content="{pt}"/>
     </metadata>
     <manifest></manifest>
-    <spine toc="ncx"></spine>
+    <spine toc="ncx"{page_progression_direction}></spine>
     <guide></guide>
 </package>
             '''.format(
                 title=prepare_string_for_xml(self.opts.catalog_title),
                 creator=prepare_string_for_xml(self.opts.creator),
                 lang=prepare_string_for_xml(lang),
-                pt="periodical:default" if self.generate_for_kindle_mobi else ""
+                pt="periodical:default" if self.generate_for_kindle_mobi else "",
+                page_progression_direction = ' page-progression-direction="rtl"' if is_rtl() else ""
         )
         root = safe_xml_fromstring(header)
         manifest = root.xpath('//*[local-name()="manifest"]')[0]


### PR DESCRIPTION
I would also like to add that the text direction will automatically be right to left, but I didn't find where exactly this is defined in the code

Another thing I would like to do - when converting a pdf to text in rtl languages, the text is completely reversed, meaning that the order of the letters is also left to right, but I would need some guidance on where this is defined in the code

Thank you very much and Happy New Year