### PR TITLE
Add option in book details to suppress author search links.

### DIFF
--- a/src/calibre/db/constants.py
+++ b/src/calibre/db/constants.py
@@ -15,6 +15,7 @@ DATA_FILE_PATTERN = f'{DATA_DIR_NAME}/**/*'
 BOOK_ID_PATH_TEMPLATE = ' ({})'
 RESOURCE_URL_SCHEME = 'calres'
 TEMPLATE_ICON_INDICATOR = ' template '  # Item values cannot start or end with space
+NO_SEARCH_LINK = '*no_link*'
 
 
 @dataclass

--- a/src/calibre/ebooks/metadata/book/render.py
+++ b/src/calibre/ebooks/metadata/book/render.py
@@ -10,7 +10,7 @@ from functools import partial
 
 from calibre import force_unicode, prepare_string_for_xml
 from calibre.constants import filesystem_encoding
-from calibre.db.constants import DATA_DIR_NAME
+from calibre.db.constants import DATA_DIR_NAME, NO_SEARCH_LINK
 from calibre.ebooks.metadata import fmt_sidx, rating_to_stars
 from calibre.ebooks.metadata.book.formatter import SafeFormat
 from calibre.ebooks.metadata.search_internet import DEFAULT_AUTHOR_SOURCE, name_for, qquote, url_for_author_search, url_for_book_search
@@ -126,7 +126,9 @@ def author_search_href(which, title=None, author=None):
 
 def render_author_link(default_author_link, author, book_title=None, author_sort=None):
     book_title = book_title or ''
-    if default_author_link.startswith('search-'):
+    if default_author_link == NO_SEARCH_LINK:
+        return '',''
+    elif default_author_link.startswith('search-'):
         which_src = default_author_link.partition('-')[2]
         link, lt = author_search_href(which_src, title=book_title, author=author)
     else:

--- a/src/calibre/gui2/preferences/look_feel_tabs/__init__.py
+++ b/src/calibre/gui2/preferences/look_feel_tabs/__init__.py
@@ -23,6 +23,7 @@ from qt.core import (
     pyqtSignal,
 )
 
+from calibre.db.constants import NO_SEARCH_LINK
 from calibre.ebooks.metadata.book.render import DEFAULT_AUTHOR_LINK
 from calibre.ebooks.metadata.search_internet import qquote
 from calibre.gui2 import choose_files, choose_save_file, error_dialog
@@ -57,6 +58,7 @@ class DefaultAuthorLink(QWidget):
                 (_('Search for the book on Goodreads'), 'search-goodreads-book'),
                 (_('Search for the book on Amazon'), 'search-amzn-book'),
                 (_('Search for the book on Google Books'), 'search-google-book'),
+                (_('No author search URL'), NO_SEARCH_LINK),
                 (_('Use a custom search URL'), 'url'),
         ]:
             c.addItem(text, data)

--- a/src/calibre/srv/code.py
+++ b/src/calibre/srv/code.py
@@ -14,6 +14,7 @@ from threading import Lock
 from calibre import as_unicode
 from calibre.constants import in_develop_mode
 from calibre.customize.ui import available_input_formats
+from calibre.db.constants import NO_SEARCH_LINK
 from calibre.db.view import sanitize_sort_field_name
 from calibre.ebooks.metadata.book.render import resolve_default_author_link
 from calibre.srv.ajax import search_result
@@ -175,6 +176,8 @@ def basic_interface_data(ctx, rd):
         'lang_code_for_user_manual': lang_code_for_user_manual(),
         'default_author_link': resolve_default_author_link(get_gpref('default_author_link')),
     }
+    if ans['default_author_link'] == NO_SEARCH_LINK:
+        ans['default_author_link'] = ''
     ans['library_map'], ans['default_library_id'] = ctx.library_info(rd)
     if ans['username']:
         ans['recently_read_by_user'] = tuple(


### PR DESCRIPTION
Question: should the constant be in calibre.constants instead of calibre.db.constants?