### PR TITLE
The template functions for the new custom column search template …

### DIFF
--- a/src/calibre/ebooks/metadata/book/render.py
+++ b/src/calibre/ebooks/metadata/book/render.py
@@ -70,7 +70,8 @@ def search_action_with_data(search_term, value, book_id, field=None, **k):
 def web_search_link(template, mi, value):
     formatter = SafeFormat()
     iv = str(value)
-    mi.set('item_value', qquote(iv, True))
+    mi.set('item_value', iv)
+    mi.set('item_value_quoted', qquote(iv, True))
     mi.set('item_value_no_plus', qquote(iv, False))
     u = formatter.safe_format(template, mi, 'BOOK DETAILS WEB LINK', mi)
     if u:


### PR DESCRIPTION
…feature. There are 4 new functions:

* make_url(path, [query_name, query_value]+). This is the easiest to use.
* make_url_extended(...). This gives the user more control over constructing the URL, including user-built query strings.
* query_string([query_name, query_value, how_to_encode]+). Constructs a query string, giving more control over how the values are encoded.
* encode_for_url(value, use_plus). URL-encodes a single value.

As you said earlier, most people will use make_url(). However, I have seen cases where query values must be inserted into the path, and make_url_extended() helps with that. I have also seen cases where query args must not be encoded. And so on. These 4 functions plus other text functions like re() let the user do whatever is necessary.

Note that 'item_value' is no longer encoded. There are two more values available: 'item_value_quoted' and 'item_value_no_plus'. I'm not convinced these are particularly useful but it doesn't hurt anything to have them.