### PR TITLE
Preferences / Look & feel changes

### DIFF
--- a/src/calibre/gui2/preferences/__init__.py
+++ b/src/calibre/gui2/preferences/__init__.py
@@ -114,6 +114,9 @@ class ConfigWidgetInterface:
     def do_on_child_tabs(self, method, *args):
         r = False
         for t in self.child_tabs:
+            tab_opened = getattr(t, 'tab_opened', True)
+            if method in ('commit', 'refresh_gui') and not tab_opened:
+                continue
             r = r | bool(getattr(t, method)(*args))
         return r
 
@@ -291,7 +294,7 @@ class ConfigWidgetBase(QWidget, ConfigWidgetInterface):
         self.settings = {}
         self.child_tabs = []
         for v in self.__dict__.values():
-            if isinstance(v, ConfigTabWidget):
+            if isinstance(v, LazyConfigWidgetBase):
                 self.child_tabs.append(v)
 
     def register(self, name, config_obj, gui_name=None, choices=None,
@@ -349,10 +352,29 @@ def get_plugin(category, name):
             (category, name))
 
 
-class ConfigTabWidget(ConfigWidgetBase):
+class LazyConfigWidgetBase(ConfigWidgetBase):
+    '''
+    Use this for dialogs that are tabs, accessed either from the left or on the
+    top. It directly replaces ConfigWidgetBase, supporting the lazy operations.
+    '''
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.tab_opened = False
 
     def set_changed_signal(self, changed_signal):
         self.changed_signal.connect(changed_signal)
+
+    def showEvent(self, event):
+        # called when the widget is actually displays. We can't do something like
+        # lazy_genesis because Qt does "things" before showEvent() is called. In
+        # particular, the register function doesn't work with combo boxes if
+        # genesis isn't called before everythign else. Why is a mystery.
+        if not self.tab_opened:
+            if hasattr(self, 'lazy_initialize'):
+                self.lazy_initialize()
+        self.tab_opened = True
+        super().showEvent(event)
 
 
 class ConfigDialog(QDialog):

--- a/src/calibre/gui2/preferences/look_feel.ui
+++ b/src/calibre/gui2/preferences/look_feel.ui
@@ -1307,487 +1307,15 @@ columns&quot;. Editing with mouse clicks and the Tab key will be disabled.&lt;/p
       <attribute name="title">
        <string>&amp;Tag browser</string>
       </attribute>
-      <widget class="QWidget" name="tb_tab1">
+      <widget class="TbDisplayTab" name="tb_display_tab">
        <attribute name="title">
         <string>Di&amp;splay</string>
        </attribute>
-       <layout class="QGridLayout" name="verticalLayout_42">
-        <item row="0" column="0">
-         <widget class="QLabel" name="label">
-          <property name="toolTip">
-           <string>User categories and Saved searches cannot be moved</string>
-          </property>
-          <property name="text">
-           <string>Select the categories to display in the Tag browser, and their &amp;order</string>
-          </property>
-          <property name="buddy">
-           <cstring>tb_display_order</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0" rowspan="3">
-         <widget class="ListViewWithMoveByKeyPress" name="tb_display_order">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>200</height>
-           </size>
-          </property>
-          <property name="alternatingRowColors">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="QToolButton" name="tb_up_button">
-          <property name="toolTip">
-           <string>Move up. User categories and Saved searches cannot be moved. Keyboard shortcut: Ctrl-Up arrow</string>
-          </property>
-          <property name="icon">
-           <iconset resource="../../../../resources/images.qrc">
-            <normaloff>:/images/arrow-up.png</normaloff>:/images/arrow-up.png</iconset>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <spacer name="verticalSpacer_5">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>50</width>
-            <height>40</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item row="3" column="1">
-         <widget class="QToolButton" name="tb_down_button">
-          <property name="toolTip">
-           <string>Move down. User categories and Saved searches cannot be moved. Keyboard shortcut: Ctrl-Down arrow</string>
-          </property>
-          <property name="icon">
-           <iconset resource="../../../../resources/images.qrc">
-            <normaloff>:/images/arrow-down.png</normaloff>:/images/arrow-down.png</iconset>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <layout class="QHBoxLayout" name="horizontalLayout_4">
-          <item>
-           <widget class="QPushButton" name="tb_reset_layout_button">
-            <property name="toolTip">
-             <string>Click this button to reset the list to its default order.</string>
-            </property>
-            <property name="text">
-             <string>Reset list</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="tb_import_layout_button">
-            <property name="toolTip">
-             <string>&lt;p&gt;Click this button to set the list to one
-previously exported. This could be useful if you have several libraries with
-similar structure and you want to use the same column order for each one. Columns
-in the imported list that aren't in the current library are ignored. Columns in
-the library that are not in the imported list are put at the end and marked
-as displayable.&lt;/p&gt;</string>
-            </property>
-            <property name="text">
-             <string>Import list</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="tb_export_layout_button">
-            <property name="toolTip">
-             <string>&lt;p&gt;Click this button to write the current display
-settings to a file. This could be useful if you have several libraries with similar
-structure and you want to use the same column order for each one.&lt;/p&gt;</string>
-            </property>
-            <property name="text">
-             <string>Export list</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </item>
-        <item row="5" column="0" colspan="3">
-         <layout class="QGridLayout" name="gridlayout_22">
-          <item row="0" column="0">
-           <widget class="QCheckBox" name="opt_show_avg_rating">
-            <property name="toolTip">
-             <string>Show the average rating per item indication in the Tag browser</string>
-            </property>
-            <property name="text">
-             <string>Show &amp;average ratings</string>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QCheckBox" name="opt_show_links_in_tag_browser">
-            <property name="toolTip">
-             <string>Show an icon if the item has an attached link</string>
-            </property>
-            <property name="text">
-             <string>Show &amp;links icons</string>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="2">
-           <widget class="QCheckBox" name="opt_tag_browser_show_tooltips">
-            <property name="text">
-             <string>Show &amp;tooltips</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QCheckBox" name="opt_tag_browser_show_counts">
-            <property name="toolTip">
-             <string>&lt;p&gt;Show counts for items in the Tag browser. Such as the number of books
-by each author, the number of authors, etc. If you turn it off, you can still
-see the counts by hovering your mouse over any item.&lt;/p&gt;</string>
-            </property>
-            <property name="text">
-             <string>Show &amp;counts</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QCheckBox" name="opt_show_notes_in_tag_browser">
-            <property name="toolTip">
-             <string>Show an icon if the item has an attached note</string>
-            </property>
-            <property name="text">
-             <string>Show &amp;notes icons</string>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="2">
-           <widget class="QCheckBox" name="opt_tag_browser_old_look">
-            <property name="text">
-             <string>Use &amp;alternating row colors</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QCheckBox" name="opt_tag_browser_hide_empty_categories">
-            <property name="toolTip">
-             <string>&lt;p&gt;When checked, calibre will automatically hide any category
-(a column, custom or standard) that has no items to show. For example, some
-categories might not have values when using Virtual libraries. Checking this
-box will cause these empty categories to be hidden.&lt;/p&gt;</string>
-            </property>
-            <property name="text">
-             <string>Hide empt&amp;y categories (columns)</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QCheckBox" name="opt_icons_on_right_in_tag_browser">
-            <property name="toolTip">
-             <string>If checked the notes and links icons will be placed at the right, after
-the count and in columns. If unchecked, the icons will be placed immediately after the text,
-to the left of the count and not in columns.</string>
-            </property>
-            <property name="text">
-             <string>Place icons on the &amp;right, in columns</string>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="2">
-           <widget class="QCheckBox" name="opt_tag_browser_always_autocollapse">
-            <property name="toolTip">
-             <string>&lt;p&gt;When checked, Find in the Tag browser will show all items
-that match the search instead of the first one. If Hide empty categories is
-also checked then only categories containing a matched item will be shown.&lt;/p&gt;</string>
-            </property>
-            <property name="text">
-             <string>Find &amp;shows all items that match</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QCheckBox" name="opt_tag_browser_restore_tree_expansion">
-            <property name="toolTip">
-             <string>&lt;p&gt;Ensure the last &quot;used&quot; item in the Tag browser is visible when opening a library.
-An item is &quot;used&quot; when it is expanded, collapsed, or clicked.&lt;/p&gt;</string>
-            </property>
-            <property name="text">
-             <string>Expand tr&amp;ee to show last used item</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item row="8" column="0" colspan="3">
-         <layout class="QVBoxLayout" name="verticalLayout">
-          <item>
-           <widget class="QCheckBox" name="opt_tag_browser_allow_keyboard_focus">
-            <property name="toolTip">
-             <string>&lt;p&gt;When checked, the Tag browser can get keyboard focus, allowing
-use of the keyboard to navigate the tree using the arrow keys. The Enter key simulates
-a click on the selected item. The keyboard shortcut 'Tag browser /
-Give the Tag browser keyboard focus' changes the keyboard focus without
-using the mouse.&lt;/p&gt;</string>
-            </property>
-            <property name="text">
-             <string>Allow the Tag browser to have keyboard &amp;focus</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLabel" name="tb_focus_label">
-            <property name="styleSheet">
-             <string notr="true">margin-left: 1.5em</string>
-            </property>
-            <property name="text">
-             <string>&lt;p style=&quot;text-indent: 2em; font-size:smaller&quot;&gt;
-If you enable this option then you should set a keyboard shortcut to
-focus the Tag browser under
-&lt;code&gt;Preferences-&amp;gt;Shortcuts-&amp;gt;Tag browser-&amp;gt;Give
-the Tag browser keyboard focus&lt;/code&gt;&lt;/p&gt;</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item row="10" column="0" colspan="3">
-         <layout class="QFormLayout" name="formLayout">
-          <property name="fieldGrowthPolicy">
-           <enum>QFormLayout::ExpandingFieldsGrow</enum>
-          </property>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label">
-            <property name="text">
-             <string>Spacing between &amp;items:</string>
-            </property>
-            <property name="buddy">
-             <cstring>opt_tag_browser_item_padding</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QDoubleSpinBox" name="opt_tag_browser_item_padding">
-            <property name="toolTip">
-             <string>&lt;p&gt;The spacing between consecutive items in the Tag browser.
-In units of (ex) which is the approximate height of the letter 'x' in the
-currently used font.&lt;/p&gt;</string>
-            </property>
-            <property name="suffix">
-             <string>ex</string>
-            </property>
-            <property name="decimals">
-             <number>1</number>
-            </property>
-            <property name="minimum">
-             <double>-1.000000000000000</double>
-            </property>
-            <property name="maximum">
-             <double>2.000000000000000</double>
-            </property>
-            <property name="singleStep">
-             <double>0.100000000000000</double>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-       </layout>
       </widget>
-      <widget class="QWidget" name="tb_tab2">
+      <widget class="TbPartitioningTab" name="tb_partioning_tab">
        <attribute name="title">
         <string>&amp;Partitioning and collapsing</string>
        </attribute>
-       <layout class="QVBoxLayout" name="verticalLayout_4">
-        <item>
-         <layout class="QGridLayout" name="gridLayout_10">
-          <item row="0" column="0">
-           <layout class="QFormLayout" name="formLayout">
-            <property name="fieldGrowthPolicy">
-             <enum>QFormLayout::ExpandingFieldsGrow</enum>
-            </property>
-            <item row="0" column="0">
-             <widget class="QLabel" name="label_9">
-              <property name="text">
-               <string>&amp;Category partitioning method:</string>
-              </property>
-              <property name="buddy">
-               <cstring>opt_tags_browser_partition_method</cstring>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1">
-             <widget class="QComboBox" name="opt_tags_browser_partition_method">
-              <property name="toolTip">
-               <string>&lt;p&gt;Choose how Tag browser subcategories are displayed when
-there are more items than the limit. Select by first
-letter to see an A, B, C list. Choose partitioned to
-have a list of fixed-sized groups. Set to disabled
-if you never want subcategories&lt;/p&gt;</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="label_10">
-              <property name="text">
-               <string>Combine letters &amp;when fewer items than:</string>
-              </property>
-              <property name="buddy">
-               <cstring>opt_tags_browser_collapse_fl_at</cstring>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <widget class="QSpinBox" name="opt_tags_browser_collapse_fl_at">
-              <property name="toolTip">
-               <string>&lt;p&gt;If collapsing by first letter, combine adjacent letters together if
-there are fewer items under a letter than specified here. If the partition method is
-not set to first letter, this value is ignored. Set to zero to disable.&lt;/p&gt;</string>
-              </property>
-              <property name="maximum">
-               <number>10000</number>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="0">
-             <widget class="QLabel" name="label_10">
-              <property name="text">
-               <string>Co&amp;llapse when more items than:</string>
-              </property>
-              <property name="buddy">
-               <cstring>opt_tags_browser_collapse_at</cstring>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="1">
-             <widget class="QSpinBox" name="opt_tags_browser_collapse_at">
-              <property name="toolTip">
-               <string>&lt;p&gt;If a Tag browser category has more than this number of items, it is divided
-up into subcategories. If the partition method is set to disable, this value is ignored.&lt;/p&gt;</string>
-              </property>
-              <property name="maximum">
-               <number>10000</number>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label">
-            <property name="toolTip">
-             <string>&lt;p&gt;Check the box for categories that are to
-be partitioned using the criteria above. Uncheck the box if you don't want to
-partition a category even if the number of items is larger than
-the value shown above. This option can be used to
-avoid collapsing hierarchical categories that have only
-a few top-level elements.&lt;/p&gt;</string>
-            </property>
-            <property name="text">
-             <string>Select categories to &amp;partition:</string>
-            </property>
-            <property name="buddy">
-             <cstring>tb_cats_to_partition</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QListView" name="tb_cats_to_partition">
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>200</height>
-             </size>
-            </property>
-            <property name="alternatingRowColors">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <layout class="QHBoxLayout" name="horizontalLayout_41">
-            <item>
-             <widget class="QPushButton" name="tb_partition_reset_button">
-              <property name="toolTip">
-               <string>Click this button to reset the list to its default order.</string>
-              </property>
-              <property name="text">
-               <string>Reset list</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPushButton" name="tb_partition_import_layout_button">
-              <property name="toolTip">
-               <string>&lt;p&gt;Click this button to set the list to one
-previously exported. This could be useful if you have several libraries with
-similar structure and you want to use the same for each one.&lt;/p&gt;</string>
-              </property>
-              <property name="text">
-               <string>Import list</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPushButton" name="tb_partition_export_layout_button">
-              <property name="toolTip">
-               <string>&lt;p&gt;Click this button to write the current display
-settings to a file. This could be useful if you have several libraries with similar
-structure and you want to use the same for each one.&lt;/p&gt;</string>
-              </property>
-              <property name="text">
-               <string>Export list</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </item>
-       </layout>
       </widget>
       <widget class="TbHierarchyTab" name="tb_hierarchy_tab">
        <attribute name="title">
@@ -1800,7 +1328,7 @@ structure and you want to use the same for each one.&lt;/p&gt;</string>
        </attribute>
       </widget>
      </widget>
-     <widget class="QWidget" name="cover_browser_tab">
+     <widget class="CoverView" name="cover_view">
       <attribute name="icon">
        <iconset resource="../../../../resources/images.qrc">
         <normaloff>:/images/cover_flow.png</normaloff>:/images/cover_flow.png</iconset>
@@ -1808,13 +1336,8 @@ structure and you want to use the same for each one.&lt;/p&gt;</string>
       <attribute name="title">
        <string>Cover &amp;browser</string>
       </attribute>
-      <layout class="QHBoxLayout">
-       <item>
-        <widget class="CoverView" name="cover_view"/>
-       </item>
-      </layout>
      </widget>
-     <widget class="QWidget" name="quickview_tab">
+     <widget class="QuickviewTab" name="quickview_tab">
       <attribute name="icon">
        <iconset resource="../../../../resources/images.qrc">
         <normaloff>:/images/quickview.png</normaloff>:/images/quickview.png</iconset>
@@ -1822,108 +1345,6 @@ structure and you want to use the same for each one.&lt;/p&gt;</string>
       <attribute name="title">
        <string>&amp;Quickview</string>
       </attribute>
-      <layout class="QGridLayout" name="gridLayout_122">
-       <item row="1" column="0" colspan="2">
-        <layout class="QGridLayout" name="gridLayout_122">
-         <item row="2" column="0">
-          <widget class="QCheckBox" name="opt_qv_respects_vls">
-           <property name="toolTip">
-            <string>&lt;p&gt;Check this box to make Quickview show books only in the
-current Virtual library. If unchecked, Quickview ignores Virtual libraries. If
-unchecked then only row changes are taken into account.&lt;/p&gt;</string>
-           </property>
-           <property name="text">
-            <string>&amp;Apply Virtual libraries</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
-          <widget class="QCheckBox" name="opt_qv_follows_column">
-           <property name="toolTip">
-            <string>&lt;p&gt;Check this box to make Quickview change the column being examined
-when the column in the book list is changed using the cursor arrow keys&lt;/p&gt;</string>
-           </property>
-           <property name="text">
-            <string>&amp;Change Quickview item when book list column changes</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QCheckBox" name="opt_qv_retkey_changes_column">
-           <property name="toolTip">
-            <string>&lt;p&gt;Pressing Enter in a cell changes both the book and the
-column being examined (the left-hand panel)&lt;/p&gt;</string>
-           </property>
-           <property name="text">
-            <string>&amp;Pressing Enter changes the examined column</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QCheckBox" name="opt_qv_dclick_changes_column">
-           <property name="toolTip">
-            <string>&lt;p&gt;Double-clicking in a cell changes both the book and the
-column being examined (the left-hand panel)&lt;/p&gt;</string>
-           </property>
-           <property name="text">
-            <string>&amp;Double click changes examined column</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item row="3" column="0" rowspan="2">
-        <widget class="QGroupBox" name="groupBox">
-         <property name="title">
-          <string>Select columns to display</string>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_32">
-          <item row="0" column="1">
-           <widget class="QToolButton" name="qv_up_button">
-            <property name="toolTip">
-             <string>Move up. Keyboard shortcut: Ctrl-Up arrow</string>
-            </property>
-            <property name="icon">
-             <iconset resource="../../../../resources/images.qrc">
-              <normaloff>:/images/arrow-up.png</normaloff>:/images/arrow-up.png</iconset>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QToolButton" name="qv_down_button">
-            <property name="toolTip">
-             <string>Move down. Keyboard shortcut: Ctrl-Down arrow</string>
-            </property>
-            <property name="icon">
-             <iconset resource="../../../../resources/images.qrc">
-              <normaloff>:/images/arrow-down.png</normaloff>:/images/arrow-down.png</iconset>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0" rowspan="3">
-           <widget class="ListViewWithMoveByKeyPress" name="qv_display_order">
-            <property name="alternatingRowColors">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <spacer name="verticalSpacer_5">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </widget>
-       </item>
-      </layout>
      </widget>
     </widget>
    </item>
@@ -1962,6 +1383,16 @@ column being examined (the left-hand panel)&lt;/p&gt;</string>
    <header>calibre/gui2/preferences/look_feel.h</header>
   </customwidget>
   <customwidget>
+   <class>TbDisplayTab</class>
+   <extends>ConfigWidget</extends>
+   <header>calibre/gui2/preferences/look_feel_tabs.tb_display.h</header>
+  </customwidget>
+  <customwidget>
+   <class>TbPartitioningTab</class>
+   <extends>ConfigWidget</extends>
+   <header>calibre/gui2/preferences/look_feel_tabs.tb_partitioning.h</header>
+  </customwidget>
+  <customwidget>
    <class>TbIconRulesTab</class>
    <extends>ConfigWidget</extends>
    <header>calibre/gui2/preferences/look_feel_tabs.tb_icon_rules.h</header>
@@ -1975,6 +1406,11 @@ column being examined (the left-hand panel)&lt;/p&gt;</string>
    <class>CoverView</class>
    <extends>ConfigWidget</extends>
    <header>calibre/gui2/preferences/look_feel_tabs.cover_view.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QuickviewTab</class>
+   <extends>ConfigWidget</extends>
+   <header>calibre/gui2/preferences/look_feel_tabs.tb_quickview.h</header>
   </customwidget>
  </customwidgets>
  <resources>
@@ -1994,22 +1430,6 @@ column being examined (the left-hand panel)&lt;/p&gt;</string>
     <hint type="destinationlabel">
      <x>101</x>
      <y>51</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>opt_tag_browser_allow_keyboard_focus</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>tb_focus_label</receiver>
-   <slot>setVisible(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>275</x>
-     <y>528</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>358</x>
-     <y>555</y>
     </hint>
    </hints>
   </connection>

--- a/src/calibre/gui2/preferences/look_feel_tabs/__init__.py
+++ b/src/calibre/gui2/preferences/look_feel_tabs/__init__.py
@@ -109,7 +109,7 @@ class DisplayedFields(QAbstractListModel):  # {{{
             return idx
 
 def export_layout(in_widget, model=None):
-    filename = choose_save_file(in_widget, 'tb_display_import_export_field_list',
+    filename = choose_save_file(in_widget, 'look_feel_prefs_import_export_field_list',
             _('Save column list to file'),
             filters=[(_('Column list'), ['json'])])
     if filename:
@@ -121,7 +121,7 @@ def export_layout(in_widget, model=None):
                          _('<p>Could not write field list. Error:<br>%s')%err, show=True)
 
 def import_layout(in_widget, model=None):
-    filename = choose_files(in_widget, 'tb_display_import_export_field_list',
+    filename = choose_files(in_widget, 'look_feel_prefs_import_export_field_list',
             _('Load column list from file'),
             filters=[(_('Column list'), ['json'])])
     if filename:

--- a/src/calibre/gui2/preferences/look_feel_tabs/cover_view.py
+++ b/src/calibre/gui2/preferences/look_feel_tabs/cover_view.py
@@ -2,7 +2,7 @@
 
 
 __license__   = 'GPL v3'
-__copyright__ = '2010, Kovid Goyal <kovid@kovidgoyal.net>'
+__copyright__ = '2025, Kovid Goyal <kovid@kovidgoyal.net>'
 __docformat__ = 'restructuredtext en'
 
 
@@ -10,15 +10,15 @@ from qt.core import QKeySequence
 
 from calibre.gui2 import config, gprefs
 from calibre.gui2.dialogs.template_dialog import TemplateDialog
-from calibre.gui2.preferences import ConfigTabWidget, ConfigWidgetBase, set_help_tips
+from calibre.gui2.preferences import LazyConfigWidgetBase, ConfigWidgetBase, set_help_tips
 from calibre.gui2.preferences.look_feel_tabs.cover_view_ui import Ui_Form
 
 
-class CoverView(ConfigTabWidget, Ui_Form):
+class CoverView(LazyConfigWidgetBase, Ui_Form):
 
     def genesis(self, gui):
         self.gui = gui
-        db = gui.library_view.model().db
+        db = self.gui.library_view.model().db
         r = self.register
 
         r('books_autoscroll_time', gprefs)
@@ -41,7 +41,7 @@ class CoverView(ConfigTabWidget, Ui_Form):
         self.fs_help_msg.setText(self.fs_help_msg.text()%(
             QKeySequence(QKeySequence.StandardKey.FullScreen).toString(QKeySequence.SequenceFormat.NativeText)))
 
-    def initialize(self):
+    def lazy_initialize(self):
         ConfigWidgetBase.initialize(self)
         set_help_tips(self.opt_cover_browser_narrow_view_position, _(
             'This option controls the position of the cover browser when using the Narrow user '
@@ -55,6 +55,9 @@ class CoverView(ConfigTabWidget, Ui_Form):
         t.setWindowTitle(_('Edit template for caption'))
         if t.exec():
             self.opt_cover_browser_title_template.setText(t.rule[1])
+
+    def commit(self):
+        return ConfigWidgetBase.commit(self)
 
     def refresh_gui(self, gui):
         gui.cover_flow.setShowReflections(gprefs['cover_browser_reflections'])

--- a/src/calibre/gui2/preferences/look_feel_tabs/cover_view.py
+++ b/src/calibre/gui2/preferences/look_feel_tabs/cover_view.py
@@ -59,6 +59,9 @@ class CoverView(LazyConfigWidgetBase, Ui_Form):
     def commit(self):
         return ConfigWidgetBase.commit(self)
 
+    def restore_defaults(self):
+        ConfigWidgetBase.restore_defaults(self)
+
     def refresh_gui(self, gui):
         gui.cover_flow.setShowReflections(gprefs['cover_browser_reflections'])
         gui.cover_flow.setPreserveAspectRatio(gprefs['cb_preserve_aspect_ratio'])

--- a/src/calibre/gui2/preferences/look_feel_tabs/cover_view.py
+++ b/src/calibre/gui2/preferences/look_feel_tabs/cover_view.py
@@ -51,7 +51,15 @@ class CoverView(LazyConfigWidgetBase, Ui_Form):
             'list. This option has no effect when using the Wide user interface layout.'))
 
     def edit_cb_title_template(self):
-        t = TemplateDialog(self, self.opt_cover_browser_title_template.text(), fm=self.gui.current_db.field_metadata)
+        rows = self.gui.library_view.selectionModel().selectedRows()
+        mi = None
+        db = self.gui.current_db.new_api
+        if rows:
+            ids = list(map(self.gui.library_view.model().id, rows))
+            mi = []
+            for bk in ids[0:min(10, len(ids))]:
+                mi.append(db.get_proxy_metadata(bk))
+        t = TemplateDialog(self, self.opt_cover_browser_title_template.text(), mi=mi, fm=db.field_metadata)
         t.setWindowTitle(_('Edit template for caption'))
         if t.exec():
             self.opt_cover_browser_title_template.setText(t.rule[1])

--- a/src/calibre/gui2/preferences/look_feel_tabs/tb_display.py
+++ b/src/calibre/gui2/preferences/look_feel_tabs/tb_display.py
@@ -111,7 +111,7 @@ class TbDisplayTab(LazyConfigWidgetBase, Ui_Form):
 
     def restore_defaults(self):
         ConfigWidgetBase.restore_defaults(self)
-        self.display_model.restore_defaults()
+        self.tb_display_model.restore_defaults()
 
     def commit(self):
         self.tb_display_model.commit()

--- a/src/calibre/gui2/preferences/look_feel_tabs/tb_display.py
+++ b/src/calibre/gui2/preferences/look_feel_tabs/tb_display.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+
+
+__license__   = 'GPL v3'
+__copyright__ = '2025, Kovid Goyal <kovid@kovidgoyal.net>'
+__docformat__ = 'restructuredtext en'
+
+from functools import partial
+
+from calibre.db.categories import is_standard_category
+from calibre.gui2 import config, gprefs
+from calibre.gui2.preferences import ConfigWidgetBase, LazyConfigWidgetBase
+from calibre.gui2.preferences.look_feel_tabs import (
+     DisplayedFields,
+     import_layout,
+     export_layout,
+     move_field_down,
+     move_field_up,
+     reset_layout
+ )
+from calibre.gui2.preferences.look_feel_tabs.tb_display_ui import Ui_Form
+
+class TBDisplayedFields(DisplayedFields):  # {{{
+    # The code in this class depends on the fact that the tag browser is
+    # initialized before this class is instantiated.
+
+    def __init__(self, db, parent=None, category_icons=None):
+        DisplayedFields.__init__(self, db, parent, category_icons=category_icons)
+        from calibre.gui2.ui import get_gui
+        self.gui = get_gui()
+
+    def initialize(self, use_defaults=False, pref_data_override=None):
+        tv = self.gui.tags_view
+        cat_ord = tv.model().get_ordered_categories(use_defaults=use_defaults,
+                                                    pref_data_override=pref_data_override)
+        if use_defaults:
+            hc = []
+            self.changed = True
+        elif pref_data_override:
+            hc = [k for k,v in pref_data_override if not v]
+            self.changed = True
+        else:
+            hc = tv.hidden_categories
+
+        self.beginResetModel()
+        self.fields = [[x, x not in hc] for x in cat_ord]
+        self.endResetModel()
+
+    def commit(self):
+        if self.changed:
+            self.db.prefs.set('tag_browser_hidden_categories', [k for k,v in self.fields if not v])
+            self.db.prefs.set('tag_browser_category_order', [k for k,v in self.fields])
+# }}}
+
+
+class TbDisplayTab(LazyConfigWidgetBase, Ui_Form):
+
+    def genesis(self, gui):
+        self.gui = gui
+        r = self.register
+        r('tag_browser_old_look', gprefs)
+        r('tag_browser_hide_empty_categories', gprefs)
+        r('tag_browser_always_autocollapse', gprefs)
+        r('tag_browser_restore_tree_expansion', gprefs)
+        r('tag_browser_show_tooltips', gprefs)
+        r('tag_browser_allow_keyboard_focus', gprefs)
+        r('tag_browser_show_counts', gprefs)
+        r('tag_browser_item_padding', gprefs)
+        r('show_avg_rating', config)
+        r('show_links_in_tag_browser', gprefs)
+        r('show_notes_in_tag_browser', gprefs)
+        r('icons_on_right_in_tag_browser', gprefs)
+
+        self.tb_display_model = TBDisplayedFields(self.gui.current_db, self.tb_display_order,
+                                  category_icons=self.gui.tags_view.model().category_custom_icons)
+        self.tb_display_model.dataChanged.connect(self.changed_signal)
+        self.tb_display_order.setModel(self.tb_display_model)
+        self.tb_reset_layout_button.clicked.connect(partial(reset_layout, self, model=self.tb_display_model))
+        self.tb_export_layout_button.clicked.connect(partial(export_layout, self, model=self.tb_display_model))
+        self.tb_import_layout_button.clicked.connect(partial(import_layout, self, model=self.tb_display_model))
+        self.tb_up_button.clicked.connect(self.tb_up_button_clicked)
+        self.tb_down_button.clicked.connect(self.tb_down_button_clicked)
+        self.tb_display_order.set_movement_functions(self.tb_up_button_clicked, self.tb_down_button_clicked)
+
+    def lazy_initialize(self):
+        self.tb_display_model.initialize()
+        self.tb_focus_label.setVisible(self.opt_tag_browser_allow_keyboard_focus.isChecked())
+
+    def tb_down_button_clicked(self):
+        idx = self.tb_display_order.currentIndex()
+        if idx.isValid():
+            row = idx.row()
+            model = self.tb_display_model
+            fields = model.fields
+            key = fields[row][0]
+            if not is_standard_category(key):
+                return
+            if row < len(fields) and is_standard_category(fields[row+1][0]):
+                move_field_down(self.tb_display_order, model)
+
+    def tb_up_button_clicked(self):
+        idx = self.tb_display_order.currentIndex()
+        if idx.isValid():
+            row = idx.row()
+            model = self.tb_display_model
+            fields = model.fields
+            key = fields[row][0]
+            if not is_standard_category(key):
+                return
+            move_field_up(self.tb_display_order, model)
+
+    def restore_defaults(self):
+        ConfigWidgetBase.restore_defaults(self)
+        self.display_model.restore_defaults()
+
+    def commit(self):
+        self.tb_display_model.commit()
+        return ConfigWidgetBase.commit(self)

--- a/src/calibre/gui2/preferences/look_feel_tabs/tb_display.ui
+++ b/src/calibre/gui2/preferences/look_feel_tabs/tb_display.ui
@@ -1,0 +1,360 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>1096</width>
+    <height>791</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="verticalLayout_42">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="toolTip">
+      <string>User categories and Saved searches cannot be moved</string>
+     </property>
+     <property name="text">
+      <string>Select the categories to display in the Tag browser, and their &amp;order</string>
+     </property>
+     <property name="buddy">
+      <cstring>tb_display_order</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" rowspan="3">
+    <widget class="ListViewWithMoveByKeyPress" name="tb_display_order">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>200</height>
+      </size>
+     </property>
+     <property name="alternatingRowColors">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QToolButton" name="tb_up_button">
+     <property name="toolTip">
+      <string>Move up. User categories and Saved searches cannot be moved. Keyboard shortcut: Ctrl-Up arrow</string>
+     </property>
+     <property name="icon">
+      <iconset resource="../../../../resources/images.qrc">
+       <normaloff>:/images/arrow-up.png</normaloff>:/images/arrow-up.png</iconset>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <spacer name="verticalSpacer_5">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>50</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="3" column="1">
+    <widget class="QToolButton" name="tb_down_button">
+     <property name="toolTip">
+      <string>Move down. User categories and Saved searches cannot be moved. Keyboard shortcut: Ctrl-Down arrow</string>
+     </property>
+     <property name="icon">
+      <iconset resource="../../../../resources/images.qrc">
+       <normaloff>:/images/arrow-down.png</normaloff>:/images/arrow-down.png</iconset>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <item>
+      <widget class="QPushButton" name="tb_reset_layout_button">
+       <property name="toolTip">
+        <string>Click this button to reset the list to its default order.</string>
+       </property>
+       <property name="text">
+        <string>Reset list</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="tb_import_layout_button">
+       <property name="toolTip">
+        <string>&lt;p&gt;Click this button to set the list to one
+previously exported. This could be useful if you have several libraries with
+similar structure and you want to use the same column order for each one. Columns
+in the imported list that aren't in the current library are ignored. Columns in
+the library that are not in the imported list are put at the end and marked
+as displayable.&lt;/p&gt;</string>
+       </property>
+       <property name="text">
+        <string>Import list</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="tb_export_layout_button">
+       <property name="toolTip">
+        <string>&lt;p&gt;Click this button to write the current display
+settings to a file. This could be useful if you have several libraries with similar
+structure and you want to use the same column order for each one.&lt;/p&gt;</string>
+       </property>
+       <property name="text">
+        <string>Export list</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item row="5" column="0" colspan="3">
+    <layout class="QGridLayout" name="gridlayout_22">
+     <item row="0" column="0">
+      <widget class="QCheckBox" name="opt_show_avg_rating">
+       <property name="toolTip">
+        <string>Show the average rating per item indication in the Tag browser</string>
+       </property>
+       <property name="text">
+        <string>Show &amp;average ratings</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QCheckBox" name="opt_show_links_in_tag_browser">
+       <property name="toolTip">
+        <string>Show an icon if the item has an attached link</string>
+       </property>
+       <property name="text">
+        <string>Show &amp;links icons</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="2">
+      <widget class="QCheckBox" name="opt_tag_browser_show_tooltips">
+       <property name="text">
+        <string>Show &amp;tooltips</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QCheckBox" name="opt_tag_browser_show_counts">
+       <property name="toolTip">
+        <string>&lt;p&gt;Show counts for items in the Tag browser. Such as the number of books
+by each author, the number of authors, etc. If you turn it off, you can still
+see the counts by hovering your mouse over any item.&lt;/p&gt;</string>
+       </property>
+       <property name="text">
+        <string>Show &amp;counts</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QCheckBox" name="opt_show_notes_in_tag_browser">
+       <property name="toolTip">
+        <string>Show an icon if the item has an attached note</string>
+       </property>
+       <property name="text">
+        <string>Show &amp;notes icons</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="QCheckBox" name="opt_tag_browser_old_look">
+       <property name="text">
+        <string>Use &amp;alternating row colors</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QCheckBox" name="opt_tag_browser_hide_empty_categories">
+       <property name="toolTip">
+        <string>&lt;p&gt;When checked, calibre will automatically hide any category
+(a column, custom or standard) that has no items to show. For example, some
+categories might not have values when using Virtual libraries. Checking this
+box will cause these empty categories to be hidden.&lt;/p&gt;</string>
+       </property>
+       <property name="text">
+        <string>Hide empt&amp;y categories (columns)</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QCheckBox" name="opt_icons_on_right_in_tag_browser">
+       <property name="toolTip">
+        <string>If checked the notes and links icons will be placed at the right, after
+the count and in columns. If unchecked, the icons will be placed immediately after the text,
+to the left of the count and not in columns.</string>
+       </property>
+       <property name="text">
+        <string>Place icons on the &amp;right, in columns</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="2">
+      <widget class="QCheckBox" name="opt_tag_browser_always_autocollapse">
+       <property name="toolTip">
+        <string>&lt;p&gt;When checked, Find in the Tag browser will show all items
+that match the search instead of the first one. If Hide empty categories is
+also checked then only categories containing a matched item will be shown.&lt;/p&gt;</string>
+       </property>
+       <property name="text">
+        <string>Find &amp;shows all items that match</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QCheckBox" name="opt_tag_browser_restore_tree_expansion">
+       <property name="toolTip">
+        <string>&lt;p&gt;Ensure the last &quot;used&quot; item in the Tag browser is visible when opening a library.
+An item is &quot;used&quot; when it is expanded, collapsed, or clicked.&lt;/p&gt;</string>
+       </property>
+       <property name="text">
+        <string>Expand tr&amp;ee to show last used item</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="8" column="0" colspan="3">
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <widget class="QCheckBox" name="opt_tag_browser_allow_keyboard_focus">
+       <property name="toolTip">
+        <string>&lt;p&gt;When checked, the Tag browser can get keyboard focus, allowing
+use of the keyboard to navigate the tree using the arrow keys. The Enter key simulates
+a click on the selected item. The keyboard shortcut 'Tag browser /
+Give the Tag browser keyboard focus' changes the keyboard focus without
+using the mouse.&lt;/p&gt;</string>
+       </property>
+       <property name="text">
+        <string>Allow the Tag browser to have keyboard &amp;focus</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="tb_focus_label">
+       <property name="styleSheet">
+        <string notr="true">margin-left: 1.5em</string>
+       </property>
+       <property name="text">
+        <string>&lt;p style=&quot;text-indent: 2em; font-size:smaller&quot;&gt;
+If you enable this option then you should set a keyboard shortcut to
+focus the Tag browser under
+&lt;code&gt;Preferences-&amp;gt;Shortcuts-&amp;gt;Tag browser-&amp;gt;Give
+the Tag browser keyboard focus&lt;/code&gt;&lt;/p&gt;</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="10" column="0" colspan="3">
+    <layout class="QFormLayout" name="formLayout">
+     <property name="fieldGrowthPolicy">
+      <enum>QFormLayout::ExpandingFieldsGrow</enum>
+     </property>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Spacing between &amp;items:</string>
+       </property>
+       <property name="buddy">
+        <cstring>opt_tag_browser_item_padding</cstring>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QDoubleSpinBox" name="opt_tag_browser_item_padding">
+       <property name="toolTip">
+        <string>&lt;p&gt;The spacing between consecutive items in the Tag browser.
+In units of (ex) which is the approximate height of the letter 'x' in the
+currently used font.&lt;/p&gt;</string>
+       </property>
+       <property name="suffix">
+        <string>ex</string>
+       </property>
+       <property name="decimals">
+        <number>1</number>
+       </property>
+       <property name="minimum">
+        <double>-1.000000000000000</double>
+       </property>
+       <property name="maximum">
+        <double>2.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>0.100000000000000</double>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ListViewWithMoveByKeyPress</class>
+   <extends>QListView</extends>
+   <header>calibre/gui2/preferences.h</header>
+  </customwidget>
+  <customwidget>
+   <class>ListWidgetWithMoveByKeyPress</class>
+   <extends>QListWidget</extends>
+   <header>calibre/gui2/preferences.h</header>
+  </customwidget>
+ </customwidgets>
+ <connections>
+  <connection>
+   <sender>opt_tag_browser_allow_keyboard_focus</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>tb_focus_label</receiver>
+   <slot>setVisible(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>275</x>
+     <y>528</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>358</x>
+     <y>555</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/calibre/gui2/preferences/look_feel_tabs/tb_hierarchy.py
+++ b/src/calibre/gui2/preferences/look_feel_tabs/tb_hierarchy.py
@@ -11,7 +11,7 @@ from functools import partial
 from qt.core import QListWidgetItem, Qt
 
 from calibre.gui2 import choose_files, choose_save_file, error_dialog, gprefs
-from calibre.gui2.preferences import ConfigTabWidget
+from calibre.gui2.preferences import LazyConfigWidgetBase
 from calibre.gui2.preferences.look_feel_tabs import DisplayedFields
 from calibre.gui2.preferences.look_feel_tabs.tb_hierarchy_ui import Ui_Form
 
@@ -54,18 +54,16 @@ class TBHierarchicalFields(DisplayedFields):  # {{{
 # }}}
 
 
-class TbHierarchyTab(ConfigTabWidget, Ui_Form):
+class TbHierarchyTab(LazyConfigWidgetBase, Ui_Form):
 
     def genesis(self, gui):
         self.gui = gui
-        self.tab_opened = False
         self.tb_search_order_up_button.clicked.connect(self.move_tb_search_up)
         self.tb_search_order_down_button.clicked.connect(self.move_tb_search_down)
         self.tb_search_order.set_movement_functions(self.move_tb_search_up, self.move_tb_search_down)
         self.tb_search_order_reset_button.clicked.connect(self.reset_tb_search_order)
 
-    def lazy_populate_content(self):
-        self.tab_opened = True
+    def lazy_initialize(self):
         self.fill_tb_search_order_box()
 
         self.tb_hierarchical_cats_model = TBHierarchicalFields(self.gui.current_db, self.tb_hierarchical_cats,
@@ -170,7 +168,10 @@ class TbHierarchyTab(ConfigTabWidget, Ui_Form):
                 error_dialog(self, _('Import layout'),
                              _('<p>Could not read field list. Error:<br>%s')%err, show=True)
 
+    def restore_defaults(self):
+        self.tb_hierarchical_cats_model.restore_defaults()
+        self.reset_tb_search_order()
+
     def commit(self):
-        if self.tab_opened:
-            self.tb_search_order_commit()
-            self.tb_hierarchical_cats_model.commit()
+        self.tb_search_order_commit()
+        self.tb_hierarchical_cats_model.commit()

--- a/src/calibre/gui2/preferences/look_feel_tabs/tb_icon_rules.py
+++ b/src/calibre/gui2/preferences/look_feel_tabs/tb_icon_rules.py
@@ -2,7 +2,7 @@
 
 
 __license__   = 'GPL v3'
-__copyright__ = '2010, Kovid Goyal <kovid@kovidgoyal.net>'
+__copyright__ = '2025, Kovid Goyal <kovid@kovidgoyal.net>'
 __docformat__ = 'restructuredtext en'
 
 import copy
@@ -14,7 +14,7 @@ from qt.core import QAbstractItemView, QApplication, QIcon, QMenu, Qt, QTableWid
 from calibre.constants import config_dir
 from calibre.db.constants import TEMPLATE_ICON_INDICATOR
 from calibre.gui2 import gprefs
-from calibre.gui2.preferences import ConfigTabWidget, ConfigWidgetBase
+from calibre.gui2.preferences import ConfigWidgetBase, LazyConfigWidgetBase
 from calibre.gui2.preferences.look_feel_tabs.tb_icon_rules_ui import Ui_Form
 
 DELETED_COLUMN = 0
@@ -98,7 +98,7 @@ class ChildrenTableWidgetItem(QTableWidgetItem):
         self.setIcon(QIcon.cached_icon(icon))
 
 
-class TbIconRulesTab(ConfigTabWidget, Ui_Form):
+class TbIconRulesTab(LazyConfigWidgetBase, Ui_Form):
 
     def genesis(self, gui):
         self.gui = gui
@@ -147,7 +147,7 @@ class TbIconRulesTab(ConfigTabWidget, Ui_Form):
         except Exception:
             pass
 
-    def lazy_populate_content(self):
+    def lazy_initialize(self):
         field_metadata = self.gui.current_db.field_metadata
         category_icons = self.gui.tags_view.model().category_custom_icons
         v = gprefs['tags_browser_value_icons']
@@ -256,7 +256,6 @@ class TbIconRulesTab(ConfigTabWidget, Ui_Form):
             self.rules_table.sortByColumn(FOR_CHILDREN_COLUMN, Qt.SortOrder(self.for_children_order))
 
     def commit(self):
-        rr = ConfigWidgetBase.commit(self)
         v = copy.deepcopy(gprefs['tags_browser_value_icons'])
         for r in range(self.rules_table.rowCount()):
             cat_item = self.rules_table.item(r, CATEGORY_COLUMN)
@@ -275,4 +274,4 @@ class TbIconRulesTab(ConfigTabWidget, Ui_Form):
             if len(v[category]) == 0:
                 v.pop(category, None)
         gprefs['tags_browser_value_icons'] = v
-        return rr
+        return ConfigWidgetBase.commit(self)

--- a/src/calibre/gui2/preferences/look_feel_tabs/tb_partitioning.py
+++ b/src/calibre/gui2/preferences/look_feel_tabs/tb_partitioning.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+
+
+__license__   = 'GPL v3'
+__copyright__ = '2025, Kovid Goyal <kovid@kovidgoyal.net>'
+__docformat__ = 'restructuredtext en'
+
+
+from functools import partial
+
+from calibre.gui2 import  gprefs
+from calibre.gui2.preferences import ConfigWidgetBase, LazyConfigWidgetBase
+from calibre.gui2.preferences.look_feel_tabs import DisplayedFields, export_layout, import_layout, reset_layout
+from calibre.gui2.preferences.look_feel_tabs.tb_partitioning_ui import Ui_Form
+
+
+class TBPartitionedFields(DisplayedFields):  # {{{
+    # The code in this class depends on the fact that the tag browser is
+    # initialized before this class is instantiated.
+
+    def __init__(self, db, parent=None, category_icons=None):
+        DisplayedFields.__init__(self, db, parent, category_icons=category_icons)
+        from calibre.gui2.ui import get_gui
+        self.gui = get_gui()
+
+    def filter_user_categories(self, tv):
+        cats = tv.model().categories
+        answer = {}
+        filtered = set()
+        for key,name in cats.items():
+            if key.startswith('@'):
+                key = key.partition('.')[0]
+                name = key[1:]
+            if key not in filtered:
+                answer[key] = name
+                filtered.add(key)
+        return answer
+
+    def initialize(self, use_defaults=False, pref_data_override=None):
+        tv = self.gui.tags_view
+        cats = self.filter_user_categories(tv)
+        ans = []
+        if use_defaults:
+            ans = [[k, True] for k in cats.keys()]
+            self.changed = True
+        elif pref_data_override:
+            po = {k:v for k,v in pref_data_override}
+            ans = [[k, po.get(k, True)] for k in cats.keys()]
+            self.changed = True
+        else:
+            # Check if setting not migrated yet
+            cats_to_partition = frozenset(self.db.prefs.get('tag_browser_dont_collapse', gprefs.get('tag_browser_dont_collapse')) or ())
+            for key in cats:
+                ans.append([key, key not in cats_to_partition])
+        self.beginResetModel()
+        self.fields = ans
+        self.endResetModel()
+
+    def commit(self):
+        if self.changed:
+            # Migrate to a per-library setting
+            self.db.prefs.set('tag_browser_dont_collapse', [k for k,v in self.fields if not v])
+# }}}
+
+
+class TbPartitioningTab(LazyConfigWidgetBase, Ui_Form):
+
+    def genesis(self, gui):
+        self.gui = gui
+        r = self.register
+
+        choices = [(_('Disabled'), 'disable'), (_('By first letter'), 'first letter'),
+                   (_('Partitioned'), 'partition')]
+        r('tags_browser_partition_method', gprefs, choices=choices)
+        r('tags_browser_collapse_at', gprefs)
+        r('tags_browser_collapse_fl_at', gprefs)
+
+        self.tb_categories_to_part_model = TBPartitionedFields(self.gui.current_db,
+                                   self.tb_cats_to_partition,
+                                   category_icons=self.gui.tags_view.model().category_custom_icons)
+        self.tb_categories_to_part_model.dataChanged.connect(self.changed_signal)
+        self.tb_cats_to_partition.setModel(self.tb_categories_to_part_model)
+        self.tb_partition_reset_button.clicked.connect(partial(reset_layout, self,
+                                                               model=self.tb_categories_to_part_model))
+        self.tb_partition_export_layout_button.clicked.connect(partial(export_layout, self,
+                                                                       model=self.tb_categories_to_part_model))
+        self.tb_partition_import_layout_button.clicked.connect(partial(import_layout, self,
+                                                                       model=self.tb_categories_to_part_model))
+
+    def lazy_initialize(self):
+        self.tb_categories_to_part_model.initialize()
+
+    def commit(self):
+        self.tb_categories_to_part_model.commit()
+        return ConfigWidgetBase.commit(self)
+
+
+

--- a/src/calibre/gui2/preferences/look_feel_tabs/tb_partitioning.ui
+++ b/src/calibre/gui2/preferences/look_feel_tabs/tb_partitioning.ui
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>1035</width>
+    <height>547</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_4">
+   <item>
+    <layout class="QGridLayout" name="gridLayout_10">
+     <item row="0" column="0">
+      <layout class="QFormLayout" name="formLayout">
+       <property name="fieldGrowthPolicy">
+        <enum>QFormLayout::ExpandingFieldsGrow</enum>
+       </property>
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_9">
+         <property name="text">
+          <string>&amp;Category partitioning method:</string>
+         </property>
+         <property name="buddy">
+          <cstring>opt_tags_browser_partition_method</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QComboBox" name="opt_tags_browser_partition_method">
+         <property name="toolTip">
+          <string>&lt;p&gt;Choose how Tag browser subcategories are displayed when
+there are more items than the limit. Select by first
+letter to see an A, B, C list. Choose partitioned to
+have a list of fixed-sized groups. Set to disabled
+if you never want subcategories&lt;/p&gt;</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_10">
+         <property name="text">
+          <string>Combine letters &amp;when fewer items than:</string>
+         </property>
+         <property name="buddy">
+          <cstring>opt_tags_browser_collapse_fl_at</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QSpinBox" name="opt_tags_browser_collapse_fl_at">
+         <property name="toolTip">
+          <string>&lt;p&gt;If collapsing by first letter, combine adjacent letters together if
+there are fewer items under a letter than specified here. If the partition method is
+not set to first letter, this value is ignored. Set to zero to disable.&lt;/p&gt;</string>
+         </property>
+         <property name="maximum">
+          <number>10000</number>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_10">
+         <property name="text">
+          <string>Co&amp;llapse when more items than:</string>
+         </property>
+         <property name="buddy">
+          <cstring>opt_tags_browser_collapse_at</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QSpinBox" name="opt_tags_browser_collapse_at">
+         <property name="toolTip">
+          <string>&lt;p&gt;If a Tag browser category has more than this number of items, it is divided
+up into subcategories. If the partition method is set to disable, this value is ignored.&lt;/p&gt;</string>
+         </property>
+         <property name="maximum">
+          <number>10000</number>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label">
+       <property name="toolTip">
+        <string>&lt;p&gt;Check the box for categories that are to
+be partitioned using the criteria above. Uncheck the box if you don't want to
+partition a category even if the number of items is larger than
+the value shown above. This option can be used to
+avoid collapsing hierarchical categories that have only
+a few top-level elements.&lt;/p&gt;</string>
+       </property>
+       <property name="text">
+        <string>Select categories to &amp;partition:</string>
+       </property>
+       <property name="buddy">
+        <cstring>tb_cats_to_partition</cstring>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QListView" name="tb_cats_to_partition">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>200</height>
+        </size>
+       </property>
+       <property name="alternatingRowColors">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <layout class="QHBoxLayout" name="horizontalLayout_41">
+       <item>
+        <widget class="QPushButton" name="tb_partition_reset_button">
+         <property name="toolTip">
+          <string>Click this button to reset the list to its default order.</string>
+         </property>
+         <property name="text">
+          <string>Reset list</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="tb_partition_import_layout_button">
+         <property name="toolTip">
+          <string>&lt;p&gt;Click this button to set the list to one
+previously exported. This could be useful if you have several libraries with
+similar structure and you want to use the same for each one.&lt;/p&gt;</string>
+         </property>
+         <property name="text">
+          <string>Import list</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="tb_partition_export_layout_button">
+         <property name="toolTip">
+          <string>&lt;p&gt;Click this button to write the current display
+settings to a file. This could be useful if you have several libraries with similar
+structure and you want to use the same for each one.&lt;/p&gt;</string>
+         </property>
+         <property name="text">
+          <string>Export list</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+</ui>

--- a/src/calibre/gui2/preferences/look_feel_tabs/tb_quickview.py
+++ b/src/calibre/gui2/preferences/look_feel_tabs/tb_quickview.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+
+
+__license__   = 'GPL v3'
+__copyright__ = '2025, Kovid Goyal <kovid@kovidgoyal.net>'
+__docformat__ = 'restructuredtext en'
+
+from functools import partial
+
+from calibre.gui2 import gprefs
+from calibre.gui2.actions.show_quickview import get_quickview_action_plugin
+from calibre.gui2.dialogs.quickview import get_qv_field_list
+from calibre.gui2.preferences import LazyConfigWidgetBase, ConfigWidgetBase
+from calibre.gui2.preferences.look_feel_tabs import DisplayedFields, move_field_down, move_field_up
+from calibre.gui2.preferences.look_feel_tabs.tb_quickview_ui import Ui_Form
+
+class QVDisplayedFields(DisplayedFields):  # {{{
+
+    def __init__(self, db, parent=None):
+        DisplayedFields.__init__(self, db, parent)
+
+    def initialize(self, use_defaults=False):
+        self.beginResetModel()
+        self.fields = [[x[0], x[1]] for x in
+                get_qv_field_list(self.db.field_metadata, use_defaults=use_defaults)]
+        self.endResetModel()
+        self.changed = True
+
+    def commit(self):
+        if self.changed:
+            self.db.new_api.set_pref('qv_display_fields', self.fields)
+
+# }}}
+
+
+class QuickviewTab(LazyConfigWidgetBase, Ui_Form):
+
+    def genesis(self, gui):
+        self.gui = gui
+        r = self.register
+
+        r('qv_respects_vls', gprefs)
+        r('qv_dclick_changes_column', gprefs)
+        r('qv_retkey_changes_column', gprefs)
+        r('qv_follows_column', gprefs)
+
+        self.qv_display_model = QVDisplayedFields(self.gui.current_db, self.qv_display_order)
+        self.qv_display_model.dataChanged.connect(self.changed_signal)
+        self.qv_display_order.setModel(self.qv_display_model)
+
+        mu = partial(move_field_up, self.qv_display_order, self.qv_display_model)
+        md = partial(move_field_down, self.qv_display_order, self.qv_display_model)
+        self.qv_display_order.set_movement_functions(mu, md)
+        self.qv_up_button.clicked.connect(mu)
+        self.qv_down_button.clicked.connect(md)
+
+    def lazy_initialize(self):
+        self.qv_display_model.initialize()
+
+    def restore_defaults(self):
+        ConfigWidgetBase.restore_defaults(self)
+        self.qv_display_model.restore_defaults()
+
+    def refresh_gui(self, gui):
+        qv = get_quickview_action_plugin()
+        if qv:
+            qv.refill_quickview()
+
+    def commit(self, *args):
+        rr = ConfigWidgetBase.commit(self, *args)
+        self.qv_display_model.commit()
+        return rr
+
+

--- a/src/calibre/gui2/preferences/look_feel_tabs/tb_quickview.ui
+++ b/src/calibre/gui2/preferences/look_feel_tabs/tb_quickview.ui
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="cover_browser_tab">
+  <attribute name="icon">
+   <iconset resource="../../../../resources/images.qrc">
+    <normaloff>:/images/cover_flow.png</normaloff>:/images/cover_flow.png</iconset>
+  </attribute>
+  <layout class="QGridLayout" name="gridLayout_122">
+   <item row="1" column="0" colspan="2">
+    <layout class="QGridLayout" name="gridLayout_122">
+     <item row="2" column="0">
+      <widget class="QCheckBox" name="opt_qv_respects_vls">
+       <property name="toolTip">
+        <string>&lt;p&gt;Check this box to make Quickview show books only in the
+current Virtual library. If unchecked, Quickview ignores Virtual libraries. If
+unchecked then only row changes are taken into account.&lt;/p&gt;</string>
+       </property>
+       <property name="text">
+        <string>&amp;Apply Virtual libraries</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QCheckBox" name="opt_qv_follows_column">
+       <property name="toolTip">
+        <string>&lt;p&gt;Check this box to make Quickview change the column being examined
+when the column in the book list is changed using the cursor arrow keys&lt;/p&gt;</string>
+       </property>
+       <property name="text">
+        <string>&amp;Change Quickview item when book list column changes</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QCheckBox" name="opt_qv_retkey_changes_column">
+       <property name="toolTip">
+        <string>&lt;p&gt;Pressing Enter in a cell changes both the book and the
+column being examined (the left-hand panel)&lt;/p&gt;</string>
+       </property>
+       <property name="text">
+        <string>&amp;Pressing Enter changes the examined column</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QCheckBox" name="opt_qv_dclick_changes_column">
+       <property name="toolTip">
+        <string>&lt;p&gt;Double-clicking in a cell changes both the book and the
+column being examined (the left-hand panel)&lt;/p&gt;</string>
+       </property>
+       <property name="text">
+        <string>&amp;Double click changes examined column</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="3" column="0" rowspan="2">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Select columns to display</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_32">
+      <item row="0" column="1">
+       <widget class="QToolButton" name="qv_up_button">
+        <property name="toolTip">
+         <string>Move up. Keyboard shortcut: Ctrl-Up arrow</string>
+        </property>
+        <property name="icon">
+         <iconset resource="../../../../resources/images.qrc">
+          <normaloff>:/images/arrow-up.png</normaloff>:/images/arrow-up.png</iconset>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QToolButton" name="qv_down_button">
+        <property name="toolTip">
+         <string>Move down. Keyboard shortcut: Ctrl-Down arrow</string>
+        </property>
+        <property name="icon">
+         <iconset resource="../../../../resources/images.qrc">
+          <normaloff>:/images/arrow-down.png</normaloff>:/images/arrow-down.png</iconset>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0" rowspan="3">
+       <widget class="ListViewWithMoveByKeyPress" name="qv_display_order">
+        <property name="alternatingRowColors">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <spacer name="verticalSpacer_5">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ListViewWithMoveByKeyPress</class>
+   <extends>QListView</extends>
+   <header>calibre/gui2/preferences.h</header>
+  </customwidget>
+  <customwidget>
+   <class>ListWidgetWithMoveByKeyPress</class>
+   <extends>QListWidget</extends>
+   <header>calibre/gui2/preferences.h</header>
+  </customwidget>
+ </customwidgets>
+
+</ui>

--- a/src/calibre/gui2/preferences/main.py
+++ b/src/calibre/gui2/preferences/main.py
@@ -418,6 +418,7 @@ class Preferences(QDialog):
         return self.close_after_initial or (must_restart and rc) or do_restart
 
     def restore_defaults(self, *args):
+        self.showing_widget.do_on_child_tabs('restore_defaults')
         self.showing_widget.restore_defaults()
 
     def on_shutdown(self):


### PR DESCRIPTION
- Add infrastructure for automatic handling of lazy operations (now lazy_initialize). There is a new class LazyConfigWidgetBase that supports the lazy operations. It is a drop-in replacement for ConfigWidgetBase
- Convert tab widgets: tb display, tb_partitioning, quickview

Over time I will convert other look & feel tabs, if for no other reason than to speed up opening that set of preferences.