### PR TITLE
Update GitHub Actions dependencies and enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,13 @@ jobs:
                 os: [ubuntu-latest, macos-latest, windows-latest]
         steps:
             - name: Checkout source code
-              uses: actions/checkout@v3
+              uses: actions/checkout@v5
               with:
                 fetch-depth: 10
                 persist-credentials: false
 
             - name: Set up Python
-              uses: actions/setup-python@v3
+              uses: actions/setup-python@v6
               with:
                 python-version: "3.10"
 
@@ -51,7 +51,7 @@ jobs:
                 pacman -S --noconfirm tar
 
             - name: Checkout source code
-              uses: actions/checkout@master
+              uses: actions/checkout@v5
               with:
                 fetch-depth: 10
 

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -21,7 +21,7 @@ jobs:
                 pacman -S --noconfirm tar
 
             - name: Checkout source code
-              uses: actions/checkout@master
+              uses: actions/checkout@v5
               with:
                 fetch-depth: 2
                 persist-credentials: false


### PR DESCRIPTION
[Dependabot](https://docs.github.com/en/code-security/dependabot/ecosystems-supported-by-dependabot/supported-ecosystems-and-repositories) will keep these action dependencies updated with pull requests