### PR TITLE
Add ability to tag browser specify icons for individual values, as is…

### DIFF
--- a/src/calibre/gui2/__init__.py
+++ b/src/calibre/gui2/__init__.py
@@ -420,6 +420,7 @@ def create_defs():
     defs['bd_show_cover'] = True
     defs['bd_overlay_cover_size'] = False
     defs['tags_browser_category_icons'] = {}
+    defs['tags_browser_value_icons'] = {}
     defs['cover_browser_reflections'] = True
     defs['book_list_extra_row_spacing'] = 0
     defs['refresh_book_list_on_bulk_edit'] = True


### PR DESCRIPTION
… already done automatically for 'formats'.

This scheme could be used to replace the existing tag browser category icon selection. I didn't do that because the risk seemed high. The category icon dict is used in several places and in plugins. It also has meaning for search and user categories, where the new value icon stuff doesn't.

If the new facilities are not used then performance risk is near zero. Performance shouldn't be an issue if used because the icon dictionaries scale well. The exception might be templates. We have no control over the complexity or performance of user-written templates.

This PR fixes a few bugs I found while implementing the new feature.