### PR TITLE
Update nzz_ger.recipe

### DIFF
--- a/recipes/nzz_ger.recipe
+++ b/recipes/nzz_ger.recipe
@@ -12,7 +12,7 @@ class Nzz(BasicNewsRecipe):
     description = 'Neue Zürcher Zeitung'
     publisher = 'Neue Zürcher Zeitung'
     category = 'news, politics'
-    oldest_article = 30
+    oldest_article = 7
     max_articles_per_feed = 15
     language = 'de'
     no_stylesheets = True

--- a/recipes/nzz_ger.recipe
+++ b/recipes/nzz_ger.recipe
@@ -32,6 +32,7 @@ class Nzz(BasicNewsRecipe):
         dict(name='figcaption', attrs={'class': 'articlecomponent__description'}),
         dict(name='div', attrs={'class': 'nzzinteraction'}),
         dict(name='section', attrs={'class': 'nzzinteraction'}),
+        dict(name='div', attrs={'class': 'disabled-overlay'}),
     ]
 
     remove_attributes = ['style', 'font', 'class']


### PR DESCRIPTION
- Avoid annoying "Make sure JavaScript is enabled" paragraphs by removing `div` tags of `class="disabled-overlay"`
- Set the default value of the `oldest_article` attribute to 7 instead of 30 to reduce the size of the output file