### PR TITLE
Remove git credentials after checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
               uses: actions/checkout@v3
               with:
                 fetch-depth: 10
+                persist-credentials: false
 
             - name: Set up Python
               uses: actions/setup-python@v3

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -24,6 +24,7 @@ jobs:
               uses: actions/checkout@master
               with:
                 fetch-depth: 2
+                persist-credentials: false
 
             - name: Install calibre dependencies
               run: setup/arch-ci.sh


### PR DESCRIPTION
This PR removes Git credentials/SSH keys after checkout as a security precaution by setting `persist-credentials` to `false`. They are not used after the initial checkout, and this stops them from accidentally leaking through a script; see [`actions/checkout` documentation](https://github.com/actions/checkout?tab=readme-ov-file#checkout-v4).