### PR TITLE
When renaming items, serialize item names before writing to the db. …

### DIFF
--- a/src/calibre/db/tables.py
+++ b/src/calibre/db/tables.py
@@ -515,7 +515,8 @@ class ManyToManyTable(ManyToOneTable):
         if existing_item is None or existing_item == item_id:
             # A simple rename will do the trick
             self.id_map[item_id] = new_name
-            db.execute(f'UPDATE {table} SET {col}=? WHERE id=?', (new_name, item_id))
+            nn = self.serialize(new_name) if self.serialize else new_name
+            db.execute(f'UPDATE {table} SET {col}=? WHERE id=?', (nn, item_id))
         else:
             # We have to replace
             new_id = existing_item


### PR DESCRIPTION
…This ensures author "B, A" is written as "B| A",

As far as I can tell this problem has existed forever. Renaming an author containing a comma wrote the name to the db with the comma, not the |. Result: table.item_ids_for_names() fails because the db doesn't contain the serialized value. I wonder how many people have dbs with "bad" authors in them?

Attempting to edit/create a note for an author exposes the problem.

At least it is easily fixable once this change is released. Simply rename the author to itself.