### PR TITLE
Several related formatter/template changes:

### DIFF
--- a/src/calibre/gui2/__init__.py
+++ b/src/calibre/gui2/__init__.py
@@ -488,6 +488,8 @@ def create_defs():
     defs['book_details_note_link_icon_width'] = 1.0
     defs['tag_browser_show_category_icons'] = True
     defs['tag_browser_show_value_icons'] = True
+    defs['template_editor_run_as_you_type'] = True
+    defs['template_editor_show_all_selected_books'] = True
 
     def migrate_tweak(tweak_name, pref_name):
         # If the tweak has been changed then leave the tweak in the file so

--- a/src/calibre/gui2/dialogs/template_dialog.ui
+++ b/src/calibre/gui2/dialogs/template_dialog.ui
@@ -206,14 +206,13 @@
             </widget>
            </item>
            <item>
-            <widget class="QCheckBox" name="break_box">
+            <widget class="QCheckBox" name="run_as_you_type_box">
              <property name="text">
-              <string>Enable &amp;breakpoints</string>
+              <string>R&amp;un as you type</string>
              </property>
              <property name="toolTip">
-              <string>&lt;p&gt;If checked, the template evaluator will stop when it
-evaluates an expression on a double-clicked line number, opening a dialog showing
-you the value as well as all the local variables&lt;/p&gt;</string>
+              <string>&lt;p&gt;If checked then the template will be run (tested) after every
+keystroke. If unchecked then the template will be run when the "Go" button is pushed.&lt;/p&gt;</string>
              </property>
             </widget>
            </item>
@@ -237,7 +236,7 @@ you the value as well as all the local variables&lt;/p&gt;</string>
               <set>Qt::ToolButtonTextBesideIcon</set>
              </property>
              <property name="toolTip">
-              <string>If 'Enable breakpoints' is checked then click this button to run your template</string>
+              <string>If 'Run as you type' is not checked then click this button to run your template</string>
              </property>
             </widget>
            </item>
@@ -245,6 +244,18 @@ you the value as well as all the local variables&lt;/p&gt;</string>
             <widget class="Separator">
              <property name="buddy">
               <cstring>go_button</cstring>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="break_box">
+             <property name="text">
+              <string>Enable &amp;breakpoints</string>
+             </property>
+             <property name="toolTip">
+              <string>&lt;p&gt;If checked, the template evaluator will stop when it
+evaluates an expression on a double-clicked line number, opening a dialog showing
+you the value as well as all the local variables&lt;/p&gt;</string>
              </property>
             </widget>
            </item>
@@ -378,17 +389,34 @@ you the value as well as all the local variables&lt;/p&gt;</string>
           </widget>
          </item>
          <item row="7" column="0">
-          <widget class="QLabel">
-           <property name="text">
-            <string>Template value:</string>
-           </property>
-           <property name="buddy">
-            <cstring>template_value</cstring>
-           </property>
-           <property name="toolTip">
-            <string>The value of the template using the current book in the library view</string>
-           </property>
-          </widget>
+          <layout class="QHBoxLayout">
+           <item>
+            <widget class="QLabel">
+             <property name="text">
+              <string>Template value:</string>
+             </property>
+             <property name="buddy">
+              <cstring>template_value</cstring>
+             </property>
+             <property name="toolTip">
+              <string>The value of the template using the currently selected book(s)
+in the library view</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="show_all_selected_books">
+             <property name="text">
+              <string>Show template result for all selected books</string>
+             </property>
+             <property name="toolTip">
+              <string>&lt;p&gt;If checked then the template will be evaluated for all selected
+books. If not checked then the template will be evaluated for the first selected book. Unchecking this
+box is useful if the template uses the selected books to generate a report.&lt;/p&gt;</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </item>
          <item row="8" column="0" colspan="3">
           <widget class="QTableWidget" name="template_value">


### PR DESCRIPTION
* Add a "with" statement to the template language that for the duration of the code block changes the "current book" to the one specified by the book id.
* A new formatter function selected_books() that returns the book ids of the currently selected books
* A new formatter function selected_column() that returns the lookup name of the column containing the selected cell.
* A new formatter function sort_book_ids() that sorts the books specified by book_ids.
* A new formatter function show_dialog() that opens a dialog to display plain text or html.
* Add check boxes to the template tester to control "run as you type" and to restrict test runs to the first selected book.

Here is an example using several of the new features:

```
program:
 ids = sort_book_ids(selected_books(), 'series', 1, 'title', 1);
 res = '<style> th, td {padding: 2px;}</style> <h2>Book Size Report</h2><p><table>';
 total = 0;

 def table_row(title, series, size):
  return strcat('<tr><td>', title, '</td>',
       '<td>', series, '</td>',
       '<td>', if size !=# 0 then human_readable(size) else '0' fi, '</td>',
       '</tr>', character('newline'))
 fed;

 for id in ids:
  with id:
   s = booksize();
   total = total + s;
   res = strcat(res, table_row($title, $series, s))
  htiw
 rof;
 res = strcat(res, table_row('TOTAL', '', total));
 res = strcat(res, '</table>');
 show_dialog(res)
```