### PR TITLE
tag_list_editor.ui - Fix double space

### DIFF
--- a/src/calibre/gui2/dialogs/tag_list_editor.ui
+++ b/src/calibre/gui2/dialogs/tag_list_editor.ui
@@ -65,7 +65,7 @@
              </size>
             </property>
             <property name="toolTip">
-             <string>Search for an item in the first column using the text in this box.  The search ignores case.</string>
+             <string>Search for an item in the first column using the text in this box. The search ignores case.</string>
             </property>
             <property name="clearButtonEnabled">
              <bool>true</bool>


### PR DESCRIPTION
Double space in Manage Tags dialog tooltip