### PR TITLE
Refactor L&F / Tag browser / icon rules editor. Allow adding new …

### DIFF
--- a/src/calibre/gui2/preferences/look_feel.ui
+++ b/src/calibre/gui2/preferences/look_feel.ui
@@ -80,7 +80,7 @@
       </widget>
       <widget class="TbIconRulesTab" name="tb_icon_browser_tab">
        <attribute name="title">
-        <string>Val&amp;ue icon rules viewer</string>
+        <string>Val&amp;ue icon rules</string>
        </attribute>
       </widget>
      </widget>

--- a/src/calibre/gui2/preferences/look_feel_tabs/tb_icon_rules.ui
+++ b/src/calibre/gui2/preferences/look_feel_tabs/tb_icon_rules.ui
@@ -89,6 +89,18 @@ Otherwise all edits would be lost.</string>
           </property>
          </widget>
         </item>
+        <item>
+         <widget class="QToolButton" name="add_button">
+          <property name="icon">
+          <iconset resource="../../../../../resources/images.qrc">
+            <normaloff>:/images/plus.png</normaloff>:/images/plus.png</iconset>
+          </property>
+          <property name="toolTip">
+           <string>Add a new rule. The rule is added immediately. If you decide you don't
+want it then you must delete it.</string>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
      </layout>


### PR DESCRIPTION
…rules. To avoid lots of problems don't allow changing lookup names and values for existing rules. The user can use delete & add to fix "dead" rules.