### PR TITLE
Move "Grid rule editor" to its own widget

### DIFF
--- a/src/calibre/gui2/preferences/look_feel_tabs/__init__.py
+++ b/src/calibre/gui2/preferences/look_feel_tabs/__init__.py
@@ -254,6 +254,10 @@ class ColumnIconRules(LazyEditRulesBase):
     rule_set_name = 'column_icon_rules'
 
 
+class GridEmblemnRules(LazyEditRulesBase):
+    rule_set_name = 'cover_grid_icon_rules'
+
+
 def export_layout(in_widget, model=None):
     filename = choose_save_file(in_widget, 'look_feel_prefs_import_export_field_list',
             _('Save column list to file'),

--- a/src/calibre/gui2/preferences/look_feel_tabs/cover_grid.ui
+++ b/src/calibre/gui2/preferences/look_feel_tabs/cover_grid.ui
@@ -271,7 +271,7 @@ A value of zero means calculate automatically.</string>
      </item>
     </layout>
    </widget>
-   <widget class="QWidget" name="emblems_tab">
+   <widget class="GridEmblemnRules" name="grid_rules">
     <attribute name="title">
      <string>&amp;Emblems</string>
     </attribute>
@@ -412,6 +412,18 @@ A value of zero means calculate automatically.</string>
     </layout>
    </widget>
   </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ConfigWidgetBase</class>
+   <extends>QWidget</extends>
+   <header>calibre/gui2/preferences/look_feel_tabs.h</header>
+  </customwidget>
+  <customwidget>
+   <class>GridEmblemnRules</class>
+   <extends>ConfigWidgetBase</extends>
+   <header>calibre/gui2/preferences/look_feel_tabs.h</header>
+  </customwidget>
+ </customwidgets>
  <resources>
  <include location="../../../../../resources/images.qrc"/>
  </resources>


### PR DESCRIPTION
Move also the "Grid rule editor" to its own widget, so that every rule editors use the same logic.