### PR TITLE
Add for support fo regex labeled APNX entries.

### DIFF
--- a/src/calibre/devices/kindle/apnx.py
+++ b/src/calibre/devices/kindle/apnx.py
@@ -15,6 +15,7 @@ from calibre.devices.kindle.apnx_page_generator.generators.accurate_page_generat
 from calibre.devices.kindle.apnx_page_generator.generators.exact_page_generator import ExactPageGenerator
 from calibre.devices.kindle.apnx_page_generator.generators.fast_page_generator import FastPageGenerator
 from calibre.devices.kindle.apnx_page_generator.generators.pagebreak_page_generator import PagebreakPageGenerator
+from calibre.devices.kindle.apnx_page_generator.generators.regex_page_generator import  RegexPageGenerator
 from calibre.devices.kindle.apnx_page_generator.i_page_generator import IPageGenerator
 from calibre.devices.kindle.apnx_page_generator.pages import Pages
 from calibre.ebooks.mobi.reader.headers import MetadataHeader
@@ -32,10 +33,11 @@ class APNXBuilder:
         FastPageGenerator.instance.name(): FastPageGenerator.instance,
         AccuratePageGenerator.instance.name(): AccuratePageGenerator.instance,
         PagebreakPageGenerator.instance.name(): PagebreakPageGenerator.instance,
+        RegexPageGenerator.instance.name(): RegexPageGenerator.instance,
         # ExactPageGenerator.instance.name(): ExactPageGenerator.instance,
     }
 
-    def write_apnx(self, mobi_file_path: str, apnx_path: str, method: str | None = None, page_count: int = 0):
+    def write_apnx(self, mobi_file_path: str, apnx_path: str, method: str | None = None, page_count: int = 0, page_break_regex : str = ""):
         '''
         If you want a fixed number of pages (such as from a custom column) then
         pass in a value to page_count, otherwise a count will be estimated
@@ -48,7 +50,7 @@ class APNXBuilder:
         else:
             generator: IPageGenerator = self.generators.setdefault(method, FastPageGenerator.instance)
 
-        pages = generator.generate(mobi_file_path, page_count)
+        pages = generator.generate(mobi_file_path, page_count, page_break_regex)
         if pages.number_of_pages == 0:
             raise Exception(_('Could not generate page mapping.'))
         # Generate the APNX file from the page mapping.

--- a/src/calibre/devices/kindle/apnx_page_generator/generators/accurate_page_generator.py
+++ b/src/calibre/devices/kindle/apnx_page_generator/generators/accurate_page_generator.py
@@ -16,9 +16,9 @@ class AccuratePageGenerator(IPageGenerator):
         return 'accurate'
 
     def _generate_fallback(self, mobi_file_path: str, real_count: int | None) -> Pages:
-        return FastPageGenerator.instance.generate(mobi_file_path, real_count)
+        return FastPageGenerator.instance.generate(mobi_file_path, real_countm, "")
 
-    def _generate(self, mobi_file_path: str, real_count: int | None) -> Pages:
+    def _generate(self, mobi_file_path: str, real_count: int | None, regex: str) -> Pages:
         '''
         A more accurate but much more resource intensive and slower
         method to calculate the page length.

--- a/src/calibre/devices/kindle/apnx_page_generator/generators/exact_page_generator.py
+++ b/src/calibre/devices/kindle/apnx_page_generator/generators/exact_page_generator.py
@@ -16,9 +16,9 @@ class ExactPageGenerator(IPageGenerator):
         return 'exact'
 
     def _generate_fallback(self, mobi_file_path: str, real_count: int | None) -> Pages:
-        return FastPageGenerator.instance.generate(mobi_file_path, real_count)
+        return FastPageGenerator.instance.generate(mobi_file_path, real_count, "")
 
-    def _generate(self, mobi_file_path: str, real_count: int | None) -> Pages:
+    def _generate(self, mobi_file_path: str, real_count: int | None, regex: str) -> Pages:
         '''
         Given a specified page count (such as from a custom column),
         create our array of pages for the apnx file by dividing by

--- a/src/calibre/devices/kindle/apnx_page_generator/generators/fast_page_generator.py
+++ b/src/calibre/devices/kindle/apnx_page_generator/generators/fast_page_generator.py
@@ -15,7 +15,7 @@ class FastPageGenerator(IPageGenerator):
     def _generate_fallback(self, mobi_file_path: str, real_count: int | None) -> Pages:
         raise Exception('Fast calculation impossible.')
 
-    def _generate(self, mobi_file_path: str, real_count: int | None) -> Pages:
+    def _generate(self, mobi_file_path: str, real_count: int | None, regex: str) -> Pages:
         '''
         2300 characters of uncompressed text per page. This is
         not meant to map 1 to 1 to a print book but to be a

--- a/src/calibre/devices/kindle/apnx_page_generator/generators/pagebreak_page_generator.py
+++ b/src/calibre/devices/kindle/apnx_page_generator/generators/pagebreak_page_generator.py
@@ -15,9 +15,9 @@ class PagebreakPageGenerator(IPageGenerator):
         return 'pagebreak'
 
     def _generate_fallback(self, mobi_file_path: str, real_count: int | None) -> Pages:
-        return FastPageGenerator.instance.generate(mobi_file_path, real_count)
+        return FastPageGenerator.instance.generate(mobi_file_path, real_count, "")
 
-    def _generate(self, mobi_file_path: str, real_count: int | None) -> Pages:
+    def _generate(self, mobi_file_path: str, real_count: int | None, regex: str) -> Pages:
         ''' Determine pages based on the presence of <*pagebreak*/>. '''
         html = mobi_html(mobi_file_path)
         pages = []

--- a/src/calibre/devices/kindle/apnx_page_generator/generators/regex_page_generator.py
+++ b/src/calibre/devices/kindle/apnx_page_generator/generators/regex_page_generator.py
@@ -1,0 +1,87 @@
+__license__ = 'GPL v3'
+__copyright__ = '2025, Vaso Li <vaso at vipl.in.rs>'
+__docformat__ = 'restructuredtext en'
+
+from typing import Optional
+
+from calibre.devices.kindle.apnx_page_generator.generators.fast_page_generator import FastPageGenerator
+from calibre.devices.kindle.apnx_page_generator.i_page_generator import IPageGenerator, mobi_html
+from calibre.devices.kindle.apnx_page_generator.page_number_type import PageNumberTypes
+from calibre.devices.kindle.apnx_page_generator.pages import Pages
+from calibre.devices.kindle.apnx_page_generator.page_group import PageGroup
+import re
+
+roman_numeral_map = (('m', 1000), ('cm', 900), ('d', 500), ('cd', 400), ('c', 100), ('xc', 90), ('l', 50), ('xl', 40),
+                     ('x', 10), ('ix', 9), ('v', 5), ('iv', 4), ('i', 1))
+
+roman_numeral_pattern = re.compile("""^m{0,4}(cm|cd|d?c{0,3})(xc|xl|l?x{0,3})(ix|iv|V?i{0,3})$""", re.VERBOSE)
+
+
+def from_roman(s: str) -> int:
+    """convert Roman numeral to integer"""
+    if not s:
+        raise ValueError('Input can not be blank')
+    if not roman_numeral_pattern.match(s):
+        raise ValueError('Invalid Roman numeral: %s' % s)
+
+    result = 0
+    index = 0
+    for numeral, integer in roman_numeral_map:
+        while s[index:index + len(numeral)] == numeral:
+            result += integer
+            index += len(numeral)
+    return result
+
+
+class LabelDescriptor:
+    def __init__(self, label: str, value: int, label_type: PageNumberTypes):
+        self.label: str = label
+        self.value: int = value
+        self.label_type: PageNumberTypes = label_type
+
+
+class RegexPageGenerator(IPageGenerator):
+
+    def name(self) -> str:
+        return "regex_page"
+
+    def _generate_fallback(self, mobi_file_path: str, real_count: Optional[int]) -> Pages:
+        return FastPageGenerator.instance.generate(mobi_file_path, real_count, "")
+
+    def _generate(self, mobi_file_path: str, real_count: int | None, regex: str) -> Pages:
+        html = mobi_html(mobi_file_path)
+        pages = Pages()
+
+        compiled_regex = re.compile(regex.encode('utf-8'))
+        for m in compiled_regex.finditer(html):
+            label_descriptor = self.get_label(m.group(1))
+            if pages.number_of_pages == 0:
+                pages.append(PageGroup(m.end(), label_descriptor.label_type, label_descriptor.value,
+                                       label_descriptor.label))
+            elif (
+                    pages.last_group.last_value == label_descriptor.value - 1 or label_descriptor.label_type ==
+                    PageNumberTypes.Custom) and pages.last_group.page_number_types == label_descriptor.label_type:
+
+                if label_descriptor.label_type != PageNumberTypes.Custom:
+                    pages.last_group.append(m.end())
+                else:
+                    pages.last_group.append((m.end(), label_descriptor.label))
+            else:
+                pages.append(PageGroup(m.end(), label_descriptor.label_type, label_descriptor.value,
+                                       label_descriptor.label))
+
+        return pages
+
+    @staticmethod
+    def get_label(label: bytes) -> LabelDescriptor:
+        label_string = label.decode()
+        try:
+            return LabelDescriptor(label_string, int(label_string), PageNumberTypes.Arabic)
+        except ValueError:
+            try:
+                return LabelDescriptor(label_string, from_roman(label_string), PageNumberTypes.Roman)
+            except ValueError:
+                return LabelDescriptor(label_string, 0, PageNumberTypes.Custom)
+
+
+RegexPageGenerator.instance = RegexPageGenerator()

--- a/src/calibre/devices/kindle/apnx_page_generator/i_page_generator.py
+++ b/src/calibre/devices/kindle/apnx_page_generator/i_page_generator.py
@@ -14,16 +14,16 @@ from polyglot.builtins import as_bytes
 class IPageGenerator(metaclass=ABCMeta):
 
     @abstractmethod
-    def _generate(self, mobi_file_path: str, real_count: int | None) -> Pages:
+    def _generate(self, mobi_file_path: str, real_count: int | None, regex : str) -> Pages:
         pass
 
     @abstractmethod
     def _generate_fallback(self, mobi_file_path: str, real_count: int | None) -> Pages:
         pass
 
-    def generate(self, mobi_file_path: str, real_count: int | None) -> Pages:
+    def generate(self, mobi_file_path: str, real_count: int | None, regex : str) -> Pages:
         try:
-            result = self._generate(mobi_file_path, real_count)
+            result = self._generate(mobi_file_path, real_count, regex)
             if result.number_of_pages > 0:
                 return result
             return self._generate_fallback(mobi_file_path, real_count)


### PR DESCRIPTION
About 3 years ago I wanted to submit page generation labels based on aria (Accessible Rich Internet Applications) https://kb.daisy.org/publishing/docs/html/dpub-aria/doc-pagebreak.html specification of encoding pagebreaks.

That was rejected as too specific.

This time I am submitting general regex (with one regex group) page generator. Whenever regex is matched, it looks for a group in regex as set that as page location. This time aria page break is just default value for regex.

I hope this modification can be accepted as additional generation of APNX files.

PS: Is it ok to make generation of APNX files possible without attached device? Maybe like additional conversion option? Or something similar?