### PR TITLE
Clean unused variable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,7 @@ ignore = [
     'E402', 'E722', 'E741',
     'UP012', 'UP030', 'UP038', 'C413', 'C420', 'PIE790', 'ISC003',
     'RUF001', 'RUF002', 'RUF003', 'RUF005', 'RUF012', 'RUF013', 'RUF015', 'RUF031', 'RUF100',
-    'F841',  # because in preview, unused tuple unpacking variable that not use dummy syntax (prefix '_' underscore)
-             # raise error 'unused-variable', sigh (https://github.com/astral-sh/ruff/issues/8884)
+    'RUF059',  # unused unpacked variable
 ]
 select = [
     'E', 'F', 'I', 'W', 'INT',

--- a/recipes/nytimes.recipe
+++ b/recipes/nytimes.recipe
@@ -190,7 +190,6 @@ class NewYorkTimes(BasicNewsRecipe):
         script = type(u'')(script)
         json_data = script[script.find('{'):script.rfind(';')].strip().rstrip(';')
         data = json.loads(json_data.replace(':undefined', ':null'))['initialState']
-        containers, sections = {}, {}
         article_map = {}
         sections = []
         for key in data:

--- a/recipes/nytimes_sub.recipe
+++ b/recipes/nytimes_sub.recipe
@@ -190,7 +190,6 @@ class NewYorkTimes(BasicNewsRecipe):
         script = type(u'')(script)
         json_data = script[script.find('{'):script.rfind(';')].strip().rstrip(';')
         data = json.loads(json_data.replace(':undefined', ':null'))['initialState']
-        containers, sections = {}, {}
         article_map = {}
         sections = []
         for key in data:

--- a/src/calibre/devices/kobo/driver.py
+++ b/src/calibre/devices/kobo/driver.py
@@ -2855,7 +2855,7 @@ class KOBOTOUCH(KOBO):
         if self.isTolinoDevice() and self.dbversion >= 191:
             ImageID_split = ImageID.rsplit('.', 1)
             ImageID_split[0] = ImageID_split[0].replace('.', '_')
-            ImageId = '.'.join(ImageID_split)
+            ImageID = '.'.join(ImageID_split)
         else:
             ImageID = ImageID.replace('.', '_')
         return ImageID

--- a/src/calibre/ebooks/oeb/polish/kepubify.py
+++ b/src/calibre/ebooks/oeb/polish/kepubify.py
@@ -630,9 +630,8 @@ h1, h2, h3, h4, h5, h6, td {{
 
 
 def profile():
-    from calibre.ptempfile import TemporaryDirectory
     path = sys.argv[-1]
-    with TemporaryDirectory() as tdir, Profiler():
+    with Profiler():
         kepubify_path(path, max_workers=1)
 
 

--- a/src/calibre/gui2/dialogs/connect_to_folder.py
+++ b/src/calibre/gui2/dialogs/connect_to_folder.py
@@ -69,8 +69,6 @@ class Model(QStandardItemModel):
         for cls in usbms_plugins():
             for model in cls.model_metadata():
                 man_map.setdefault(model.manufacturer_name, []).append(model)
-        lcd = gprefs.get('last_connected_folder_as_device', None)
-        selected_device = None
         for manufacturer in sorted(man_map, key=primary_sort_key):
             devs = man_map[manufacturer]
             m = QStandardItem(manufacturer)
@@ -82,8 +80,6 @@ class Model(QStandardItemModel):
                 i.setData(dev)
                 i.setFlags(i.flags() | Qt.ItemFlag.ItemNeverHasChildren)
                 m.appendRow(i)
-                if dev.settings_key == lcd:
-                    selected_device = i
 
     def itermodels(self):
         root = self.invisibleRootItem()

--- a/src/calibre/srv/code.py
+++ b/src/calibre/srv/code.py
@@ -438,7 +438,6 @@ def web_search(ctx, rd, book_id, field, item_val):
     with db.safe_read_lock:
         if not ctx.has_id(rd, db, book_id):
             raise BookNotFound(book_id, db)
-        mi = db.get_metadata(book_id, get_cover=False)
         url, tooltip = web_search_link(db, book_id, field, item_val)
         if url:
             raise HTTPTempRedirect(url)


### PR DESCRIPTION
ruff 0.9.10 fix the issue with the unused unpacked variable which forces to completly hide F841 "unused variable", by spliting this behavior into a other rule. `pyproject.toml` updated and code cleaned accordingly.