### PR TITLE
ffmpeg plugin: correct the version check for avcodec_get_supported_config

### DIFF
--- a/src/calibre/utils/ffmpeg.c
+++ b/src/calibre/utils/ffmpeg.c
@@ -240,7 +240,7 @@ open_output_file(Transcoder *t) {
     av_channel_layout_default(&t->enc_ctx->ch_layout, t->dec_ctx->ch_layout.nb_channels);
     t->enc_ctx->sample_rate = t->dec_ctx->sample_rate;
     int ret;
-#if LIBAVCODEC_VERSION_MAJOR >= 61
+#if LIBAVCODEC_VERSION_MAJOR >= 61 && LIBAVCODEC_VERSION_MINOR >= 14
     const enum AVSampleFormat *sample_fmts = NULL;
     ret = avcodec_get_supported_config(t->dec_ctx, output_codec, AV_CODEC_CONFIG_SAMPLE_FORMAT, 0, (const void**)&sample_fmts, NULL);
     t->enc_ctx->sample_fmt = (ret >= 0 && sample_fmts) ? sample_fmts[0] : t->dec_ctx->sample_fmt;


### PR DESCRIPTION
It was added in ffmpeg 7.1 at avcodec API (61, 14) but we were checking for and using it at API 61, which matched in ffmpeg 7.0 and failed to compile.

Fixes: 3e1a9ec3e704c98b19fd870728d0e3fe1b60126b