### PR TITLE
Drop unused exec permission for log files

### DIFF
--- a/src/calibre/srv/utils.py
+++ b/src/calibre/srv/utils.py
@@ -285,7 +285,7 @@ class RotatingStream:
             self.stream = share_open(self.filename, 'a', newline='')
         else:
             # see https://bugs.python.org/issue27805
-            self.stream = open(os.open(self.filename, os.O_WRONLY|os.O_APPEND|os.O_CREAT|os.O_CLOEXEC), 'w')
+            self.stream = open(os.open(self.filename, os.O_WRONLY|os.O_APPEND|os.O_CREAT|os.O_CLOEXEC, mode=0o666), 'w')
         try:
             self.stream.tell()
         except OSError:


### PR DESCRIPTION
Python's default permission mode is 0o777.
Use mode 0o666 for text log files to drop unwanted exec permission.
