### PR TITLE
Improve reset icon tag browser

### DIFF
--- a/src/calibre/gui2/tag_browser/model.py
+++ b/src/calibre/gui2/tag_browser/model.py
@@ -424,10 +424,10 @@ class TagsModel(QAbstractItemModel):  # {{{
         '''
         old_icon = self.prefs['tags_browser_category_icons'].get(old_key, None)
         if old_icon is not None:
-            old_path = os.path.join(config_dir, 'tb_icons', old_icon)
+            old_path = os.path.join(self.icon_config_dir, old_icon)
             _, ext = os.path.splitext(old_path)
             new_icon = new_key + ext
-            new_path = os.path.join(config_dir, 'tb_icons', new_icon)
+            new_path = os.path.join(self.icon_config_dir, new_icon)
             os.replace(old_path, new_path)
             self.set_custom_category_icon(new_key, new_icon)
             self.set_custom_category_icon(old_key, None)
@@ -456,31 +456,27 @@ class TagsModel(QAbstractItemModel):  # {{{
         self.value_icon_cache.pop(file_name, None)
         self.prefs['tags_browser_value_icons'] = self.value_icons
 
-    def remove_value_icon(self, key, value, file_name):
-        self.value_icons = self.prefs['tags_browser_value_icons']
-        self.value_icons.get(key, {}).pop(value, None)
-        self.prefs['tags_browser_value_icons'] =self.value_icons
+    def _remove_icon_file(self, file_name):
         if file_name is not None:
-            path = os.path.join(config_dir, 'tb_icons', file_name)
+            path = os.path.join(self.icon_config_dir, file_name)
             try:
                 os.remove(path)
             except:
                 pass
 
+    def remove_value_icon(self, key, value, file_name):
+        self.value_icons = self.prefs['tags_browser_value_icons']
+        self.value_icons.get(key, {}).pop(value, None)
+        self.prefs['tags_browser_value_icons'] =self.value_icons
+        self._remove_icon_file(file_name)
+
     def set_custom_category_icon(self, key, path):
         d = self.prefs['tags_browser_category_icons']
         if path:
             d[key] = path
-            self.category_custom_icons[key] = QIcon(os.path.join(config_dir,
-                                                            'tb_icons', path))
+            self.category_custom_icons[key] = QIcon(os.path.join(self.icon_config_dir, path))
         else:
-            if key in d:
-                path = os.path.join(config_dir, 'tb_icons', d[key])
-                try:
-                    os.remove(path)
-                except:
-                    pass
-            d.pop(key, None)
+            self._remove_icon_file(d.pop(key, None))
             self.category_custom_icons.pop(key, None)
         self.prefs['tags_browser_category_icons'] = d
 

--- a/src/calibre/gui2/tag_browser/model.py
+++ b/src/calibre/gui2/tag_browser/model.py
@@ -470,12 +470,14 @@ class TagsModel(QAbstractItemModel):  # {{{
         self.prefs['tags_browser_value_icons'] =self.value_icons
         self._remove_icon_file(file_name)
 
-    def remove_all_value_icons(self, key):
+    def remove_all_value_icons(self, key, keep_template=True):
         self.value_icons = self.prefs['tags_browser_value_icons']
         values = self.value_icons.pop(key, {})
         self.value_icons[key] = {}
+        template = values.pop(TEMPLATE_ICON_INDICATOR, None)
+        if keep_template and template is not None:
+            self.value_icons[key][TEMPLATE_ICON_INDICATOR] = template
         self.prefs['tags_browser_value_icons'] = self.value_icons
-        values.pop(TEMPLATE_ICON_INDICATOR, None)
         for file_name,child in values.values():
             self._remove_icon_file(file_name)
 

--- a/src/calibre/gui2/tag_browser/model.py
+++ b/src/calibre/gui2/tag_browser/model.py
@@ -470,6 +470,15 @@ class TagsModel(QAbstractItemModel):  # {{{
         self.prefs['tags_browser_value_icons'] =self.value_icons
         self._remove_icon_file(file_name)
 
+    def remove_all_value_icons(self, key):
+        self.value_icons = self.prefs['tags_browser_value_icons']
+        values = self.value_icons.pop(key, {})
+        self.value_icons[key] = {}
+        self.prefs['tags_browser_value_icons'] = self.value_icons
+        values.pop(TEMPLATE_ICON_INDICATOR, None)
+        for file_name,child in values.values():
+            self._remove_icon_file(file_name)
+
     def set_custom_category_icon(self, key, path):
         d = self.prefs['tags_browser_category_icons']
         if path:

--- a/src/calibre/gui2/tag_browser/model.py
+++ b/src/calibre/gui2/tag_browser/model.py
@@ -458,7 +458,7 @@ class TagsModel(QAbstractItemModel):  # {{{
 
     def remove_value_icon(self, key, value, file_name):
         self.value_icons = self.prefs['tags_browser_value_icons']
-        self.value_icons.get(key).pop(value, None)
+        self.value_icons.get(key, {}).pop(value, None)
         self.prefs['tags_browser_value_icons'] =self.value_icons
         if file_name is not None:
             path = os.path.join(config_dir, 'tb_icons', file_name)

--- a/src/calibre/gui2/tag_browser/view.py
+++ b/src/calibre/gui2/tag_browser/view.py
@@ -733,17 +733,17 @@ class TagsView(QTreeView):  # {{{
                     self._model.set_value_icon(key, item_val, icon_file_name, bool(for_children))
                 self.recount()
                 return
-            if action == 'clear_icon_value':
-                if index is not None:
-                    val, icon_name = make_icon_name(key, index)
-                    self._model.remove_value_icon(key, val, icon_name)
-                else:
-                    self._model.remove_value_icon(key, TEMPLATE_ICON_INDICATOR, None)
-                self.recount()
-                return
             if action == 'clear_icon':
-                self._model.set_custom_category_icon(key, None)
-                self._model.remove_all_value_icons(key)
+                if extra == 'all':
+                    self._model.remove_all_value_icons(key)
+                elif extra == 'value':
+                    if index is not None:
+                        val, icon_name = make_icon_name(key, index)
+                        self._model.remove_value_icon(key, val, icon_name)
+                    else:
+                        self._model.remove_value_icon(key, TEMPLATE_ICON_INDICATOR, None)
+                else:
+                    self._model.set_custom_category_icon(key, None)
                 self.recount()
                 return
 
@@ -1286,17 +1286,21 @@ class TagsView(QTreeView):  # {{{
                                                 key=key, index=index, category=category, extra=(icon_name, True)))
                     ma.setEnabled(icon_name is not None and not for_child)
                     ma = im.addAction(_('Use the default icon for {}').format(for_name),
-                                 partial(self.context_menu_handler, action='clear_icon_value',
-                                         key=key, index=index, category=category))
+                                 partial(self.context_menu_handler, action='clear_icon',
+                                         key=key, index=index, category=category, extra='value'))
                     ma.setEnabled(name is not None and icon_name is not None)
                     im.addSection(_('Defaults'))
                     im.addAction(_('Use/edit a template to choose the default value icon'),
                                       partial(self.context_menu_handler, action='set_icon',
                                               key=key, index=index, category=None, extra=(None, None)))
                     ma = im.addAction(_('Use the category icon for the default value icon'),
-                                 partial(self.context_menu_handler, action='clear_icon_value',
-                                         key=key, index=None, category=category))
+                                 partial(self.context_menu_handler, action='clear_icon',
+                                         key=key, index=None, category=category, extra='value'))
                     ma.setEnabled(self._model.value_icons.get(key, {}).get(TEMPLATE_ICON_INDICATOR) is not None)
+                    im.addSection(_('All values'))
+                    ma = im.addAction(_('Reset all value icons to category icon'),
+                                 partial(self.context_menu_handler, action='clear_icon',
+                                         key=key, index=None, category=category, extra='all'))
                     im.addSeparator()
                 # Always show the User categories editor
                 self.context_menu.addSeparator()

--- a/src/calibre/gui2/tag_browser/view.py
+++ b/src/calibre/gui2/tag_browser/view.py
@@ -1310,6 +1310,10 @@ class TagsView(QTreeView):  # {{{
                                  partial(self.context_menu_handler, action='clear_icon',
                                          key=key, index=index, category=category, extra='value'))
                     ma.setEnabled(name is not None and icon_name is not None)
+                    im.addSeparator()
+                    ma = im.addAction(_('Reset all value icons to the default icon'),
+                                 partial(self.context_menu_handler, action='clear_icon',
+                                         key=key, index=None, category=category, extra='all'))
                     im.addSection(_('Defaults'))
                     im.addAction(_('Use/edit a template to choose the default value icon'),
                                       partial(self.context_menu_handler, action='set_icon',
@@ -1318,10 +1322,6 @@ class TagsView(QTreeView):  # {{{
                                  partial(self.context_menu_handler, action='clear_icon',
                                          key=key, index=None, category=category, extra='value'))
                     ma.setEnabled(self._model.value_icons.get(key, {}).get(TEMPLATE_ICON_INDICATOR) is not None)
-                    im.addSection(_('All values'))
-                    ma = im.addAction(_('Reset all value icons to the default icon'),
-                                 partial(self.context_menu_handler, action='clear_icon',
-                                         key=key, index=None, category=category, extra='all'))
                     im.addSeparator()
                 # Always show the User categories editor
                 self.context_menu.addSeparator()

--- a/src/calibre/gui2/tag_browser/view.py
+++ b/src/calibre/gui2/tag_browser/view.py
@@ -735,7 +735,7 @@ class TagsView(QTreeView):  # {{{
                 return
             if action == 'clear_icon':
                 if extra == 'all':
-                    self._model.remove_all_value_icons(key)
+                    self._model.remove_all_value_icons(key, keep_template=True)
                 elif extra == 'value':
                     if index is not None:
                         val, icon_name = make_icon_name(key, index)
@@ -1298,7 +1298,7 @@ class TagsView(QTreeView):  # {{{
                                          key=key, index=None, category=category, extra='value'))
                     ma.setEnabled(self._model.value_icons.get(key, {}).get(TEMPLATE_ICON_INDICATOR) is not None)
                     im.addSection(_('All values'))
-                    ma = im.addAction(_('Reset all value icons to category icon'),
+                    ma = im.addAction(_('Reset all value icons to the default icon'),
                                  partial(self.context_menu_handler, action='clear_icon',
                                          key=key, index=None, category=category, extra='all'))
                     im.addSeparator()

--- a/src/calibre/gui2/tag_browser/view.py
+++ b/src/calibre/gui2/tag_browser/view.py
@@ -47,6 +47,7 @@ from calibre.constants import config_dir
 from calibre.ebooks.metadata import rating_to_stars
 from calibre.gui2 import FunctionDispatcher, choose_files, config, empty_index, gprefs, pixmap_to_data, question_dialog, rating_font, safe_open_url
 from calibre.gui2.complete2 import EditWithComplete
+from calibre.gui2.dialogs.confirm_delete import confirm
 from calibre.gui2.dialogs.edit_category_notes import EditNoteDialog
 from calibre.gui2.tag_browser.model import (
     COUNT_ROLE,
@@ -735,14 +736,34 @@ class TagsView(QTreeView):  # {{{
                 return
             if action == 'clear_icon':
                 if extra == 'all':
+                    if not confirm(
+                        _('<b>All</b> the value icons for the category "{}" '
+                        'will be <b>permanently deleted</b>. Are you sure?').format(category),
+                        'clear_category_all_value_icons', parent=get_gui()):
+                        return
                     self._model.remove_all_value_icons(key, keep_template=True)
                 elif extra == 'value':
                     if index is not None:
                         val, icon_name = make_icon_name(key, index)
+                        if not confirm(
+                            _('The icon for the value "{0}" of the "{1}" category '
+                            'will be <b>permanently deleted</b>. Are you sure?').format(val, category),
+                            'clear_category_value_icon_single', parent=get_gui()):
+                            return
                         self._model.remove_value_icon(key, val, icon_name)
                     else:
+                        if not confirm(
+                            _('The template to choose the default value icons for the category "{}" '
+                            'will be <b>permanently deleted</b>. Are you sure?').format(category),
+                            'clear_category_value_icon_template', parent=get_gui()):
+                            return
                         self._model.remove_value_icon(key, TEMPLATE_ICON_INDICATOR, None)
                 else:
+                    if not confirm(
+                        _('The icon for the category "{}" '
+                        'will be <b>permanently deleted</b>. Are you sure?').format(category),
+                        'clear_category_icon', parent=get_gui()):
+                        return
                     self._model.set_custom_category_icon(key, None)
                 self.recount()
                 return

--- a/src/calibre/gui2/tag_browser/view.py
+++ b/src/calibre/gui2/tag_browser/view.py
@@ -734,13 +734,17 @@ class TagsView(QTreeView):  # {{{
                     self._model.set_value_icon(key, item_val, icon_file_name, bool(for_children))
                     self.recount()
                 return
-            if action == 'clear_icon':
+            if action == 'clear_icon_value':
                 if index is not None:
                     val, icon_name = make_icon_name(key, index)
                     self._model.remove_value_icon(key, val, icon_name)
                 else:
-                    self._model.set_custom_category_icon(key, None)
                     self._model.remove_value_icon(key, TEMPLATE_ICON_INDICATOR, None)
+                self.recount()
+                return
+            if action == 'clear_icon':
+                self._model.set_custom_category_icon(key, None)
+                self._model.remove_all_value_icons(key)
                 self.recount()
                 return
 
@@ -1283,7 +1287,7 @@ class TagsView(QTreeView):  # {{{
                                                 key=key, index=index, category=category, extra=(icon_name, True)))
                     ma.setEnabled(icon_name is not None and not for_child)
                     ma = im.addAction(_('Use the default icon for {}').format(for_name),
-                                 partial(self.context_menu_handler, action='clear_icon',
+                                 partial(self.context_menu_handler, action='clear_icon_value',
                                          key=key, index=index, category=category))
                     ma.setEnabled(name is not None and icon_name is not None)
                     im.addSection(_('Defaults'))
@@ -1291,7 +1295,7 @@ class TagsView(QTreeView):  # {{{
                                       partial(self.context_menu_handler, action='set_icon',
                                               key=key, index=index, category=None, extra=(None, None)))
                     ma = im.addAction(_('Use the category icon for the default value icon'),
-                                 partial(self.context_menu_handler, action='clear_icon',
+                                 partial(self.context_menu_handler, action='clear_icon_value',
                                          key=key, index=None, category=category))
                     ma.setEnabled(self._model.value_icons.get(key, {}).get(TEMPLATE_ICON_INDICATOR) is not None)
                     im.addSeparator()

--- a/src/calibre/gui2/tag_browser/view.py
+++ b/src/calibre/gui2/tag_browser/view.py
@@ -729,10 +729,9 @@ class TagsView(QTreeView):  # {{{
                     icon_file_name = desired_file_name
                 if index is None: # category icon
                     self._model.set_custom_category_icon(key, str(icon_file_name))
-                    self.recount()
                 else: # value icon
                     self._model.set_value_icon(key, item_val, icon_file_name, bool(for_children))
-                    self.recount()
+                self.recount()
                 return
             if action == 'clear_icon_value':
                 if index is not None:


### PR DESCRIPTION
Improve the reset to default icons for category and values in tag browser.

Fix bug when 'Restore {} category default icon' action reset all icons except template.
Fix bug when 'Use the category icon for the default value icon' actions reset also the category icon to default (instead of just the template).