### PR TITLE
Allow custom-metadata comment rows to grow with the window.

### DIFF
--- a/src/calibre/gui2/custom_column_widgets.py
+++ b/src/calibre/gui2/custom_column_widgets.py
@@ -977,6 +977,9 @@ def populate_metadata_page(layout, db, book_id, bulk=False, two_column=False, pa
         if is_comments:
             layout.addLayout(l, row, column, layout_rows_for_comments, 1)
             layout.setColumnStretch(column, 100)
+            # All multiline fields should grow with the window
+            for i in range(layout_rows_for_comments):
+                layout.setRowStretch(row + i, 100)
             row += layout_rows_for_comments
         else:
             layout.addLayout(l, row, column, 1, 1)


### PR DESCRIPTION
### Problem description

I'm using a few custom columns to track data such as:  
 - when I've read a book
 - my own comments/notes/etc

Especially the multiline custom-fields are a bit  annoying, because they have a fixed height and I can't resize them to be bigger.  
 
<img width="1893" height="1197" alt="image" src="https://github.com/user-attachments/assets/b9518592-4977-4dfc-ad5c-500317e27ba3" />

The "Comments" field under Basic-metadata behaves a bit better, and actually fills the available width of the window.

### Solution

I've changed all `is_comments` rows to have `row_stretch`.  
This way, multiline (= comment) rows grow with the window, and if there are multiple they all grow equally.

<img width="1892" height="1197" alt="image" src="https://github.com/user-attachments/assets/b708ec3d-bf68-4e9d-83db-c81b429043ef" />


