### PR TITLE
Define _FILE_OFFSET_BITS=64 and replace usage of pread64

### DIFF
--- a/setup/build.py
+++ b/setup/build.py
@@ -274,7 +274,7 @@ def init_env(debug=False, sanitize=False, compiling_for='native'):
             cflags.append('-fsanitize=address')
 
     if islinux:
-        cflags.append('-pthread')
+        cflags.extend(['-pthread', '-D_FILE_OFFSET_BITS=64'])
         if sys.stdout.isatty():
             base_cflags.append('-fdiagnostics-color=always')
             cflags.append('-fdiagnostics-color=always')

--- a/src/calibre/utils/speedup.c
+++ b/src/calibre/utils/speedup.c
@@ -748,11 +748,7 @@ pread_all(PyObject *self, PyObject *args) {
             break;
         }
 #else
-#ifdef __linux__
-        ssize_t nr = pread64(fd, buf + pos, n - pos, offset);
-#else
         ssize_t nr = pread(fd, buf + pos, n - pos, offset);
-#endif
         if (nr < 0) {
             if (errno == EINTR || errno == EAGAIN) continue;
             saved_errno = errno;


### PR DESCRIPTION
pread64 and its fellow LFS64 interfaces are no longer present on musl systems as of musl 1.2.4, as pread is always 64-bit on musl. Instead of conditionalizing usage of pread64 to glibc, use pread instead and pass _FILE_OFFSET_BITS=64 to ensure pread is 64-bit on glibc. This should not have an any effect on other platforms.