### PR TITLE
Add an option to adjust the size of the link and note icons in book …

### DIFF
--- a/src/calibre/ebooks/metadata/book/render.py
+++ b/src/calibre/ebooks/metadata/book/render.py
@@ -107,13 +107,15 @@ def mi_to_html(
         mi,
         field_list=None, default_author_link=None, use_roman_numbers=True,
         rating_font='Liberation Serif', rtl=False, comments_heading_pos='hide',
-        for_qt=False, vertical_fields=(), show_links=True, item_id_if_has_note=None
+        for_qt=False, vertical_fields=(), show_links=True, item_id_if_has_note=None,
+        link_note_icon_size=16
     ):
 
     link_markup =  '↗️'
     if for_qt:
-        link_markup = '<img valign="bottom" src="calibre-icon:///external-link.png" width=16 height=16>'
-        note_markup = '<img valign="bottom" src="calibre-icon:///notes.png" width=16 height=16>'
+        s = link_note_icon_size
+        link_markup = f'<img valign="bottom" src="calibre-icon:///external-link.png" width={s} height={s}>'
+        note_markup = f'<img valign="bottom" src="calibre-icon:///notes.png" width={s} height={s}>'
     def get_link_map(column):
         try:
             return mi.link_maps[column]

--- a/src/calibre/gui2/__init__.py
+++ b/src/calibre/gui2/__init__.py
@@ -485,6 +485,7 @@ def create_defs():
     defs['dark_palettes'] = {}
     defs['light_palettes'] = {}
     defs['saved_layouts'] = {}
+    defs['book_details_note_link_icon_width'] = 16
 
     def migrate_tweak(tweak_name, pref_name):
         # If the tweak has been changed then leave the tweak in the file so

--- a/src/calibre/gui2/__init__.py
+++ b/src/calibre/gui2/__init__.py
@@ -485,7 +485,7 @@ def create_defs():
     defs['dark_palettes'] = {}
     defs['light_palettes'] = {}
     defs['saved_layouts'] = {}
-    defs['book_details_note_link_icon_width'] = 16
+    defs['book_details_note_link_icon_width'] = 1.0
 
     def migrate_tweak(tweak_name, pref_name):
         # If the tweak has been changed then leave the tweak in the file so

--- a/src/calibre/gui2/book_details.py
+++ b/src/calibre/gui2/book_details.py
@@ -15,6 +15,7 @@ from qt.core import (
     QColor,
     QDialog,
     QEasingCurve,
+    QFontMetrics,
     QIcon,
     QKeySequence,
     QMenu,
@@ -394,12 +395,15 @@ def render_data(mi, use_roman_numbers=True, all_fields=False, pref_name='book_di
                 if db.notes_for(field, item_id):
                     return item_id
 
+    # Compute the size of the link and note icons by scaling the current font
+    # height by the option specified in Preferences / L&F / Book details.
+    icon_size = int(QFontMetrics(QApplication.font()).height() * gprefs['book_details_note_link_icon_width'])
     return mi_to_html(
         mi, field_list=field_list, use_roman_numbers=use_roman_numbers, rtl=is_rtl(),
         rating_font=rating_font(), default_author_link=default_author_link(),
         comments_heading_pos=gprefs['book_details_comments_heading_pos'], for_qt=True,
         vertical_fields=vertical_fields, show_links=show_links, item_id_if_has_note=item_id_if_has_note,
-        link_note_icon_size=gprefs['book_details_note_link_icon_width']
+        link_note_icon_size=icon_size
     )
 
 # }}}

--- a/src/calibre/gui2/book_details.py
+++ b/src/calibre/gui2/book_details.py
@@ -398,7 +398,8 @@ def render_data(mi, use_roman_numbers=True, all_fields=False, pref_name='book_di
         mi, field_list=field_list, use_roman_numbers=use_roman_numbers, rtl=is_rtl(),
         rating_font=rating_font(), default_author_link=default_author_link(),
         comments_heading_pos=gprefs['book_details_comments_heading_pos'], for_qt=True,
-        vertical_fields=vertical_fields, show_links=show_links, item_id_if_has_note=item_id_if_has_note
+        vertical_fields=vertical_fields, show_links=show_links, item_id_if_has_note=item_id_if_has_note,
+        link_note_icon_size=gprefs['book_details_note_link_icon_width']
     )
 
 # }}}

--- a/src/calibre/gui2/preferences/look_feel.py
+++ b/src/calibre/gui2/preferences/look_feel.py
@@ -678,6 +678,7 @@ class ConfigWidget(ConfigWidgetBase, Ui_Form):
         r('booklist_grid', gprefs)
         r('book_details_comments_heading_pos', gprefs, choices=[
             (_('Never'), 'hide'), (_('Above text'), 'above'), (_('Beside text'), 'side')])
+        r('book_details_note_link_icon_width', gprefs)
         self.cover_browser_title_template_button.clicked.connect(self.edit_cb_title_template)
         self.id_links_button.clicked.connect(self.edit_id_link_rules)
 

--- a/src/calibre/gui2/preferences/look_feel.ui
+++ b/src/calibre/gui2/preferences/look_feel.ui
@@ -957,7 +957,7 @@ A value of zero means calculate automatically.</string>
          </item>
         </layout>
        </item>
-       <item row="1" column="0" colspan="2">
+       <item row="1" column="0" colspan="3">
         <layout class="QHBoxLayout" name="horizontalLayout_2">
          <item>
           <widget class="QLabel" name="label_25">
@@ -978,6 +978,58 @@ A value of zero means calculate automatically.</string>
             </sizepolicy>
            </property>
           </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_bd13">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>10</width>
+             <height>0</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_1022">
+           <property name="text">
+            <string>Link and note icon si&amp;ze:</string>
+           </property>
+           <property name="buddy">
+            <cstring>opt_book_details_note_link_icon_width</cstring>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="opt_book_details_note_link_icon_width">
+           <property name="toolTip">
+            <string>Specify the size (width and height) of the links and notes icons</string>
+           </property>
+           <property name="suffix">
+            <string> pixels</string>
+           </property>
+           <property name="maximum">
+            <number>48</number>
+           </property>
+           <property name="minimum">
+            <number>12</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_bd13">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>30</width>
+             <height>0</height>
+            </size>
+           </property>
+          </spacer>
          </item>
         </layout>
        </item>

--- a/src/calibre/gui2/preferences/look_feel.ui
+++ b/src/calibre/gui2/preferences/look_feel.ui
@@ -1003,18 +1003,22 @@ A value of zero means calculate automatically.</string>
           </widget>
          </item>
          <item>
-          <widget class="QSpinBox" name="opt_book_details_note_link_icon_width">
+          <widget class="QDoubleSpinBox" name="opt_book_details_note_link_icon_width">
            <property name="toolTip">
-            <string>Specify the size (width and height) of the links and notes icons</string>
+            <string>Increase or decrease the size of the links and notes icons by this number. Larger
+than one increases the icon size while smaller than one decreases it.</string>
            </property>
-           <property name="suffix">
-            <string> pixels</string>
-           </property>
-           <property name="maximum">
-            <number>48</number>
+           <property name="decimals">
+            <number>1</number>
            </property>
            <property name="minimum">
-            <number>12</number>
+            <double>0.5</double>
+           </property>
+           <property name="maximum">
+            <double>4.0</double>
+           </property>
+           <property name="singleStep">
+            <double>0.1</double>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
…details.

In the tag browser and booklist the icons resize automatically with the font. That doesn't happen in book details because there isn't any notion of a "row". With this option the user can make the size as desired. For more background see the first few posts of https://www.mobileread.com/forums/showthread.php?t=365537