### PR TITLE
Fix follow-up typos

### DIFF
--- a/resources/templates/kobo.js
+++ b/resources/templates/kobo.js
@@ -90,7 +90,7 @@ function setupBookColumns()
 function paginate(tagId)
 {
 	// Get the height of the page. We do this only once. In setupBookColumns we compare this
-	// value to the height of the window and then decide wether to force the page count to one.
+	// value to the height of the window and then decide whether to force the page count to one.
 	if (gClientHeight == undefined) {
 		gClientHeight = document.getElementById('book-columns').clientHeight;
 	}

--- a/src/calibre/gui2/store/__init__.py
+++ b/src/calibre/gui2/store/__init__.py
@@ -38,7 +38,7 @@ class StorePlugin:  # {{{
 
     Plugin authors can use affiliate programs within their plugin. The
     distribution of money earned from a store plugin is 70/30. 70% going
-    to the pluin author / maintainer and 30% going to the calibre project.
+    to the plugin author / maintainer and 30% going to the calibre project.
 
     The easiest way to handle affiliate money payouts is to randomly select
     between the author's affiliate id and calibre's affiliate id so that

--- a/src/pyj/popups.pyj
+++ b/src/pyj/popups.pyj
@@ -46,7 +46,7 @@ def create_popup(parent, idprefix):
     popup_count += 1
     pid = (idprefix or 'popup') + '-' + popup_count
     # Position has to be fixed so that setting style.top/style.bottom works in
-    # viewport co-ordinates
+    # viewport coordinates
     div = E.div(id=pid, style='display: none; position: fixed; z-index: {}'.format(POPUP_Z_INDEX))
     parent = parent or document.body
     parent.appendChild(div)

--- a/src/pyj/read_book/cfi.pyj
+++ b/src/pyj/read_book/cfi.pyj
@@ -19,7 +19,7 @@ from __python__ import hash_literals
 #    at_current(): Returns the CFI corresponding to the current viewport scroll location
 #
 #    scroll_to(cfi): which scrolls the browser to a point corresponding to the
-#                    given cfi, and returns the x and y co-ordinates of the point.
+#                    given cfi, and returns the x and y coordinates of the point.
 
 from read_book.viewport import scroll_viewport, rem_size
 
@@ -507,7 +507,7 @@ def sort_cfis(array_of_cfis):
 # }}}
 
 def at(x, y, doc):  # {{{
-    # x, y are in viewport co-ordinates
+    # x, y are in viewport coordinates
     doc = doc or window.document
     cdoc = doc
     target = None

--- a/src/pyj/read_book/viewport.pyj
+++ b/src/pyj/read_book/viewport.pyj
@@ -164,8 +164,8 @@ class ScrollViewport:
     # Assure that the viewport position returned is corrected for the RTL
     # mode of ScrollViewport.
     def viewport_to_document(self, x, y, doc):
-        # Convert x, y from the viewport (window) co-ordinate system to the
-        # document (body) co-ordinate system
+        # Convert x, y from the viewport (window) coordinate system to the
+        # document (body) coordinate system
         doc = doc or window.document
         topdoc = window.document
         while doc is not topdoc and doc.defaultView:


### PR DESCRIPTION
Found via `codespell -q 3 -S "*.svg,./Changelog.*,./recipes,./resources/dictionaries,./src/unicode_names/names.h" -L alo,ans,bootup,clen,fo,lokales,nam,nd,oclock,pard,re-use,re-used,ro,secnd,som,succeded,te,ue,vailable`