### PR TITLE
Closing in SIGTERM/SIGINT.

### DIFF
--- a/src/calibre/gui2/viewer/main.py
+++ b/src/calibre/gui2/viewer/main.py
@@ -196,6 +196,10 @@ def main(args=sys.argv):
                 pass
     args = processed_args
     app = Application(args, override_program_name=override, windows_app_uid=VIEWER_APP_UID)
+    import signal
+    def interrupt(a, b):
+        app.quit()
+    signal.signal(signal.SIGINT, interrupt)
     from calibre.utils.webengine import setup_default_profile
     setup_default_profile()
 


### PR DESCRIPTION
I do not know if it can be done in this way. (I do not understand the implications and why you catched this signals to start with)

But I think complying with SIGINT and SIGTERM is minimum politeness in Linux with the terminal users.

Currently the situation is very bad, Calibre acts almost like a malicious program that refuses to be killed under any circumstance unless you stop it in the GUI.

If there is an important reason why Calibre cannot die that easily then precisely for that reason you should gracesfully catch SIGINT and SIGTERM, because you can handle them.

The user is going to send SIGKILL that you cannot handle if you refuse to die and that's is going to be a lot more damaging.

References https://bugs.launchpad.net/calibre/+bug/2099777 
