### PR TITLE
clarify wording

### DIFF
--- a/src/calibre/ebooks/conversion/plumber.py
+++ b/src/calibre/ebooks/conversion/plumber.py
@@ -422,7 +422,7 @@ OptionRecommendation(name='remove_fake_margins',
 OptionRecommendation(name='add_alt_text_to_img',
     recommended_value=False, level=OptionRecommendation.LOW,
     help=_('When an <img> tag has no alt attribute, check the associated image file for metadata that specifies alternate text, and'
-            ' use it to fill in the alt attribute. The alt attribute is used by screen readers for assisting the visually challenged.')
+            ' use it to fill in the alt attribute. The alt attribute is used by screen readers for assisting blind people.')
 ),
 
 OptionRecommendation(name='margin_top',


### PR DESCRIPTION
Phrases like "xxx challenged" should be avoided when speaking about disabled people.

see https://dragonscave.space/@jscholes/114044327869174785 for blind people noticing this case and https://www.cdrnys.org/blog/disability-dialogue/the-disability-dialogue-4-disability-euphemisms-that-need-to-bite-the-dust for an explanation why it should be avoided.