### PR TITLE
Page number information (APNX) for MTP Kindles

### DIFF
--- a/src/calibre/devices/mtp/defaults.py
+++ b/src/calibre/devices/mtp/defaults.py
@@ -26,6 +26,7 @@ class DeviceDefaults:
                     'format_map': ['azw3', 'mobi', 'azw',
                                     'azw1', 'azw4', 'kfx', 'pdf'],
                     'send_to': ['documents', 'kindle', 'books'],
+                    'apnx': {'send': True, 'method': 'fast', 'custom_column_page_count': None, 'custom_column_method': None}
                     }
                 ),
                 # B&N devices

--- a/src/calibre/devices/mtp/driver.py
+++ b/src/calibre/devices/mtp/driver.py
@@ -545,7 +545,8 @@ class MTP_DEVICE(BASE):
                 try:
                     self.upload_cover(parent, relpath, storage, mi, stream)
                     # Upload the apnx file
-                    self.upload_apnx(parent, fname, storage, mi, infile)
+                    if self.is_kindle:
+                      self.upload_apnx(parent, fname, storage, mi, infile)
                 except Exception:
                     import traceback
                     traceback.print_exc()

--- a/src/calibre/devices/mtp/driver.py
+++ b/src/calibre/devices/mtp/driver.py
@@ -644,13 +644,13 @@ class MTP_DEVICE(BASE):
 
     def upload_apnx(self, parent, filename, storage, mi, filepath):
         from calibre.devices.kindle.apnx import APNXBuilder
-        apnx_builder = APNXBuilder()
+        import tempfile
 
-        name = filename.rpartition('.')[0]
-        apnx_filename = f'{name[:-2]}.apnx'
-        apnx_local_path = f'{os.path.join('/tmp', apnx_filename)}'
+        apnx_local_path = tempfile.NamedTemporaryFile(prefix='calibre-apnx-', suffix='.apnx', delete=False).name
 
         try:
+            apnx_builder = APNXBuilder()
+
             custom_page_count = 0
             cust_col_name = self.get_pref('apnx').get('custom_column_page_count', None)
             if cust_col_name:
@@ -677,6 +677,8 @@ class MTP_DEVICE(BASE):
             apnx_stream = open(apnx_local_path, 'rb')
 
             try:
+              name = filename.rpartition('.')[0]
+              apnx_filename = f'{name[:-2]}.apnx'
               apnx_path = parent.name, f'{name[:-2]}.sdr', apnx_filename
               sdr_parent = self.ensure_parent(storage, apnx_path)
               self.put_file(sdr_parent, apnx_filename, apnx_stream, apnx_size)

--- a/src/calibre/devices/mtp/driver.py
+++ b/src/calibre/devices/mtp/driver.py
@@ -87,7 +87,7 @@ class MTP_DEVICE(BASE):
             p.defaults['rules'] = []
             p.defaults['ignored_folders'] = {}
             p.defaults['apnx'] = {
-                'send': True,
+                'send': False,
                 'method': 'fast',
                 'custom_column_page_count': None,
                 'custom_column_method': None,
@@ -643,6 +643,7 @@ class MTP_DEVICE(BASE):
     # }}}
 
     def upload_apnx(self, parent, filename, storage, mi, filepath):
+        debug('upload_apnx() called')
         from calibre.devices.kindle.apnx import APNXBuilder
         from calibre.ptempfile import PersistentTemporaryFile
 
@@ -651,16 +652,19 @@ class MTP_DEVICE(BASE):
         apnx_local_file.close()
 
         try:
+            pref = self.get_pref('apnx')
+
             custom_page_count = 0
-            cust_col_name = self.get_pref('apnx').get('custom_column_page_count', None)
+            cust_col_name = pref.get('custom_column_page_count', None)
             if cust_col_name:
                 try:
                     custom_page_count = int(mi.get(cust_col_name, 0))
                 except Exception:
                     pass
 
-            method = self.get_pref('apnx').get('method', 'fast')
-            cust_col_method = self.get_pref('apnx').get('custom_column_method', None)
+            method = pref.get('method', 'fast')
+
+            cust_col_method = pref.get('custom_column_method', None)
             if cust_col_method:
                 try:
                     method = str(mi.get(cust_col_method)).lower()
@@ -689,6 +693,7 @@ class MTP_DEVICE(BASE):
             traceback.print_exc()
         finally:
           os.remove(apnx_local_path)
+        debug('upload_apnx() ended')
 
     def add_books_to_metadata(self, mtp_files, metadata, booklists):
         debug('add_books_to_metadata() called')

--- a/src/calibre/devices/mtp/driver.py
+++ b/src/calibre/devices/mtp/driver.py
@@ -552,8 +552,9 @@ class MTP_DEVICE(BASE):
                     self.upload_cover(parent, relpath, storage, mi, stream)
                     # Upload the apnx file
                     if self.is_kindle and self.get_pref('apnx').get('send', False):
-                      debug('Uploading APNX file for', fname)
-                      self.upload_apnx(parent, fname, storage, mi, infile)
+                      name = path[-1].rpartition('.')[0]
+                      debug('Uploading APNX file for', name)
+                      self.upload_apnx(parent, name, storage, mi, infile)
                 except Exception:
                     import traceback
                     traceback.print_exc()
@@ -642,7 +643,7 @@ class MTP_DEVICE(BASE):
         debug(f'Restored {count} cover thumbnails that were destroyed by Amazon')
     # }}}
 
-    def upload_apnx(self, parent, filename, storage, mi, filepath):
+    def upload_apnx(self, parent, name, storage, mi, filepath):
         debug('upload_apnx() called')
         from calibre.devices.kindle.apnx import APNXBuilder
         from calibre.ptempfile import PersistentTemporaryFile
@@ -681,9 +682,8 @@ class MTP_DEVICE(BASE):
             apnx_size = os.path.getsize(apnx_local_path)
 
             with open(apnx_local_path, 'rb') as apnx_stream:
-              name = filename.rpartition('.')[0]
-              apnx_filename = f'{name[:-2]}.apnx'
-              apnx_path = parent.name, f'{name[:-2]}.sdr', apnx_filename
+              apnx_filename = f'{name}.apnx'
+              apnx_path = parent.name, f'{name}.sdr', apnx_filename
               sdr_parent = self.ensure_parent(storage, apnx_path)
               self.put_file(sdr_parent, apnx_filename, apnx_stream, apnx_size)
 


### PR DESCRIPTION
MTP kindles support APNX files within the book sidecar.

This PR uses the existing APNX logic to generate a local file and then upload it to the proper path within the device when sending books to an MTP kindle.