### PR TITLE
Allow using templates to define custom tooltips for the books list. …

### DIFF
--- a/src/calibre/db/backend.py
+++ b/src/calibre/db/backend.py
@@ -628,6 +628,7 @@ class DB:
         defs['styled_columns'] = {}
         defs['edit_metadata_ignore_display_order'] = False
         defs['fts_enabled'] = False
+        defs['column_tooltip_templates'] = {}
 
         # Migrate the bool tristate tweak
         defs['bools_are_tristate'] = \


### PR DESCRIPTION
…The action is on the column context menu. It might be good to add a "calibre action" to do the same thing so the it can be put on book context menu etc.