### PR TITLE
Resubmission of two FFML changes:

### DIFF
--- a/src/calibre/gui2/dialogs/template_general_info.py
+++ b/src/calibre/gui2/dialogs/template_general_info.py
@@ -66,8 +66,9 @@ a space before the closing \`\` characters. Trailing blanks in the code text are
   Example: \:guilabel\:\`Preferences->Advanced->Template functions\`. For HTML the produced text is in a different font, as in: :guilabel:`Some text`
 [*][B]Empty lines[/B], indicated by two newlines in a row. A visible empty line in the FFML
 will become an empty line in the output.
-[*][B]URLs.[/B] The syntax is similar to BBCODE: ``[URL href="http..."]Link text[/URL]``.\
-  Example: ``[URL href="https://en.wikipedia.org/wiki/ISO_8601"]ISO[/URL]`` produces [URL href="https://en.wikipedia.org/wiki/ISO_8601"]ISO[/URL]
+[*][B]URLs.[/B] The syntax is similar to BBCODE: ``[URL href="http..."]Link text[/URL]``.
+Example: ``[URL href="https://en.wikipedia.org/wiki/ISO_8601"]ISO[/URL]``
+produces [URL href="https://en.wikipedia.org/wiki/ISO_8601"]ISO[/URL]
 [*][B]Internal function reference links[/B]. These are links to formatter function
 documentation. The syntax is the same as guilabel. Example: ``:ref:`get_note` ``.
 The characters '()' are automatically added to the function name when

--- a/src/calibre/utils/ffml_processor.py
+++ b/src/calibre/utils/ffml_processor.py
@@ -304,7 +304,7 @@ class FFMLProcessor:
         elif tree.node_kind() == NodeKinds.ITALIC_TEXT:
             result += f'<i>{tree.escaped_text()}</i>'
         elif tree.node_kind() == NodeKinds.LIST:
-            result += '\n<ul>\n'
+            result += '<ul>\n'
             for child in tree.children():
                 result += '<li>\n'
                 result += self.tree_to_html(child, depth=depth+1)
@@ -378,9 +378,7 @@ class FFMLProcessor:
         '''
         result = ''
         if tree.node_kind() == NodeKinds.TEXT:
-            t = tree.text()
-            t = t.replace('\n', ' ')
-            result += t
+            result += tree.text()
         if tree.node_kind() == NodeKinds.BOLD_TEXT:
             result += f'[B]{tree.text()}[/B]'
         elif tree.node_kind() == NodeKinds.BLANK_LINE:
@@ -392,7 +390,7 @@ class FFMLProcessor:
             t = t + ' ' if t.endswith('`') else t
             result += f'``{t}``'
         elif tree.node_kind() == NodeKinds.CODE_BLOCK:
-            result += '\n[CODE]\n' + tree.text().replace('[/CODE]', r'[\/CODE]') + '[/CODE]\n'
+            result += '[CODE]\n' + tree.text().replace('[/CODE]', r'[\/CODE]') + '[/CODE]\n'
         elif tree.node_kind() == NodeKinds.END_SUMMARY:
             result += '[/]'
         elif tree.node_kind() == NodeKinds.ERROR_TEXT:
@@ -732,7 +730,8 @@ class FFMLProcessor:
         while True:
             p = self.find_one_of()
             if p > 0:
-                txt = self.text_to(p).replace('\n', ' ')
+                txt = self.text_to(p)
+                txt = txt[:-1].replace('\n', ' ') + txt[-1]
                 parent.add_child(TextNode(txt))
                 self.move_pos(p)
             elif p == NodeKinds.BLANK_LINE:


### PR DESCRIPTION
1) Eliminate the space at the end of some lines such as list items.
2) Remove a spurious backslash from the FFML documentation.

NB: removing the space means that the generated rst and html are slightly different from what they were before the change. The changes are white space and don't appear to change what one sees in the interpreted html and rst.

The html and rst output remains identical with original input or rst-formatted input.