### PR TITLE
Keep emphasis style on ebook conversion

### DIFF
--- a/src/calibre/ebooks/oeb/stylizer.py
+++ b/src/calibre/ebooks/oeb/stylizer.py
@@ -185,9 +185,17 @@ class StylizerRules:
                 size = 'xx-small'
             if size in FONT_SIZE_NAMES:
                 style['font-size'] = f'{self.profile.fnames[size]/float(self.profile.fbase):.1f}rem'
-        if '-epub-writing-mode' in style:
-            for x in ('-webkit-writing-mode', 'writing-mode'):
-                style[x] = style.get(x, style['-epub-writing-mode'])
+        UNPREFIXED_PROPERTIES = (
+            ['writing-mode'] +
+            [f'text-emphasis{x}' for x in ('', '-color', '-position', '-style')]
+        )
+        for unprefixed_property in UNPREFIXED_PROPERTIES:
+            epub_property = f'-epub-{unprefixed_property}'
+            webkit_property = f'-webkit-{unprefixed_property}'
+            if epub_property in style:
+                value = style[epub_property]
+                style[unprefixed_property] = style.get(unprefixed_property, value)
+                style[webkit_property] = style.get(webkit_property, value)
         return style
 
     def _apply_text_align(self, text):


### PR DESCRIPTION
Hi,

I have been converting a few Japanese ebooks from EPUB to AZW3, and I found that the property `-epub-text-emphasis` wasn't translated to `-webkit` for the Kindle.

This style is often used in Japanese to emphasis text:

<img width="64" height="174" alt="image" src="https://github.com/user-attachments/assets/8fc083a9-d73b-4cfd-9f03-9e0ae89dcd9c" />

This PR fixes this issue.