### PR TITLE
Disable GPU when running headless

### DIFF
--- a/src/calibre/gui2/__init__.py
+++ b/src/calibre/gui2/__init__.py
@@ -1619,6 +1619,8 @@ def ensure_app(headless=True):
             has_headless = ismacos or islinux or isbsd
             if headless and has_headless:
                 args += ['-platformpluginpath', plugins_loc, '-platform', os.environ.get('CALIBRE_HEADLESS_PLATFORM', 'headless')]
+                if isbsd:
+                    os.environ['QTWEBENGINE_CHROMIUM_FLAGS'] = '--disable-gpu'
                 if ismacos:
                     os.environ['QT_MAC_DISABLE_FOREGROUND_APPLICATION_TRANSFORM'] = '1'
             if headless and iswindows:


### PR DESCRIPTION
On FreeBSD this prevents a failure when building with Qt 6.9

Adding the env only if `isbsd`, but this could be needed for other OSes too.

The patch was suggested by jhale@FreeBSD.org in https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=286051