### PR TITLE
Update polish.py

### DIFF
--- a/src/calibre/gui2/actions/polish.py
+++ b/src/calibre/gui2/actions/polish.py
@@ -102,18 +102,18 @@ class Polish(QDialog):  # {{{
         count = 0
         self.all_actions = OrderedDict([
             ('embed', _('&Embed all referenced fonts')),
-            ('subset', _('&Subset all embedded fonts')),
+            ('subset', _('Su&bset all embedded fonts')),
             ('smarten_punctuation', _('Smarten &punctuation')),
             ('metadata', _('Update &metadata in the book files')),
-            ('do_cover', _('Update the &cover in the book files')),
+            ('do_cover', _('Update the co&ver in the book files')),
             ('jacket', _('Add/replace metadata as a "book &jacket" page')),
-            ('remove_jacket', _('&Remove a previously inserted book jacket')),
+            ('remove_jacket', _('Remove a previously inserted book jac&ket')),
             ('remove_unused_css', _('Remove &unused CSS rules from the book')),
-            ('compress_images', _('Losslessly &compress images')),
+            ('compress_images', _('Losslessly compress &images')),
             ('download_external_resources', _('&Download external resources')),
-            ('add_soft_hyphens', _('Add s&oft hyphens')),
-            ('remove_soft_hyphens', _('Remove so&ft hyphens')),
-            ('upgrade_book', _('&Upgrade book internals')),
+            ('add_soft_hyphens', _('Add soft &hyphens')),
+            ('remove_soft_hyphens', _('Remove soft h&yphens')),
+            ('upgrade_book', _('Up&grade book internals')),
         ])
         prefs = gprefs.get('polishing_settings', {})
         for name, text in iteritems(self.all_actions):
@@ -161,6 +161,7 @@ class Polish(QDialog):  # {{{
         self.none_button = b = bb.addButton(_('Select &none'), QDialogButtonBox.ButtonRole.ActionRole)
         connect_lambda(b.clicked, self, lambda self: self.select_all(False))
         l.addWidget(bb, count+1, 1, 1, -1)
+        bb.setFocus()
         self.setup_load_button()
         self.resize(self.sizeHint())
 


### PR DESCRIPTION
Changed default focus to "OK" button instead of the first checkbox.

When activating the "Polish Books" dialog and pressing the Enter key without changing any options, the expected behavior should be running the Polish action with the saved selection.

Also changed repeating shortcut key hints so every element now has a unique one, prioritizing action buttons over setting checkboxes.