### PR TITLE
Clean up tag browser context and config menus a bit.

### DIFF
--- a/src/calibre/gui2/tag_browser/ui.py
+++ b/src/calibre/gui2/tag_browser/ui.py
@@ -879,6 +879,10 @@ class TagBrowserWidget(QFrame):  # {{{
                 action=ac, group=_('Tag browser'))
         ac.triggered.connect(self.filter_book_list)
 
+        l.m.addSeparator()
+        ac = l.m.addAction(QIcon.ic('config.png'), _('Preferences / Look & feel / Tag browser'))
+        ac.triggered.connect(self.show_tag_browser_preferences)
+
         ac = QAction(parent)
         parent.addAction(ac)
         parent.keyboard.register_shortcut('tag browser toggle item',
@@ -896,6 +900,11 @@ class TagBrowserWidget(QFrame):  # {{{
         # self.leak_test_timer = QTimer(self)
         # self.leak_test_timer.timeout.connect(self.test_for_leak)
         # self.leak_test_timer.start(5000)
+
+    def show_tag_browser_preferences(self):
+        from calibre.gui2.ui import get_gui
+        get_gui().iactions['Preferences'].do_config(initial_plugin=('Interface', 'Look & Feel', 'tag_browser_tab'),
+                                                   close_after_initial=True)
 
     def about_to_show_configure_menu(self):
         ac = self.alter_tb.m.show_counts_action


### PR DESCRIPTION
- When right-clicking in tag browser white space, remove any context menu that depends on having an index.
- Remove general subcategorization menu options from the context menu. These are global, not part of context for the current index.
- Add a menu option to the config menu to open Prefs / L&F / Tag browser. This permits easily getting to the global subcat and display options, avoiding adding more menu lines to the config menu.