### PR TITLE
Fix deletion of symlink targets on Windows

### DIFF
--- a/src/calibre/utils/copy_files.py
+++ b/src/calibre/utils/copy_files.py
@@ -104,6 +104,9 @@ class WindowsFileCopier:
 
     def _open_file(self, path: str, retry_on_sharing_violation: bool = True, is_folder: bool = False) -> 'winutil.Handle':
         flags = winutil.FILE_FLAG_BACKUP_SEMANTICS if is_folder else winutil.FILE_FLAG_SEQUENTIAL_SCAN
+        if os.path.islink(path):
+            # Do not open symbolic link target to prevent unwanted delete_on_close
+            flags |= 0x00200000 # winutil.FILE_FLAG_OPEN_REPARSE_POINT
         access_flags = winutil.GENERIC_READ
         if self.delete_all:
             access_flags |= winutil.DELETE


### PR DESCRIPTION
If any book formats in a Calibre library are Windows symbolic links, renaming the book (or making any change that prompts Calibre into moving the symlink) will delete the _link target_. This can cause data loss.

Calibre opens symbolic links without `FILE_FLAG_OPEN_REPARSE_POINT`. Therefore the `delete_on_close` functionality will delete the target file and not the symbolic link. On POSIX, `unlink` deletes the link itself (as seen in `UnixFileCopier` class).

**To reproduce:**
1. Create new library.
2. Add new book from file `test.epub`.
3. Go into library folder and move `test.epub` to `X:\test.epub`.
4. Link `X:\test.epub` back to `test.epub`.
5. Calibre will accept this symbolic link.
6. Rename `test` ⇒ `test rename`.
7. File `X:\test.epub` is deleted while symlink still exists but is broken.

I do not know whether Calibre ever uses symbolic links which means this problem is unlikely to manifest during normal usage. Therefore, I'm not sure if this is something that we'd want fixed, but, given the severity (I'm lucky I had backups) and the Unix/Windows standardization benefits it might be worth it. Looking online I can see that at least some users had the idea to use symbolic links. My use-case is only linking some larger .pdf files to external storage.

It is also possible to add `FILE_FLAG_OPEN_REPARSE_POINT` flag to _all_ opened files because the flag does nothing if file is not a link.