### PR TITLE
Add a note to the L&F / Book Details custom author url tooltip that …

### DIFF
--- a/src/calibre/gui2/preferences/look_feel_tabs/__init__.py
+++ b/src/calibre/gui2/preferences/look_feel_tabs/__init__.py
@@ -66,7 +66,8 @@ class DefaultAuthorLink(QWidget):
         u.setToolTip(_(
             'Enter the URL to search. It should contain the string {0}'
             '\nwhich will be replaced by the author name. For example,'
-            '\n{1}').format('{author}', 'https://en.wikipedia.org/w/index.php?search={author}'))
+            '\n{1}. Note: the author name is already URL-encoded.').format(
+                        '{author}', 'https://en.wikipedia.org/w/index.php?search={author}'))
         u.textChanged.connect(self.changed_signal)
         u.setPlaceholderText(_('Enter the URL'))
         ul.addWidget(u)

--- a/src/calibre/gui2/tag_browser/view.py
+++ b/src/calibre/gui2/tag_browser/view.py
@@ -713,7 +713,8 @@ class TagsView(QTreeView):  # {{{
                         self.recount()
                     return
                 icon_file_name, for_children = extra if extra is not None else (None, None)
-                item_val, desired_file_name = make_icon_name(key, index, self._model.get_node(index).tag.id)
+                item_val, desired_file_name = make_icon_name(key, index,
+                                                 None if index is None else self._model.get_node(index).tag.id)
                 if icon_file_name is None:
                     # User wants to specify a specific icon
                     try:


### PR DESCRIPTION
…the author is already URL-encoded.