### PR TITLE
Fix build with -std=gnu23

### DIFF
--- a/src/calibre/ebooks/djvu/bzzdecoder.c
+++ b/src/calibre/ebooks/djvu/bzzdecoder.c
@@ -21,7 +21,9 @@
 #define STRFY2(x) STRFY(x)
 #define CORRUPT PyErr_SetString(PyExc_ValueError, "Corrupt bitstream at line: " STRFY2(__LINE__))
 
+#if __STDC_VERSION__ < 202311L
 typedef uint8_t bool;
+#endif
 
 typedef struct Table {
     uint16_t p;


### PR DESCRIPTION
Gcc 15 defaults to gnu23, which makes bool a native type, so it cannot be redefined like this.