### PR TITLE
[pdf] Add classes to display different headers and footers on the first pages of top level sections

### DIFF
--- a/manual/conversion.rst
+++ b/manual/conversion.rst
@@ -871,6 +871,12 @@ header template will show the title on odd pages and the author on even pages::
         <div class="odd-page"><i>_TITLE_</i></div>
     </header>
 
+In addition there are some more classes you can use in the headers and footers,
+documented below:
+
+  * ``first-section-page`` - include only on the first page of top level sections
+  * ``not-first-section-page`` - exclude from the first page of top level sections
+
 calibre will automatically replace :code:`_TITLE_` and :code:`_AUTHOR_` with
 the title and author of the document being converted. Setting
 :code:`justify-content` to :code:`flex-end` will cause the text to be right

--- a/src/calibre/ebooks/pdf/html_writer.py
+++ b/src/calibre/ebooks/pdf/html_writer.py
@@ -1060,10 +1060,14 @@ def add_header_footer(manager, opts, pdf_doc, container, page_number_display_map
         ans.set('style', style)
         for child in ans.xpath('descendant-or-self::*[@class]'):
             cls = frozenset(child.get('class').split())
-            q = 'even-page' if page_num % 2 else 'odd-page'
-            if q in cls or q.replace('-', '_') in cls:
-                style = child.get('style') or ''
-                child.set('style', style + '; display: none')
+            classes_to_hide = [
+                'even-page' if page_num % 2 else 'odd-page',
+                'not-first-section-page' if toplevel_pagenum_map[page_num - 1] == 1 else 'first-section-page',
+            ]
+            for c in classes_to_hide:
+                if c in cls or c.replace('-', '_') in cls:
+                    style = child.get('style') or ''
+                    child.set('style', style + '; display: none')
         return ans
 
     pages_in_doc = pdf_doc.page_count()

--- a/src/calibre/ebooks/pdf/html_writer.py
+++ b/src/calibre/ebooks/pdf/html_writer.py
@@ -999,10 +999,13 @@ def add_header_footer(manager, opts, pdf_doc, container, page_number_display_map
             section_nums.append(counter)
         return totals, section_nums
 
+    # For page number n in the document:
+    # toplevel_pagetotal_map[n-1] returns the total number of pages in its containing top-level section
+    # toplevel_pagenum_map[n-1] returns its 1-indexed page number within its containing top-level section
     if toc is None:
         page_toc_map = stack_to_map(())
         toplevel_toc_map = stack_to_map(())
-        toplevel_pagenum_map, toplevel_pages_map = page_counts_map(())
+        toplevel_pagetotal_map, toplevel_pagenum_map = page_counts_map(())
     else:
         page_toc_map = stack_to_map(create_toc_stack(toc.iterdescendants(level=0)))
 
@@ -1011,7 +1014,7 @@ def add_header_footer(manager, opts, pdf_doc, container, page_number_display_map
                 yield 0, x
 
         toplevel_toc_map = stack_to_map(create_toc_stack(tc()))
-        toplevel_pagenum_map, toplevel_pages_map = page_counts_map(tc())
+        toplevel_pagetotal_map, toplevel_pagenum_map = page_counts_map(tc())
 
     dpi = 96  # don't know how to query Qt for this, seems to be the same on all platforms
     def pt_to_px(pt): return int(pt * dpi / 72)
@@ -1038,8 +1041,8 @@ def add_header_footer(manager, opts, pdf_doc, container, page_number_display_map
 
     def format_template(template, page_num, height, margins):
         div_width_px = pt_to_px(page_layout.paintRectPoints().width() - margins.left - margins.right)
-        template = template.replace('_TOP_LEVEL_SECTION_PAGES_', str(toplevel_pagenum_map[page_num - 1]))
-        template = template.replace('_TOP_LEVEL_SECTION_PAGENUM_', str(toplevel_pages_map[page_num - 1]))
+        template = template.replace('_TOP_LEVEL_SECTION_PAGES_', str(toplevel_pagetotal_map[page_num - 1]))
+        template = template.replace('_TOP_LEVEL_SECTION_PAGENUM_', str(toplevel_pagenum_map[page_num - 1]))
         template = template.replace('_TOTAL_PAGES_', str(pages_in_doc))
         template = template.replace('_PAGENUM_', str(page_number_display_map[page_num]))
         template = template.replace('_TITLE_', prepare_string_for_xml(pdf_metadata.title, True))


### PR DESCRIPTION
In most printed books, it's common to have an empty header on the first page of each chapter, where the chapter title is the focus. This diff introduces the classes `first-section-page` and `not-first-section-page` to support this functionality.