### PR TITLE
fix: tag browser icon not loading when using a PTM

### DIFF
--- a/src/calibre/gui2/tag_browser/model.py
+++ b/src/calibre/gui2/tag_browser/model.py
@@ -144,7 +144,7 @@ class TagTreeItem:  # {{{
                             if val_icon is None and TEMPLATE_ICON_INDICATOR in self.value_icons[category]:
                                 t = self.eval_formatter.safe_format(self.value_icons[category][TEMPLATE_ICON_INDICATOR][0],
                                                                     {'category': category, 'value': self.tag.original_name},
-                                                                    'VALUE_ICON_TEMPLATE_ERROR', None)
+                                                                    'VALUE_ICON_TEMPLATE_ERROR', {})
                                 if t:
                                     val_icon = (os.path.join('template_icons', t), False)
                                 else:

--- a/src/calibre/srv/metadata.py
+++ b/src/calibre/srv/metadata.py
@@ -193,7 +193,7 @@ def get_icon_for_node(node, parent, node_to_tag_map, tag_map, eval_formatter):
     if val_icon is None and TEMPLATE_ICON_INDICATOR in value_icons.get(category, {}):
         t = eval_formatter.safe_format(
             value_icons[category][TEMPLATE_ICON_INDICATOR][0], {'category': category, 'value': name_for_icon(node)},
-            'VALUE_ICON_TEMPLATE_ERROR', None)
+            'VALUE_ICON_TEMPLATE_ERROR', {})
         if t:
             # Use POSIX path separator
             val_icon = 'template_icons/' + t


### PR DESCRIPTION
If your use a PTM as template, fail to load the icon "VALUE_ICON_TEMPLATE_ERROR Error in function get_database on line  199: AttributeError - 'NoneType' object has no attribute 'get". The error don't appear inside the template dialog because it simulates a book with a dict.

Recreate traceback:
```
File "calibre/gui2/tag_browser/model.py", line 145, in ensure_icon
File "calibre/utils/formatter.py", line 2007, in safe_format
File "calibre/utils/formatter.py", line 1888, in evaluate
File "calibre/utils/formatter.py", line 1757, in _eval_python_template
File "calibre/utils/formatter.py", line 1761, in _run_python_template
File "calibre/utils/formatter_functions.py", line 199, in get_database
AttributeError: 'NoneType' object has no attribute 'get'
```