### PR TITLE
Improve highlight grouping with recurring chapter names

### DIFF
--- a/src/calibre/gui2/viewer/highlights.py
+++ b/src/calibre/gui2/viewer/highlights.py
@@ -340,7 +340,7 @@ class Highlights(QTreeWidget):
             if tfam:
                 tsec = tfam[0]
                 lsec = tfam[-1]
-                key = (spine_index, tsec or '', lsec or '')
+                key = (spine_index,) + tfam
             else:
                 tsec = h.get('top_level_section_title')
                 lsec = h.get('lowest_level_section_title')

--- a/src/calibre/gui2/viewer/highlights.py
+++ b/src/calibre/gui2/viewer/highlights.py
@@ -336,14 +336,15 @@ class Highlights(QTreeWidget):
 
         for h in self.sorted_highlights(highlights):
             tfam = tuple(h.get('toc_family_titles') or ())
+            spine_index = h.get('spine_index', -1)
             if tfam:
                 tsec = tfam[0]
                 lsec = tfam[-1]
-                key = tfam
+                key = (spine_index, tsec or '', lsec or '')
             else:
                 tsec = h.get('top_level_section_title')
                 lsec = h.get('lowest_level_section_title')
-                key = (tsec or '', lsec or '')
+                key = (spine_index, tsec or '', lsec or '')
             short_title = lsec or tsec or _('Unknown')
             section = {
                 'title': short_title, 'tfam': tfam, 'tsec': tsec, 'lsec': lsec, 'items': [], 'tooltip': tooltip_for(tfam), 'key': key,


### PR DESCRIPTION
Several books I read have same chapter names that occurs multiple times across the book. For those books, ebook-viewer will show the highlights as grouped by the chapter names on the highlight widget. This behavior can result in the highlights being shown in inconsistent order as they appear in the book - sometimes a highlight at a position later in the book can appear before another highlight earlier in the book.

This PR changes the behavior of the grouping key to take the spine index into consideration when grouping the highlights. The difference can be seen in the following screenshots.

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/9ab75fce-1482-4365-b48d-67bdc2c194a5" width="200" />
</td>
<td>
<img src="https://github.com/user-attachments/assets/1349c7aa-d8d8-4741-988e-7c4df22efe57" width="200" />
</td>
</tr>
</table>