### PR TITLE
Update nytimes.py

### DIFF
--- a/src/calibre/web/site_parsers/nytimes.py
+++ b/src/calibre/web/site_parsers/nytimes.py
@@ -9,7 +9,7 @@ from xml.sax.saxutils import escape, quoteattr
 
 from calibre.utils.iso8601 import parse_iso8601
 
-module_version = 14  # needed for live updates
+module_version = 15  # needed for live updates
 pprint
 
 
@@ -198,8 +198,8 @@ def article_parse(data):
 def clean_js_json(text):
     text = re.sub(r'\bundefined\b', 'null', text)
     text = re.sub(
-        r',?\s*"[^"]+"\s*:\s*function\s*\([^)]*\)\s*\{.*?\}',
-        '',
+        r'{\"checkGate\":.*',
+        'null}}',
         text,
         flags=re.DOTALL
     )
@@ -207,7 +207,7 @@ def clean_js_json(text):
 
 
 def json_to_html(raw):
-    data = json.JSONDecoder(strict=False).raw_decode(raw)[0]
+    data = json.loads(clean_js_json(raw))
     # open('/t/raw.json', 'w').write(json.dumps(data, indent=2))
     try:
         data = data['initialData']['data']


### PR DESCRIPTION
fix JSON decode error

```
Could not fetch link https://www.nytimes.com/2025/09/12/opinion/trump-bolsonaro-conviction-democracy.html
Traceback (most recent call last):
  File "calibre\web\fetch\simple.py", line 557, in process_links
  File "calibre\web\fetch\simple.py", line 194, in get_soup
  File "calibre\web\feeds\news.py", line 670, in preprocess_raw_html_
  File "<string>", line 146, in preprocess_raw_html
  File "calibre.web.site_parsers.nytimes", line 295, in extract_html
  File "calibre.web.site_parsers.nytimes", line 210, in json_to_html
  File "json\decoder.py", line 355, in raw_decode
json.decoder.JSONDecodeError: Expecting value: line 1 column 51320 (char 51319)
```

EDIT: tested with nytimes feeds recipe.