### PR TITLE
Option to show only rules for category in current library

### DIFF
--- a/src/calibre/gui2/preferences/look_feel_tabs/tb_icon_rules.py
+++ b/src/calibre/gui2/preferences/look_feel_tabs/tb_icon_rules.py
@@ -354,6 +354,7 @@ class TbIconRulesTab(LazyConfigWidgetBase, Ui_Form):
     def populate_content(self):
         field_metadata = self.gui.current_db.field_metadata
         category_icons = self.gui.tags_view.model().category_custom_icons
+        only_current_library = self.show_only_current_library.isChecked()
         v = gprefs['tags_browser_value_icons']
         row = 0
 
@@ -363,11 +364,15 @@ class TbIconRulesTab(LazyConfigWidgetBase, Ui_Form):
         for category,vdict in v.items():
             if category in field_metadata:
                 display_name = field_metadata[category]['name']
-            elif self.show_only_current_library.isChecked():
+                all_values = self.gui.current_db.new_api.all_field_names(category)
+            elif only_current_library:
                 continue
             else:
                 display_name = category.removeprefix('#')
+                all_values = ()
             for item_value in vdict:
+                if only_current_library and item_value != TEMPLATE_ICON_INDICATOR and item_value not in all_values:
+                    continue
                 t.setRowCount(row + 1)
                 d = v[category][item_value]
                 t.setItem(row, DELETED_COLUMN, StateTableWidgetItem(''))

--- a/src/calibre/gui2/preferences/look_feel_tabs/tb_icon_rules.py
+++ b/src/calibre/gui2/preferences/look_feel_tabs/tb_icon_rules.py
@@ -288,6 +288,8 @@ class TbIconRulesTab(LazyConfigWidgetBase, Ui_Form):
         r('tag_browser_show_category_icons', gprefs)
         r('tag_browser_show_value_icons', gprefs)
 
+        self.show_only_current_library.setChecked(gprefs.get('tag_browser_rules_show_only_current_library', False))
+
         self.rules_table.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectItems)
         self.rules_table.setColumnCount(HEADER_SECTION_COUNT)
         self.rules_table.setHorizontalHeaderLabels(('', _('Category'), _('Value'), '',
@@ -330,6 +332,7 @@ class TbIconRulesTab(LazyConfigWidgetBase, Ui_Form):
         self.delete_button.clicked.connect(self.delete_rule)
         self.edit_button.clicked.connect(self.edit_column)
         self.undo_button.clicked.connect(self.undo_changes)
+        self.show_only_current_library.stateChanged.connect(self.change_filter_library)
 
         self.tb_icon_rules_groupbox.setContentsMargins(0, 0, 0, 0)
         self.tb_icon_rules_gridlayout.setContentsMargins(2, 2, 2, 2)
@@ -340,19 +343,28 @@ class TbIconRulesTab(LazyConfigWidgetBase, Ui_Form):
             pass
 
     def lazy_initialize(self):
+        self.rules_table.setItemDelegateForColumn(ICON_COLUMN, IconColumnDelegate(self, self.rules_table, self.changed_signal))
+        self.rules_table.setItemDelegateForColumn(FOR_CHILDREN_COLUMN,
+                                   ChildrenColumnDelegate(self, self.rules_table, self.changed_signal))
+        self.populate_content()
+        self.section_order = [0, 1, 1, 0, 0, 0, 0]
+        self.do_sort(VALUE_COLUMN)
+        self.do_sort(CATEGORY_COLUMN)
+
+    def populate_content(self):
         field_metadata = self.gui.current_db.field_metadata
         category_icons = self.gui.tags_view.model().category_custom_icons
         v = gprefs['tags_browser_value_icons']
         row = 0
 
         t = self.rules_table
-        t.setItemDelegateForColumn(ICON_COLUMN, IconColumnDelegate(self, self.rules_table, self.changed_signal))
-        t.setItemDelegateForColumn(FOR_CHILDREN_COLUMN,
-                                   ChildrenColumnDelegate(self, self.rules_table, self.changed_signal))
+        t.clearContents()
 
         for category,vdict in v.items():
             if category in field_metadata:
                 display_name = field_metadata[category]['name']
+            elif self.show_only_current_library.isChecked():
+                continue
             else:
                 display_name = category.removeprefix('#')
             for item_value in vdict:
@@ -368,10 +380,6 @@ class TbIconRulesTab(LazyConfigWidgetBase, Ui_Form):
                 item = ChildrenTableWidgetItem(d[1], item_value, t)
                 t.setItem(row, FOR_CHILDREN_COLUMN, item)
                 row += 1
-
-        self.section_order = [0, 1, 1, 0, 0, 0, 0]
-        self.do_sort(VALUE_COLUMN)
-        self.do_sort(CATEGORY_COLUMN)
 
     def show_context_menu(self, point):
         item = self.rules_table.itemAt(point)
@@ -415,6 +423,10 @@ class TbIconRulesTab(LazyConfigWidgetBase, Ui_Form):
             ev.accept()
             return
         return super().keyPressEvent(ev)
+
+    def change_filter_library(self, state):
+        gprefs['tag_browser_rules_show_only_current_library'] = self.show_only_current_library.isChecked()
+        self.populate_content()
 
     def undo_changes(self):
         idx = self.rules_table.currentIndex()
@@ -484,6 +496,7 @@ class TbIconRulesTab(LazyConfigWidgetBase, Ui_Form):
                 else:
                     self.rules_table.setColumnWidth(c, w)
                 self.table_column_widths.append(self.rules_table.columnWidth(c))
+
         gprefs['tag_browser_rules_dialog_table_widths'] = self.table_column_widths
 
     def do_sort(self, section):

--- a/src/calibre/gui2/preferences/look_feel_tabs/tb_icon_rules.py
+++ b/src/calibre/gui2/preferences/look_feel_tabs/tb_icon_rules.py
@@ -348,6 +348,7 @@ class TbIconRulesTab(LazyConfigWidgetBase, Ui_Form):
                                    ChildrenColumnDelegate(self, self.rules_table, self.changed_signal))
         self.populate_content()
         self.section_order = [0, 1, 1, 0, 0, 0, 0]
+        self.last_section_sorted = 0
         self.do_sort(VALUE_COLUMN)
         self.do_sort(CATEGORY_COLUMN)
 
@@ -432,6 +433,7 @@ class TbIconRulesTab(LazyConfigWidgetBase, Ui_Form):
     def change_filter_library(self, state):
         gprefs['tag_browser_rules_show_only_current_library'] = self.show_only_current_library.isChecked()
         self.populate_content()
+        self.rules_table.sortByColumn(self.last_section_sorted, Qt.SortOrder(self.section_order[self.last_section_sorted]))
 
     def undo_changes(self):
         idx = self.rules_table.currentIndex()
@@ -507,6 +509,7 @@ class TbIconRulesTab(LazyConfigWidgetBase, Ui_Form):
     def do_sort(self, section):
         order = 1 - self.section_order[section]
         self.section_order[section] = order
+        self.last_section_sorted = section
         self.rules_table.sortByColumn(section, Qt.SortOrder(order))
 
     def commit(self):

--- a/src/calibre/gui2/preferences/look_feel_tabs/tb_icon_rules.ui
+++ b/src/calibre/gui2/preferences/look_feel_tabs/tb_icon_rules.ui
@@ -43,7 +43,8 @@
         <property name="text">
          <string>&lt;p&gt;View all the defined value icon rules, including template rules.
 Rules are defined and edited in the Tag browser context menus. Rules can be deleted in
-this dialog using the button, the delete key, or the context menu.&lt;/p&gt;</string>
+this dialog using the button, the delete key, or the context menu. The icon value rules
+are defined per-user, not per-library.&lt;/p&gt;</string>
         </property>
         <property name="wordWrap">
          <bool>true</bool>

--- a/src/calibre/gui2/preferences/look_feel_tabs/tb_icon_rules.ui
+++ b/src/calibre/gui2/preferences/look_feel_tabs/tb_icon_rules.ui
@@ -54,7 +54,7 @@ are defined per-user, not per-library.&lt;/p&gt;</string>
       <item row="1" column="0" colspan="2">
       <widget class="QCheckBox" name="show_only_current_library">
        <property name="text">
-        <string>Show only category available in the current library</string>
+        <string>Show only categories and values available in the current library</string>
        </property>
       </widget>
       </item>

--- a/src/calibre/gui2/preferences/look_feel_tabs/tb_icon_rules.ui
+++ b/src/calibre/gui2/preferences/look_feel_tabs/tb_icon_rules.ui
@@ -51,10 +51,17 @@ are defined per-user, not per-library.&lt;/p&gt;</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
+      <item row="1" column="0" colspan="2">
+      <widget class="QCheckBox" name="show_only_current_library">
+       <property name="text">
+        <string>Show only category available in the current library</string>
+       </property>
+      </widget>
+      </item>
+      <item row="2" column="1">
        <widget class="QTableWidget" name="rules_table"/>
       </item>
-      <item row="1" column="0">
+      <item row="2" column="0">
        <layout class="QVBoxLayout">
         <item>
          <widget class="QToolButton" name="delete_button">


### PR DESCRIPTION
Add a option to show only rules for category available in the current library.

Also add a note in the ui about that the icon value rules are defined per-user, not per-library.