### PR TITLE
Implement lazy operations for "Look & feel"

### DIFF
--- a/src/calibre/gui2/preferences/look_feel.py
+++ b/src/calibre/gui2/preferences/look_feel.py
@@ -863,6 +863,7 @@ class ConfigWidget(ConfigWidgetBase, Ui_Form):
         self.tb_focus_label.setVisible(self.opt_tag_browser_allow_keyboard_focus.isChecked())
         self.update_color_palette_state()
         self.opt_gui_layout.setCurrentIndex(0 if self.gui.layout_container.is_wide else 1)
+        self.lazy_tab_operations(self.tabWidget.currentIndex(), None)
 
     def open_cg_cache(self):
         open_local_file(self.gui.grid_view.thumbnail_cache.location)

--- a/src/calibre/gui2/preferences/look_feel_tabs/tb_icon_rules.py
+++ b/src/calibre/gui2/preferences/look_feel_tabs/tb_icon_rules.py
@@ -141,8 +141,14 @@ class TbIconRulesTab(ConfigTabWidget, Ui_Form):
         self.tb_icon_rules_groupbox.setContentsMargins(0, 0, 0, 0)
         self.tb_icon_rules_gridlayout.setContentsMargins(2, 2, 2, 2)
 
-        field_metadata = gui.current_db.field_metadata
-        category_icons = gui.tags_view.model().category_custom_icons
+        try:
+            self.table_column_widths = gprefs.get('tag_browser_rules_dialog_table_widths', None)
+        except Exception:
+            pass
+
+    def lazy_populate_content(self):
+        field_metadata = self.gui.current_db.field_metadata
+        category_icons = self.gui.tags_view.model().category_custom_icons
         v = gprefs['tags_browser_value_icons']
         row = 0
         for category,vdict in v.items():
@@ -169,11 +175,6 @@ class TbIconRulesTab(ConfigTabWidget, Ui_Form):
         self.for_children_order = 0
         self.do_sort(VALUE_COLUMN)
         self.do_sort(CATEGORY_COLUMN)
-
-        try:
-            self.table_column_widths = gprefs.get('tag_browser_rules_dialog_table_widths', None)
-        except Exception:
-            pass
 
     def show_context_menu(self, point):
         clicked_item = self.rules_table.itemAt(point)


### PR DESCRIPTION
Implement a lazy operations feature for "Look & feel".

This was create to fix a user case when many Icons value are defined, the opening/loading of "Look & feel" dialog can take several time to show (test: 15000 Icons value result of ~10 second of lag).
Fix this by populate the table only when the subtab "Value icon rules viewer" is selected, rather than during the `genesis()` phase of "Look & feel" widget.
Implemented in a generic way than can be used for sections and subtabs.