### PR TITLE
Piper read aloud skipping

### DIFF
--- a/src/calibre/gui2/tts/piper.py
+++ b/src/calibre/gui2/tts/piper.py
@@ -178,7 +178,7 @@ class UtteranceAudioQueue(QIODevice):
         prev_state, self.audio_state = self.audio_state, s
         if s == prev_state:
             return
-        if s == QAudio.State.IdleState and prev_state == QAudio.State.ActiveState:
+        if s == QAudio.State.IdleState and prev_state == QAudio.State.ActiveState and len(self.current_audio_data) == 0:
             if self.utterance_being_played:
                 debug(f'Utterance {self.utterance_being_played.id} audio output finished with {len(self.current_audio_data)=} bytes left')
             self.utterance_being_played = None

--- a/src/calibre/gui2/tts/piper.py
+++ b/src/calibre/gui2/tts/piper.py
@@ -180,7 +180,7 @@ class UtteranceAudioQueue(QIODevice):
             return
         if s == QAudio.State.IdleState and prev_state == QAudio.State.ActiveState:
             if self.utterance_being_played:
-                debug(f'Utterance {self.utterance_being_played.id} audio output finished')
+                debug(f'Utterance {self.utterance_being_played.id} audio output finished with {len(self.current_audio_data)=} bytes left')
             self.utterance_being_played = None
             self.start_utterance()
         self.update_status.emit()


### PR DESCRIPTION
My Piper TTS on Ubuntu desktop will frequently skip partial or whole lines, say 1 in 20-50 on average; more so right after starting or clicking to replay a line, but it can happen at any time whether or not I've taken any action.
Intercepting the raw piper `stdin` and `stdout` showed the text and audio were fully intact.

With the log showing bytes left I was able to confirm it correlates to the audio sink state change getting an extra Active→Idle→Active occasionally.

```
[95.07] Audio sent to output: maxlen=16384 len(ans)=0
[95.12] Audio state: State.IdleState
[95.12] Utterance 578 audio output finished with len(self.current_audio_data)=0 bytes left
[95.14] Audio sent to output: maxlen=16384 len(ans)=16384
[95.14] Audio state: State.ActiveState
[95.14] Audio state: State.IdleState
[95.14] Utterance 579 audio output finished with len(self.current_audio_data)=165920 bytes left
[95.16] Audio state: State.ActiveState
[95.48] Audio sent to output: maxlen=16384 len(ans)=16384
```

So far it's worked.

I can only foresee two possible side effects:
- Is it possible for `audio_state_changed()` to never get called after `current_audio_data` is truly empty?
- Do `readyRead.emit()` and `saying.emit()` need to be called without popping the queue?
