### PR TITLE
Fix form field names for Reason

### DIFF
--- a/recipes/reason_magazine.recipe
+++ b/recipes/reason_magazine.recipe
@@ -98,9 +98,9 @@ class Reason(BasicNewsRecipe):
         br = BasicNewsRecipe.get_browser(self)
         if self.username is not None and self.password is not None:
             br.open('https://reason.com/login')
-            br.select_form(id='login_form')
-            br['text_username'] = self.username
-            br['password_password'] = self.password
+            br.select_form(id='gform_0')
+            br['input_1'] = self.username
+            br['input_2'] = self.password
             br.submit()
         return br
 


### PR DESCRIPTION
It appears that the form field names are out of date for the Reason Magazine recipe. It seems to work once I fix the names.