### PR TITLE
MTP Kindle Serial not detected

### DIFF
--- a/src/calibre/devices/mtp/unix/driver.py
+++ b/src/calibre/devices/mtp/unix/driver.py
@@ -274,7 +274,7 @@ class MTP_DEVICE(MTPDeviceBase):
         self.current_friendly_name = self.dev.friendly_name
         if not self.current_friendly_name:
             self.current_friendly_name = self.dev.model_name or _('Unknown MTP device')
-        self.current_serial_num = snum
+        self.current_serial_num = snum or self.dev.ids[-1]
         self.currently_connected_dev = connected_device
 
     @synchronous


### PR DESCRIPTION
When connecting my kindle and showing the device information, the serial number appears empty:

```
Kindle Paperwhite
Serial number: 
Manufacturer: Amazon
Model: Kindle Paperwhite
ids: (1, 17, 6473, 39297, 'xxxxx')
Device version: 
Storage:
[{'capacity': 12349591552,
  'freespace_bytes': 11801124864,
  'freespace_objects': 4294967295,
  'id': 65537,
  'name': 'Internal Storage',
  'removable': False,
  'rw': True,
  'volume_id': '-10001'}]
```

causing that the persisted config is shared across all the MTP devices, as they are not properly identified (`device-`):

```
{
  "blacklist": [],
  "device-": {
    "apnx": {
...
```

With this change, I'm assuming the last value of the list of IDs is the actual serial device, and thus using it when the default serial number is empty, fixing the scenarios stated above.