### PR TITLE
Improve slightly the final page of the wizard

### DIFF
--- a/src/calibre/gui2/wizard/finish.ui
+++ b/src/calibre/gui2/wizard/finish.ui
@@ -75,6 +75,19 @@
      </property>
     </widget>
    </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
   </layout>
  </widget>
  <resources/>


### PR DESCRIPTION
Improve slightly the readability the final page of the wizard by making the Tutorial and Manual sections more one the center of the dialog, rather that at the full bottom of it.