### PR TITLE
feat: Add LLM tab to Lookup panel

### DIFF
--- a/src/calibre/gui2/viewer/llm.py
+++ b/src/calibre/gui2/viewer/llm.py
@@ -1,0 +1,641 @@
+# License: GPL v3 Copyright: 2025, Amir Tehrani and Kovid Goyal
+
+import json
+from threading import Thread
+from urllib import request
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse, parse_qs
+
+from qt.core import (
+    QAbstractItemView, QComboBox, QDialog, QDialogButtonBox, QEvent, QFormLayout,
+    QGridLayout, QGroupBox, QHBoxLayout, QIcon, QLabel, QLineEdit, QListWidget,
+    QListWidgetItem, QMessageBox, QPushButton, QSizePolicy, Qt, QTextBrowser,
+    QTextEdit, QVBoxLayout, QWidget, pyqtSignal
+)
+
+from calibre.gui2.viewer.config import vprefs
+from calibre.utils.localization import _
+from polyglot.binary import as_hex_unicode, from_hex_unicode
+
+# --- Backend Abstraction & Cost Data ---
+MODEL_COSTS = {
+    # Anthropic
+    'anthropic/claude-3-haiku': (0.25, 1.25),
+    'anthropic/claude-3.5-sonnet': (3.00, 15.00),
+    'anthropic/claude-3.7-sonnet': (3.00, 15.00),
+    'anthropic/claude-sonnet-4': (3.00, 15.00),
+
+    # DeepSeek
+    'deepseek/deepseek-chat-v3-0324': (0.18, 0.72),
+
+    # Google
+    'google/gemini-1.5-flash': (0.075, 0.30),
+    'google/gemini-1.5-pro': (1.25, 5.00),
+    'google/gemini-2.0-flash-001': (0.10, 0.40),
+    'google/gemini-2.5-flash': (0.30, 2.50),
+    'google/gemini-2.5-flash-lite': (0.10, 0.40),
+    'google/gemini-2.5-pro': (1.25, 10.00),
+
+    # Meta
+    'meta-llama/llama-3.1-8b-instruct': (0.015, 0.02),
+    'meta-llama/llama-3.1-70b-instruct': (0.10, 0.28),
+
+    # Mistral
+    'mistralai/mistral-7b-instruct': (0.028, 0.054),
+    'mistralai/mistral-nemo': (0.008, 0.05),
+
+    # MoonshotAI
+    'moonshotai/kimi-k2': (0.14, 2.49),
+
+    # OpenAI
+    'openai/gpt-4.1-mini': (0.40, 1.60),
+    'openai/gpt-4o': (2.50, 10.00),
+    'openai/gpt-4o-mini': (0.15, 0.60),
+    'openai/gpt-5': (1.25, 10.00),
+    'openai/gpt-5-mini': (0.25, 2.00),
+    'openai/gpt-oss-120b': (0.072, 0.28),
+
+    # Qwen
+    'qwen/qwen3-coder': (0.20, 0.80),
+
+    # ZhipuAI
+    'z-ai/glm-4.5': (0.20, 0.80),
+
+    # Default Fallback
+    'default': (0.50, 1.50)
+}
+
+API_PROVIDERS = {
+    'openrouter': {
+        'url': "https://openrouter.ai/api/v1/chat/completions",
+        'headers': lambda api_key: {
+            'Authorization': f'Bearer {api_key}',
+            'Content-Type': 'application/json',
+            'HTTP-Referer': 'https://github.com/kovidgoyal/calibre',
+            'X-Title': 'Calibre E-book Viewer'
+        },
+        'payload': lambda model_id, messages: {
+            "model": model_id,
+            "messages": messages
+        },
+        'parse_response': lambda r_json: (
+            r_json['choices'][0]['message']['content'],
+            r_json.get('usage', {'prompt_tokens': 0, 'completion_tokens': 0})
+        )
+    }
+}
+# --- End Backend Abstraction ---
+
+
+class LLMAPICall(Thread):
+    def __init__(self, conversation_history, api_key, model_id, signal_emitter, provider_config):
+        super().__init__()
+        self.conversation_history = conversation_history
+        self.api_key = api_key
+        self.model_id = model_id
+        self.signal_emitter = signal_emitter
+        self.provider_config = provider_config
+        self.daemon = True
+
+    def run(self):
+        try:
+            url = self.provider_config['url']
+            headers = self.provider_config['headers'](self.api_key)
+            payload = self.provider_config['payload'](self.model_id, self.conversation_history)
+
+            encoded_data = json.dumps(payload).encode('utf-8')
+            req = request.Request(url, data=encoded_data, headers=headers, method='POST')
+
+            with request.urlopen(req, timeout=90) as response:
+                response_data = response.read().decode('utf-8')
+                response_json = json.loads(response_data)
+
+            if 'error' in response_json:
+                raise Exception(response_json['error'].get('message', 'Unknown API error'))
+            if not response_json.get('choices'):
+                raise Exception("API response did not contain any choices.")
+
+            result_text, usage_data = self.provider_config['parse_response'](response_json)
+            self.signal_emitter.emit(result_text, usage_data)
+
+        except HTTPError as e:
+            error_body = e.read().decode('utf-8')
+            try:
+                error_json = json.loads(error_body)
+                msg = error_json.get('error', {}).get('message', error_body)
+            except json.JSONDecodeError:
+                msg = error_body
+            self.signal_emitter.emit(f"<p style='color:red;'><b>API Error ({e.code}):</b> {msg}</p>", {})
+        except URLError as e:
+            self.signal_emitter.emit(f"<p style='color:red;'><b>Network Error:</b> {e.reason}</p>", {})
+        except Exception as e:
+            self.signal_emitter.emit(f"<p style='color:red;'><b>An unexpected error occurred:</b> {e}</p>", {})
+
+
+class LLMPanel(QWidget):
+    response_received = pyqtSignal(str, dict)
+    add_note_requested = pyqtSignal(dict)
+    _SAVE_ACTION_URL_SCHEME = 'calibre-llm-action'
+    DEFAULT_ACTIONS = [
+        {'name': 'Summarize', 'prompt': 'Provide a concise summary of the following text.'},
+        {'name': 'Explain Simply', 'prompt': 'Explain the following text in simple, easy-to-understand terms.'},
+        {'name': 'Key Points', 'prompt': 'Extract the key points from the following text as a bulleted list.'},
+        {'name': 'Define Terms', 'prompt': 'Identify and define any technical or complex terms in the following text.'},
+        {'name': 'Correct Grammar', 'prompt': 'Correct any grammatical errors in the following text and provide the corrected version.'},
+        {'name': 'Translate to English', 'prompt': 'Translate the following text into English.'},
+    ]
+
+    def __init__(self, parent=None, viewer=None, lookup_widget=None):
+        super().__init__(parent)
+        self.viewer = viewer
+        self.lookup_widget = lookup_widget
+
+        self.conversation_history = []
+        self.last_response_text = ''
+        self.latched_highlight_uuid = None
+        self.latched_conversation_text = None
+        self.session_api_calls = 0
+        self.session_cost = 0.0
+        self.book_title = ''
+        self.book_authors = ''
+
+        self.layout = QVBoxLayout(self)
+        self.layout.setContentsMargins(5, 5, 5, 5)
+
+        self.quick_actions_group = QGroupBox(self)
+        self.quick_actions_group.setTitle('Quick Actions')
+        self.quick_actions_layout = QGridLayout(self.quick_actions_group)
+        self.layout.addWidget(self.quick_actions_group)
+        self.rebuild_actions_ui()
+
+        custom_prompt_group = QGroupBox(self)
+        custom_prompt_group.setTitle('Custom Prompt')
+        custom_prompt_layout = QHBoxLayout(custom_prompt_group)
+        self.custom_prompt_edit = QLineEdit(self)
+        self.custom_prompt_edit.setPlaceholderText('Or, enter your own request...')
+        self.custom_prompt_button = QPushButton('Send', self)
+        custom_prompt_layout.addWidget(self.custom_prompt_edit)
+        custom_prompt_layout.addWidget(self.custom_prompt_button)
+        self.layout.addWidget(custom_prompt_group)
+
+        self.result_display = QTextBrowser(self)
+        self.result_display.setOpenExternalLinks(False)
+        self.result_display.setMinimumHeight(150)
+        self.result_display.anchorClicked.connect(self._on_chat_link_clicked)
+        self.layout.addWidget(self.result_display)
+
+        response_actions_layout = QHBoxLayout()
+        self.save_note_button = QPushButton(QIcon.ic('plus.png'), 'Save as Note', self)
+        self.save_note_button.clicked.connect(self.save_as_note)
+
+        self.new_chat_button = QPushButton(QIcon.ic('edit-clear.png'), 'New Chat', self)
+        self.new_chat_button.setToolTip('Clear the current conversation history and start a new one')
+        self.new_chat_button.clicked.connect(self.start_new_conversation)
+        self.new_chat_button.setEnabled(False)
+
+        response_actions_layout.addWidget(self.save_note_button)
+        response_actions_layout.addWidget(self.new_chat_button)
+        response_actions_layout.addStretch()
+        self.layout.addLayout(response_actions_layout)
+
+        footer_layout = QHBoxLayout()
+        self.settings_button = QPushButton("⚙️ Settings")
+        self.settings_button.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.settings_button.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        self.api_usage_label = QLabel('API calls: 0 | Cost: ~$0.0000')
+        footer_layout.addWidget(self.settings_button)
+        footer_layout.addStretch()
+        footer_layout.addWidget(self.api_usage_label)
+        self.layout.addLayout(footer_layout)
+
+        self.custom_prompt_button.clicked.connect(self.run_custom_prompt)
+        self.custom_prompt_edit.returnPressed.connect(self.run_custom_prompt)
+        self.response_received.connect(self.show_response)
+        self.settings_button.clicked.connect(self.show_settings)
+        self.show_initial_message()
+
+    def update_book_metadata(self, metadata):
+        self.book_title = metadata.get('title', '')
+        authors = metadata.get('authors', [])
+        self.book_authors = ' & '.join(authors)
+
+    def rebuild_actions_ui(self):
+        while self.quick_actions_layout.count():
+            child = self.quick_actions_layout.takeAt(0)
+            if child.widget():
+                child.widget().deleteLater()
+        actions_json = vprefs.get('llm_quick_actions', json.dumps(self.DEFAULT_ACTIONS))
+        try:
+            actions = json.loads(actions_json)
+        except json.JSONDecodeError:
+            actions = self.DEFAULT_ACTIONS
+        positions = [(i, j) for i in range(4) for j in range(2)]
+        for i, action in enumerate(actions):
+            if i >= len(positions):
+                break
+            button = QPushButton(action['name'], self)
+            button.clicked.connect(lambda _, p=action['prompt']: self.start_api_call(p))
+            row, col = positions[i]
+            self.quick_actions_layout.addWidget(button, row, col)
+
+    def show_settings(self):
+        dialog = LLMSettingsDialog(self)
+        dialog.actions_updated.connect(self.rebuild_actions_ui)
+        dialog.exec()
+
+    def show_initial_message(self):
+        self.save_note_button.setEnabled(False)
+        api_key_hex = vprefs.get('llm_api_key', '') or ''
+        api_key = from_hex_unicode(api_key_hex)
+        if not api_key:
+            self.show_response("<p style='color:orange;'><b>Welcome!</b> Please add your OpenRouter.ai API key by clicking the <b>⚙️ Settings</b> button below.</p>", {})
+        else:
+            self.show_response("<b>Ready.</b> Select text in the book to begin.", {})
+
+    def update_with_text(self, text, highlight_data, is_read_only_view=False):
+        new_uuid = highlight_data.get('uuid') if highlight_data else None
+
+        if not text and not new_uuid:
+            if self.latched_conversation_text is not None or self.latched_highlight_uuid is not None:
+                self.start_new_conversation()
+            return
+
+        if is_read_only_view:
+            self.latched_highlight_uuid = new_uuid
+            self.latched_conversation_text = text
+            return
+
+        start_new_convo = False
+        if new_uuid != self.latched_highlight_uuid:
+            start_new_convo = True
+        elif new_uuid is None and text != self.latched_conversation_text:
+            start_new_convo = True
+
+        if start_new_convo:
+            self.conversation_history = []
+            self.last_response_text = ''
+            self.latched_highlight_uuid = new_uuid
+            self.latched_conversation_text = text
+
+            if text:
+                self.show_response(f"<b>Selected:</b><br><i>'{text[:200]}...'</i>", {})
+            else:
+                self.show_response("<b>Ready.</b> Ask a follow-up question.", {})
+
+        if self.latched_highlight_uuid:
+            self.save_note_button.setToolTip('Append this response to the existing highlight\'s note')
+        else:
+            self.save_note_button.setToolTip('Create a new highlight for the selected text and save this response as its note')
+
+    def run_custom_prompt(self):
+        prompt = self.custom_prompt_edit.text().strip()
+        if prompt:
+            self.start_api_call(prompt)
+
+    def start_new_conversation(self):
+        self.conversation_history = []
+        self.last_response_text = ''
+        self.latched_highlight_uuid = None
+        self.latched_conversation_text = None
+
+        self.new_chat_button.setEnabled(False)
+        self.save_note_button.setEnabled(False)
+        self.show_initial_message()
+
+    def _render_conversation_html(self, thinking=False):
+        base_table_style = "width: 95%; border-spacing: 0px; margin: 8px 5px;"
+        base_cell_style = "padding: 8px; vertical-align: top;"
+        text_style = "color: #E2E8F0;"
+        user_bgcolor = "#2D3748"
+        assistant_bgcolor = "#4A5568"
+        thinking_style = "color: #A0AEC0; font-style: italic; margin: 5px; padding: 8px;"
+        save_button_style = (
+            "color: #E2E8F0; text-decoration: none; font-weight: bold; "
+            "font-family: monospace; padding: 2px 6px; border: 1px solid #A0AEC0; border-radius: 4px;"
+        )
+        html_output = ''
+        for i, message in enumerate(self.conversation_history):
+            role = message.get('role')
+            content_for_display = message.get('content', '').replace('\n', '<br>')
+            if role == 'user':
+                bgcolor = user_bgcolor
+                label = "You"
+                html_output += f'''
+                <table style="{base_table_style}" bgcolor="{bgcolor}" cellspacing="0" cellpadding="0">
+                    <tr><td style="{base_cell_style}"><p style="{text_style}"><b>{label}:</b><br>{content_for_display}</p></td></tr>
+                </table>'''
+            elif role == 'assistant':
+                bgcolor = assistant_bgcolor
+                label = "Assistant"
+                save_button_href = f'http://{self._SAVE_ACTION_URL_SCHEME}/save?index={i}'
+                html_output += f'''
+                <table style="{base_table_style}" bgcolor="{bgcolor}" cellspacing="0" cellpadding="0">
+                    <tr>
+                        <td style="{base_cell_style}"><p style="{text_style}"><b>{label}:</b><br>{content_for_display}</p></td>
+                        <td style="padding: 8px; width: 60px; text-align: center; vertical-align: middle;">
+                            <a style="{save_button_style}" href="{save_button_href}" title="Save this specific response to the note">[ Save ]</a>
+                        </td>
+                    </tr>
+                </table>'''
+        if thinking:
+            html_output += f'<div style="{thinking_style}"><i>Querying model...</i></div>'
+        return html_output
+
+    def start_api_call(self, action_prompt):
+        api_key_hex = vprefs.get('llm_api_key', '') or ''
+        api_key = from_hex_unicode(api_key_hex)
+        if not api_key:
+            self.show_response("<p style='color:orange;'><b>API Key Missing.</b> Click the <b>⚙️ Settings</b> button to add your key.</p>", {})
+            return
+        if not self.latched_conversation_text:
+            self.show_response("<p style='color:red;'><b>Error:</b> No text is selected for this conversation.</p>", {})
+            return
+
+        is_first_message = not self.conversation_history
+        if is_first_message:
+            display_prompt_content = f"{action_prompt}\n\n<i>On text: \"{self.latched_conversation_text[:100]}...\"</i>"
+        else:
+            display_prompt_content = action_prompt
+        self.conversation_history.append({'role': 'user', 'content': display_prompt_content})
+
+        context_header = ""
+        if self.book_title:
+            context_header += f"The user is currently reading the book \"{self.book_title}\""
+            if self.book_authors:
+                context_header += f" by {self.book_authors}."
+            else:
+                context_header += "."
+
+        api_prompt_content = (
+            f"{context_header}\n\n"
+            f"{action_prompt}\n\n"
+            f"---\n\n"
+            f"Text to analyze:\n\n"
+            f"\"{self.latched_conversation_text}\""
+        )
+
+        api_call_history = list(self.conversation_history)
+        api_call_history[-1] = {'role': 'user', 'content': api_prompt_content}
+
+        self.result_display.setHtml(self._render_conversation_html(thinking=True))
+        self.result_display.verticalScrollBar().setValue(self.result_display.verticalScrollBar().maximum())
+        self.set_all_inputs_enabled(False)
+
+        model_id = vprefs.get('llm_model_id', 'google/gemini-1.5-flash')
+        provider_config = API_PROVIDERS['openrouter']
+        api_call_thread = LLMAPICall(
+            api_call_history, api_key, model_id, self.response_received, provider_config
+        )
+        api_call_thread.start()
+
+    def show_response(self, response_text, usage_data):
+        self.last_response_text = ''
+        is_error_or_status = "<b>" in response_text
+
+        if not is_error_or_status:
+            self.session_api_calls += 1
+            self.update_cost(usage_data)
+            self.last_response_text = response_text
+            self.conversation_history.append({'role': 'assistant', 'content': response_text})
+            self.new_chat_button.setEnabled(True)
+
+        self.save_note_button.setEnabled(bool(self.last_response_text) and bool(self.latched_conversation_text))
+
+        if is_error_or_status:
+            self.result_display.setHtml(response_text)
+        else:
+            self.result_display.setHtml(self._render_conversation_html())
+
+        self.result_display.verticalScrollBar().setValue(self.result_display.verticalScrollBar().maximum())
+        self.set_all_inputs_enabled(True)
+        self.custom_prompt_edit.clear()
+
+    def update_cost(self, usage_data):
+        model_id = vprefs.get('llm_model_id', 'google/gemini-1.5-flash')
+        prompt_tokens = usage_data.get('prompt_tokens', 0)
+        completion_tokens = usage_data.get('completion_tokens', 0)
+        prompt_cost = 0.0
+        completion_cost = 0.0
+        if not model_id.endswith(':free'):
+            costs = MODEL_COSTS.get(model_id, MODEL_COSTS['default'])
+            prompt_cost = (prompt_tokens / 1_000_000) * costs[0]
+            completion_cost = (completion_tokens / 1_000_000) * costs[1]
+        self.session_cost += prompt_cost + completion_cost
+        self.api_usage_label.setText(f'API calls: {self.session_api_calls} | Cost: ~${self.session_cost:.4f}')
+
+    def save_as_note(self):
+        if self.last_response_text and self.latched_conversation_text:
+            payload = {
+                'highlight': self.latched_highlight_uuid,
+                'conversation_history': self.conversation_history
+            }
+            self.add_note_requested.emit(payload)
+
+    def save_specific_note(self, message_index):
+        if not (0 <= message_index < len(self.conversation_history)):
+            return
+        target_message = self.conversation_history[message_index]
+        if target_message.get('role') != 'assistant':
+            return
+        history_for_record = self.conversation_history[:message_index + 1]
+        payload = {
+            'highlight': self.latched_highlight_uuid,
+            'conversation_history': history_for_record
+        }
+        self.add_note_requested.emit(payload)
+
+    def _on_chat_link_clicked(self, qurl):
+        url_str = qurl.toString()
+        parsed_url = urlparse(url_str)
+        if parsed_url.hostname == self._SAVE_ACTION_URL_SCHEME and parsed_url.path == '/save':
+            query_params = parse_qs(parsed_url.query)
+            index_str = query_params.get('index', [None])[0]
+            if index_str is not None:
+                try:
+                    index = int(index_str)
+                    self.save_specific_note(index)
+                except (ValueError, TypeError):
+                    pass
+            return
+
+    def set_all_inputs_enabled(self, enabled):
+        for i in range(self.quick_actions_layout.count()):
+            widget = self.quick_actions_layout.itemAt(i).widget()
+            if widget:
+                widget.setEnabled(enabled)
+        self.custom_prompt_edit.setEnabled(enabled)
+        self.custom_prompt_button.setEnabled(enabled)
+
+class ActionEditDialog(QDialog):
+    def __init__(self, action=None, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle('Edit Quick Action' if action else 'Add Quick Action')
+        self.layout = QFormLayout(self)
+        self.name_edit = QLineEdit(self)
+        self.prompt_edit = QTextEdit(self)
+        self.prompt_edit.setAcceptRichText(False)
+        self.prompt_edit.setMinimumHeight(100)
+        self.layout.addRow('Button Name:', self.name_edit)
+        self.layout.addRow('System Prompt:', self.prompt_edit)
+        self.button_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
+        self.layout.addWidget(self.button_box)
+        self.button_box.accepted.connect(self.accept)
+        self.button_box.rejected.connect(self.reject)
+        if action:
+            self.name_edit.setText(action.get('name', ''))
+            self.prompt_edit.setPlainText(action.get('prompt', ''))
+        self.name_edit.installEventFilter(self)
+        self.prompt_edit.installEventFilter(self)
+
+    def eventFilter(self, obj, event):
+        if event.type() == QEvent.Type.KeyPress:
+            if obj is self.name_edit and event.key() in (Qt.Key.Key_Return, Qt.Key.Key_Enter):
+                self.prompt_edit.setFocus()
+                return True
+            if obj is self.prompt_edit and event.key() in (Qt.Key.Key_Return, Qt.Key.Key_Enter):
+                if event.modifiers() & Qt.KeyboardModifier.ControlModifier:
+                    self.accept()
+                    return True
+        return super().eventFilter(obj, event)
+
+    def get_action(self):
+        return {'name': self.name_edit.text().strip(), 'prompt': self.prompt_edit.toPlainText().strip()}
+
+class LLMSettingsDialog(QDialog):
+    actions_updated = pyqtSignal()
+    DEFAULT_ACTIONS = LLMPanel.DEFAULT_ACTIONS
+    COLOR_MAP = {
+        'yellow': 'Yellow highlight',
+        'green': 'Green highlight',
+        'blue': 'Blue highlight',
+        'red': 'Pink highlight',
+        'purple': 'Purple highlight',
+    }
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle('LLM Settings (OpenRouter)')
+        self.setMinimumWidth(550)
+        self.layout = QVBoxLayout(self)
+        api_model_layout = QFormLayout()
+        api_key_layout = QHBoxLayout()
+        self.api_key_edit = QLineEdit(self)
+        self.api_key_edit.setPlaceholderText('Paste your OpenRouter.ai API key here')
+        self.clear_api_key_button = QPushButton('Clear', self)
+        api_key_layout.addWidget(self.api_key_edit)
+        api_key_layout.addWidget(self.clear_api_key_button)
+        self.model_edit = QLineEdit(self)
+        self.model_edit.setPlaceholderText('google/gemini-flash-1.5')
+
+        self.highlight_color_combo = QComboBox(self)
+
+        model_label = QLabel('Model (<a href="https://openrouter.ai/models">see list</a>):')
+        model_label.setOpenExternalLinks(True)
+        api_model_layout.addRow('API Key:', api_key_layout)
+        api_model_layout.addRow(model_label, self.model_edit)
+        api_model_layout.addRow('Highlight Color:', self.highlight_color_combo)
+        self.layout.addLayout(api_model_layout)
+        self.layout.addWidget(QLabel('<h3>Quick Actions</h3>'))
+        self.actions_list = QListWidget(self)
+        self.actions_list.setDragDropMode(QAbstractItemView.DragDropMode.InternalMove)
+        self.layout.addWidget(self.actions_list)
+        actions_button_layout = QHBoxLayout()
+        self.add_button = QPushButton('Add...')
+        self.edit_button = QPushButton('Edit...')
+        self.remove_button = QPushButton('Remove')
+        self.reset_button = QPushButton('Reset to Defaults')
+        actions_button_layout.addWidget(self.add_button)
+        actions_button_layout.addWidget(self.edit_button)
+        actions_button_layout.addWidget(self.remove_button)
+        actions_button_layout.addStretch()
+        actions_button_layout.addWidget(self.reset_button)
+        self.layout.addLayout(actions_button_layout)
+        self.button_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
+        self.layout.addWidget(self.button_box)
+        self.button_box.accepted.connect(self.accept)
+        self.button_box.rejected.connect(self.reject)
+        self.clear_api_key_button.clicked.connect(self.clear_api_key)
+        self.add_button.clicked.connect(self.add_action)
+        self.edit_button.clicked.connect(self.edit_action)
+        self.remove_button.clicked.connect(self.remove_action)
+        self.reset_button.clicked.connect(self.reset_actions)
+        self.actions_list.itemDoubleClicked.connect(self.edit_action)
+        self.load_settings()
+        self.actions_list.setFocus()
+
+    def load_settings(self):
+        self.api_key_edit.setText(from_hex_unicode(vprefs.get('llm_api_key', '')))
+        self.model_edit.setText(vprefs.get('llm_model_id', 'google/gemini-flash-1.5'))
+
+        self.highlight_color_combo.clear()
+        current_color_internal_name = vprefs.get('llm_highlight_color', 'yellow')
+
+        for internal_name, friendly_name in self.COLOR_MAP.items():
+            self.highlight_color_combo.addItem(friendly_name, internal_name)
+
+        index_to_set = self.highlight_color_combo.findData(current_color_internal_name)
+        if index_to_set != -1:
+            self.highlight_color_combo.setCurrentIndex(index_to_set)
+
+        self.load_actions_from_prefs()
+
+    def load_actions_from_prefs(self):
+        self.actions_list.clear()
+        actions_json = vprefs.get('llm_quick_actions', json.dumps(self.DEFAULT_ACTIONS))
+        try:
+            actions = json.loads(actions_json)
+        except json.JSONDecodeError:
+            actions = self.DEFAULT_ACTIONS
+        for action in actions:
+            item = QListWidgetItem(action['name'], self.actions_list)
+            item.setData(Qt.ItemDataRole.UserRole, action)
+
+    def add_action(self):
+        dialog = ActionEditDialog(parent=self)
+        if dialog.exec() == QDialog.DialogCode.Accepted:
+            action = dialog.get_action()
+            if action['name'] and action['prompt']:
+                item = QListWidgetItem(action['name'], self.actions_list)
+                item.setData(Qt.ItemDataRole.UserRole, action)
+
+    def edit_action(self):
+        item = self.actions_list.currentItem()
+        if not item:
+            return
+        action = item.data(Qt.ItemDataRole.UserRole)
+        dialog = ActionEditDialog(action, parent=self)
+        if dialog.exec() == QDialog.DialogCode.Accepted:
+            new_action = dialog.get_action()
+            if new_action['name'] and new_action['prompt']:
+                item.setText(new_action['name'])
+                item.setData(Qt.ItemDataRole.UserRole, new_action)
+
+    def remove_action(self):
+        item = self.actions_list.currentItem()
+        if item and QMessageBox.question(self, 'Confirm Remove', f"Remove the '{item.text()}' action?",
+                                        QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No) == QMessageBox.StandardButton.Yes:
+            self.actions_list.takeItem(self.actions_list.row(item))
+
+    def reset_actions(self):
+        if QMessageBox.question(self, 'Confirm Reset', "Reset all quick actions to their default state?",
+                                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No) == QMessageBox.StandardButton.Yes:
+            vprefs.set('llm_quick_actions', json.dumps(self.DEFAULT_ACTIONS))
+            self.load_actions_from_prefs()
+
+    def clear_api_key(self):
+        self.api_key_edit.clear()
+
+    def accept(self):
+        vprefs.set('llm_api_key', as_hex_unicode(self.api_key_edit.text().strip()))
+        vprefs.set('llm_model_id', self.model_edit.text().strip() or 'google/gemini-flash-1.5')
+
+        selected_internal_name = self.highlight_color_combo.currentData()
+        vprefs.set('llm_highlight_color', selected_internal_name or 'yellow')
+
+        actions = []
+        for i in range(self.actions_list.count()):
+            item = self.actions_list.item(i)
+            actions.append(item.data(Qt.ItemDataRole.UserRole))
+        vprefs.set('llm_quick_actions', json.dumps(actions))
+        self.actions_updated.emit()
+        super().accept()

--- a/src/calibre/gui2/viewer/ui.py
+++ b/src/calibre/gui2/viewer/ui.py
@@ -6,51 +6,50 @@ import os
 import re
 import sys
 import time
+import uuid
 from collections import defaultdict, namedtuple
 from hashlib import sha256
 from threading import Thread
+from datetime import datetime
 
 from qt.core import (
-    QApplication,
-    QCursor,
-    QDockWidget,
-    QEvent,
-    QMainWindow,
-    QMenu,
-    QMimeData,
-    QModelIndex,
-    QPixmap,
-    Qt,
-    QTimer,
-    QToolBar,
-    QUrl,
-    QVBoxLayout,
-    QWidget,
-    pyqtSignal,
-    sip,
+    QAbstractItemView, QAction, QApplication, QCursor, QDockWidget, QEvent,
+    QMainWindow, QMenu, QMimeData, QModelIndex, QPixmap, Qt, QTimer, QToolBar,
+    QUrl, QVBoxLayout, QWidget, pyqtSignal, sip
 )
 
 from calibre import prints
 from calibre.constants import ismacos, iswindows
 from calibre.customize.ui import available_input_formats
 from calibre.db.annotations import merge_annotations
-from calibre.gui2 import add_to_recent_docs, choose_files, error_dialog, sanitize_env_vars
+from calibre.gui2 import (
+    add_to_recent_docs, choose_files, error_dialog, sanitize_env_vars
+)
 from calibre.gui2.dialogs.drm_error import DRMErrorMessage
 from calibre.gui2.image_popup import ImagePopup
 from calibre.gui2.main_window import MainWindow
-from calibre.gui2.viewer import get_boss, get_current_book_data, performance_monitor
-from calibre.gui2.viewer.annotations import AnnotationsSaveWorker, annotations_dir, parse_annotations
+from calibre.gui2.viewer import (
+    get_boss, get_current_book_data, performance_monitor
+)
+from calibre.gui2.viewer.annotations import (
+    AnnotationsSaveWorker, annotations_dir, parse_annotations
+)
 from calibre.gui2.viewer.bookmarks import BookmarkManager
-from calibre.gui2.viewer.config import get_session_pref, load_reading_rates, save_reading_rates, vprefs
+from calibre.gui2.viewer.config import (
+    get_session_pref, load_reading_rates, save_reading_rates, vprefs
+)
 from calibre.gui2.viewer.convert_book import prepare_book
 from calibre.gui2.viewer.highlights import HighlightsPanel
-from calibre.gui2.viewer.integration import get_book_library_details, load_annotations_map_from_library
-from calibre.gui2.viewer.lookup import Lookup
+from calibre.gui2.viewer.integration import (
+    get_book_library_details, load_annotations_map_from_library
+)
 from calibre.gui2.viewer.overlay import LoadingOverlay
 from calibre.gui2.viewer.search import SearchPanel
 from calibre.gui2.viewer.toc import TOC, TOCSearch, TOCView
 from calibre.gui2.viewer.toolbars import ActionsToolBar
-from calibre.gui2.viewer.web_view import WebView, get_path_for_name, set_book_path
+from calibre.gui2.viewer.web_view import (
+    WebView, get_path_for_name, set_book_path
+)
 from calibre.startup import connect_lambda
 from calibre.utils.date import utcnow
 from calibre.utils.img import image_from_path
@@ -71,10 +70,8 @@ def is_float(x):
 def dock_defs():
     Dock = namedtuple('Dock', 'name title initial_area allowed_areas')
     ans = {}
-
     def d(title, name, area, allowed=Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea):
         ans[name] = Dock(name + '-dock', title, area, allowed)
-
     d(_('Table of Contents'), 'toc', Qt.DockWidgetArea.LeftDockWidgetArea)
     d(_('Lookup'), 'lookup', Qt.DockWidgetArea.RightDockWidgetArea)
     d(_('Bookmarks'), 'bookmarks', Qt.DockWidgetArea.RightDockWidgetArea)
@@ -98,6 +95,8 @@ class EbookViewer(MainWindow):
     def __init__(self, open_at=None, continue_reading=None, force_reload=False, calibre_book_data=None):
         MainWindow.__init__(self, None)
         get_boss(self)
+
+        self.pending_note_for_next_highlight = None
         self.annotations_saver = None
         self.calibre_book_data_for_first_book = calibre_book_data
         self.shutting_down = self.close_forced = self.shutdown_done = False
@@ -156,7 +155,8 @@ class EbookViewer(MainWindow):
         self.search_dock.setWidget(w)
         self.search_dock.visibilityChanged.connect(self.search_widget.visibility_changed)
 
-        self.lookup_widget = w = Lookup(self)
+        from calibre.gui2.viewer.lookup import Lookup
+        self.lookup_widget = w = Lookup(self, viewer=self)
         self.lookup_dock.visibilityChanged.connect(self.lookup_widget.visibility_changed)
         self.lookup_dock.setWidget(w)
 
@@ -207,8 +207,8 @@ class EbookViewer(MainWindow):
         self.web_view.update_reading_rates.connect(self.update_reading_rates)
         self.web_view.edit_book.connect(self.edit_book)
         self.web_view.content_file_changed.connect(self.content_file_changed)
+
         self.actions_toolbar.initialize(self.web_view, self.search_dock.toggleViewAction())
-        at.update_action_state(False)
         self.setCentralWidget(self.web_view)
         self.loading_overlay = LoadingOverlay(self)
         self.restore_state()
@@ -219,14 +219,25 @@ class EbookViewer(MainWindow):
         self.highlights_widget.notes_edited_signal.connect(self.notes_edited)
         if continue_reading:
             self.continue_reading()
+
         self.setup_mouse_auto_hide()
+
+        try:
+            self.lookup_widget.llm_add_note_requested.disconnect(self.add_note_to_highlight)
+        except TypeError:
+            pass
+        self.lookup_widget.llm_add_note_requested.connect(self.add_note_to_highlight)
+
+    def create_uuid(self):
+        return uuid.uuid4().hex
 
     def shortcuts_changed(self, smap):
         rmap = defaultdict(list)
         for k, v in iteritems(smap):
             rmap[v].append(k)
         self.actions_toolbar.set_tooltips(rmap)
-        self.highlights_widget.set_tooltips(rmap)
+        if hasattr(self, 'highlights_widget'):
+            self.highlights_widget.set_tooltips(rmap)
 
     def resizeEvent(self, ev):
         self.loading_overlay.resize(self.size())
@@ -399,7 +410,6 @@ class EbookViewer(MainWindow):
 
     def bookmarks_edited(self, bookmarks):
         self.current_book_data['annotations_map']['bookmark'] = bookmarks
-        # annotations will be saved in book file on exit
         self.save_annotations(in_book_file=False)
 
     def goto_cfi(self, cfi, add_to_history=False):
@@ -419,22 +429,18 @@ class EbookViewer(MainWindow):
                 self.image_popup.current_url = QUrl.fromLocalFile(path)
                 self.image_popup()
             else:
-                error_dialog(self, _('Invalid image'), _(
-                    'Failed to load the image {}').format(name), show=True)
+                error_dialog(self, _('Invalid image'), _('Failed to load the image {}').format(name), show=True)
         else:
-            error_dialog(self, _('Image not found'), _(
-                    'Failed to find the image {}').format(name), show=True)
+            error_dialog(self, _('Image not found'), _('Failed to find the image {}').format(name), show=True)
 
     def copy_image(self, name):
         path = get_path_for_name(name)
         if not path:
-            return error_dialog(self, _('Image not found'), _(
-                'Failed to find the image {}').format(name), show=True)
+            return error_dialog(self, _('Image not found'), _('Failed to find the image {}').format(name), show=True)
         try:
             img = image_from_path(path)
         except Exception:
-            return error_dialog(self, _('Invalid image'), _(
-                'Failed to load the image {}').format(name), show=True)
+            return error_dialog(self, _('Invalid image'), _('Failed to load the image {}').format(name), show=True)
         url = QUrl.fromLocalFile(path)
         md = QMimeData()
         md.setImageData(img)
@@ -470,8 +476,7 @@ class EbookViewer(MainWindow):
 
     def print_book(self):
         if not hasattr(set_book_path, 'pathtoebook'):
-            error_dialog(self, _('Cannot print book'), _(
-                'No book is currently open'), show=True)
+            error_dialog(self, _('Cannot print book'), _('No book is currently open'), show=True)
             return
         from .printing import print_book
         print_book(set_book_path.pathtoebook, book_title=self.current_book_data['metadata']['title'], parent=self)
@@ -496,8 +501,7 @@ class EbookViewer(MainWindow):
     def ask_for_open_from_js(self, path):
         if path and not os.path.exists(path):
             self.web_view.remove_recently_opened(path)
-            error_dialog(self, _('Book does not exist'), _(
-                'Cannot open {} as it no longer exists').format(path), show=True)
+            error_dialog(self, _('Book does not exist'), _('Cannot open {} as it no longer exists').format(path), show=True)
         else:
             self.ask_for_open(path)
 
@@ -577,9 +581,7 @@ class EbookViewer(MainWindow):
             if last_line.startswith('calibre.ebooks.DRMError'):
                 DRMErrorMessage(self).exec()
             else:
-                error_dialog(self, _('Loading book failed'), _(
-                    'Failed to open the book at {0}. Click "Show details" for more info.').format(data['pathtoebook']),
-                    det_msg=tb, show=True)
+                error_dialog(self, _('Loading book failed'), _('Failed to open the book at {0}. Click "Show details" for more info.').format(data['pathtoebook']), det_msg=tb, show=True)
             self.loading_overlay.hide()
             self.web_view.show_home_page()
             return
@@ -631,6 +633,8 @@ class EbookViewer(MainWindow):
         rates = load_reading_rates(self.current_book_data['annotations_path_key'])
         self.web_view.start_book_load(initial_position=initial_position, highlights=highlights, current_book_data=self.current_book_data, reading_rates=rates)
         performance_monitor('webview loading requested')
+
+        self.lookup_widget.book_loaded(self.current_book_data)
 
     def load_book_data(self, calibre_book_data=None):
         self.current_book_data['book_library_details'] = get_book_library_details(self.current_book_data['pathtoebook'])
@@ -700,8 +704,7 @@ class EbookViewer(MainWindow):
     def cfi_changed(self, cfi):
         if not self.current_book_data:
             return
-        self.current_book_data['annotations_map']['last-read'] = [{
-            'pos': cfi, 'pos_type': 'epubcfi', 'timestamp': utcnow().isoformat()}]
+        self.current_book_data['annotations_map']['last-read'] = [{'pos': cfi, 'pos_type': 'epubcfi', 'timestamp': utcnow().isoformat()}]
         self.save_pos_timer.start()
     # }}}
 
@@ -732,46 +735,22 @@ class EbookViewer(MainWindow):
         if key and rates:
             save_reading_rates(key, rates)
 
-    def highlights_changed(self, highlights):
-        if not self.current_book_data:
-            return
-        amap = self.current_book_data['annotations_map']
-        amap['highlight'] = highlights
-        self.highlights_widget.refresh(highlights)
-        self.save_annotations()
-
-    def notes_edited(self, uuid, notes):
-        for h in self.current_book_data['annotations_map']['highlight']:
-            if h.get('uuid') == uuid:
-                h['notes'] = notes
-                h['timestamp'] = utcnow().isoformat()
-                break
-        else:
-            return
-        self.save_annotations()
-
     def edit_book(self, file_name, progress_frac, selected_text):
         import subprocess
-
         from calibre.ebooks.oeb.polish.main import SUPPORTED
         from calibre.utils.ipc.launch import exe_path, macos_edit_book_bundle_path
         try:
             path = set_book_path.pathtoebook
         except AttributeError:
-            return error_dialog(self, _('Cannot edit book'), _(
-                'No book is currently open'), show=True)
+            return error_dialog(self, _('Cannot edit book'), _('No book is currently open'), show=True)
         fmt = path.rpartition('.')[-1].upper().replace('ORIGINAL_', '')
         if fmt not in SUPPORTED:
-            return error_dialog(self, _('Cannot edit book'), _(
-                'The book must be in the %s formats to edit.'
-                '\n\nFirst convert the book to one of these formats.'
-            ) % (_(' or ').join(SUPPORTED)), show=True)
+            return error_dialog(self, _('Cannot edit book'), _('The book must be in the %s formats to edit.\n\nFirst convert the book to one of these formats.') % (_(' or ').join(SUPPORTED)), show=True)
         exe = 'ebook-edit'
         if ismacos:
             exe = os.path.join(macos_edit_book_bundle_path(), exe)
         else:
             exe = exe_path(exe)
-
         cmd = [exe] if isinstance(exe, str) else list(exe)
         if selected_text:
             cmd += ['--select-text', selected_text]
@@ -859,7 +838,6 @@ class EbookViewer(MainWindow):
             self.hide_cursor_timer.start()
         elif et == QEvent.Type.FocusIn:
             if iswindows and obj and obj.objectName() == 'EbookViewerClassWindow' and self.isFullScreen():
-                # See https://bugs.launchpad.net/calibre/+bug/1918591
                 self.web_view.repair_after_fullscreen_switch()
         return False
 
@@ -868,3 +846,139 @@ class EbookViewer(MainWindow):
             self.cursor_hidden = True
             QApplication.instance().setOverrideCursor(Qt.CursorShape.BlankCursor)
     # }}}
+
+    def highlights_changed(self, changed_annotations: list):
+        try:
+            if self.pending_note_for_next_highlight:
+                old_uuids = {h.get('uuid') for h in self.current_book_data.get('annotations_map', {}).get('highlight', []) if h.get('uuid')}
+                new_master_uuids = {h.get('uuid') for h in changed_annotations if h.get('uuid')}
+                newly_created_uuids = new_master_uuids - old_uuids
+
+                if newly_created_uuids:
+                    new_uuid = newly_created_uuids.pop()
+                    note_to_add = self.pending_note_for_next_highlight
+
+                    js_payload_note = {'uuid': new_uuid, 'notes': note_to_add}
+                    self.web_view.generic_action('set-notes-in-highlight', js_payload_note)
+
+                    for h in changed_annotations:
+                        if h.get('uuid') == new_uuid:
+                            h['notes'] = note_to_add
+                            break
+
+                    js_payload_focus = {'uuid': new_uuid}
+                    self.web_view.generic_action('show-highlight-selection-bar', js_payload_focus)
+
+                    self.pending_note_for_next_highlight = None
+                else:
+                    self.pending_note_for_next_highlight = None
+
+            master_map = self.current_book_data.setdefault('annotations_map', {})
+            master_map['highlight'] = changed_annotations
+            self.highlights_widget.load(changed_annotations)
+            self.save_annotations()
+
+        except Exception:
+            import traceback
+            traceback.print_exc()
+
+    def notes_edited(self, uuid, notes):
+        for h in self.current_book_data['annotations_map']['highlight']:
+            if h.get('uuid') == uuid:
+                h['notes'] = notes
+                h['timestamp'] = utcnow().isoformat()
+                break
+        else:
+            return
+        self.save_annotations()
+        self.web_view.generic_action('set-notes-in-highlight', {'uuid': uuid, 'notes': notes})
+
+    def _format_llm_note_entry(self, history: list) -> str:
+        """
+        Formats a conversation history into a standardized, self-contained note entry.
+        """
+        if not history:
+            return ""
+
+        main_response = ''
+        for message in reversed(history):
+            if message.get('role') == 'assistant':
+                main_response = message.get('content', '').strip()
+                break
+
+        if not main_response:
+            return ""
+
+        def clean_text(text):
+            return text.replace('<i>', '').replace('</i>', '')
+
+        timestamp = datetime.now().strftime("%b %d, %Y, %I:%M:%S %p")
+        header = f"--- AI Assistant Note ({timestamp}) ---"
+
+        record_lines = []
+        for message in history:
+            role = "You" if message.get('role') == 'user' else "Assistant"
+            content = clean_text(message.get('content', ''))
+
+            prompt_part = content
+            text_part = ""
+            if "\nOn text:" in content:
+                parts = content.split("\nOn text:", 1)
+                prompt_part = parts[0].strip()
+                text_part = f"On text:{parts[1]}"
+
+            entry = f"{role}: {prompt_part}"
+            if text_part:
+                entry += f"\n\n{text_part}"
+            record_lines.append(entry)
+
+        record_body = "\n\n".join(record_lines)
+        record_header = "--- Conversation Record ---"
+
+        return (
+            f"{header}\n\n{main_response}\n\n"
+            f"------------------------------------\n\n"
+            f"{record_header}\n\n{record_body}"
+        )
+
+    def add_note_to_highlight(self, payload):
+        highlight_uuid = payload.get('highlight')
+        history = payload.get('conversation_history', [])
+
+        new_self_contained_entry = self._format_llm_note_entry(history)
+        if not new_self_contained_entry:
+            return
+
+        if highlight_uuid:
+            found_highlight = False
+            highlight_list = self.current_book_data.setdefault('annotations_map', {}).get('highlight', [])
+            for h in highlight_list:
+                if h.get('uuid') == highlight_uuid:
+                    found_highlight = True
+                    existing_note = h.get('notes', '').strip()
+
+                    separator = f"\n\n------------------------------------\n\n"
+                    combined_note = f"{existing_note}{separator}{new_self_contained_entry}" if existing_note else new_self_contained_entry
+
+                    h['notes'] = combined_note
+                    h['timestamp'] = utcnow().isoformat()
+
+                    js_payload = {'uuid': highlight_uuid, 'notes': combined_note}
+                    self.web_view.generic_action('set-notes-in-highlight', js_payload)
+
+                    self.save_annotations()
+                    self.statusBar().showMessage('Note appended to highlight', 3000)
+                    break
+
+            if not found_highlight:
+                # This case should ideally not be hit if the logic is sound, but it is a safe fallback.
+                pass
+
+        else:
+            self.pending_note_for_next_highlight = new_self_contained_entry
+            js_payload = {
+                'type': 'apply-highlight',
+                'style': {'type': 'builtin', 'kind': 'color', 'which': vprefs.get('llm_highlight_color', 'yellow')},
+            }
+            self.web_view.generic_action('annotations', js_payload)
+            self.statusBar().showMessage('Creating highlight with note...', 3000)


### PR DESCRIPTION
Dear Kovid, may this pull request find you very well!

Following our discussion between each other and peers on [MobileRead](https://www.mobileread.com/forums/showthread.php?t=369298), I have implemented the proposed LLM integration as a tab in the lookout panel. It is fully modular (all logic isolated in llm.py) and lazy-loaded (nothing loads until the LLM tab is clicked; zero cost for non-users). It also persists the last-open tab, just [as you suggested](https://www.mobileread.com/forums/showpost.php?p=4530010&postcount=18).

Images of the feature:
<img width="437" height="1115" alt="image" src="https://github.com/user-attachments/assets/5705fe4a-b296-407c-a98c-bc2125deaa0f" />
<img width="681" height="480" alt="image" src="https://github.com/user-attachments/assets/41b31fee-5f4e-4614-a773-107ab13bec33" />
<img width="457" height="376" alt="image" src="https://github.com/user-attachments/assets/bab561b8-243a-462a-a8f4-932bf2764f67" />


Also, some additional ideas I had:
- Allowing the user to ask follow-up questions about the same piece of selected text (e.g., user could "Summarize" then "Elaborate" then "Translate" all without having to go to a separate window)
- Adding a small "Add as note" button next to the LLM's response - thus, the AI-generated response can be appended to the "Notes" field of the original highlight
- Optional real-time cost estimate for the session (instead of just the # of API calls)

Thank you for all your time and support in this matter, for this opportunity to contribute, and for all that you have done for Calibre! I look forward to your feedback, Kovid!

---
Integrates LLM query interface as a new tab in the existing Lookup panel (within Calibre's E-Book Viewer), following feedback from Kovid Goyal on MobileRead forums. The interface is implemented in a modular way + is lazily loaded on first use to ensure zero performance cost when inactive.