### PR TITLE
add get_book_path() to Cache (DRY)

### DIFF
--- a/src/calibre/db/copy_to_library.py
+++ b/src/calibre/db/copy_to_library.py
@@ -112,7 +112,7 @@ def copy_one_book(
         new_book_id = newdb.add_books(
             [(mi, format_map)], add_duplicates=True, apply_import_tags=tweaks['add_new_book_tags_when_importing_books'],
             preserve_uuid=preserve_uuid, run_hooks=False)[0][0]
-        bp = db.field_for('path', book_id)
+        bp = db.get_book_path(book_id, sep='/', unsafe=True)
         if bp:
             for (relpath, src_path, stat_result) in db.backend.iter_extra_files(book_id, bp, db.fields['formats'], yield_paths=True):
                 nbp = newdb.field_for('path', new_book_id)

--- a/src/calibre/db/legacy.py
+++ b/src/calibre/db/legacy.py
@@ -325,7 +325,7 @@ class LibraryDatabase:
     def path(self, index, index_is_id=False):
         'Return the relative path to the directory containing this books files as a unicode string.'
         book_id = index if index_is_id else self.id(index)
-        return self.new_api.field_for('path', book_id).replace('/', os.sep)
+        return self.new_api.get_book_path(book_id)
 
     def abspath(self, index, index_is_id=False, create_dirs=True):
         'Return the absolute path to the directory containing this books files as a unicode string.'

--- a/src/calibre/db/tests/filesystem.py
+++ b/src/calibre/db/tests/filesystem.py
@@ -104,7 +104,7 @@ class FilesystemTest(BaseTest):
                 expected_contents.add(fname + '.' + fmt.lower())
             ae(expected_contents, bookdir_contents)
             fs_path = bookdir.split(os.sep)[-2:]
-            db_path = cache.field_for('path', book_id).split('/')
+            db_path = cache.get_book_path(book_id, sep='/').split('/')
             ae(db_path, fs_path)
             ae(initial_side_data, side_data(book_id))
 

--- a/src/calibre/db/tests/writing.py
+++ b/src/calibre/db/tests/writing.py
@@ -379,7 +379,7 @@ class WritingTest(BaseTest):
 
         def read_all_extra_files(book_id=1):
             ans = {}
-            bp = cache.field_for('path', book_id)
+            bp = cache.get_book_path(book_id, sep='/')
             for (relpath, fobj, stat_result) in cache.backend.iter_extra_files(book_id, bp, cache.fields['formats']):
                 ans[relpath] = fobj.read()
             return ans

--- a/src/calibre/gui2/dialogs/book_info.py
+++ b/src/calibre/gui2/dialogs/book_info.py
@@ -306,7 +306,7 @@ class BookInfo(QDialog, DropMixin):
                 dbn = db.new_api
                 mi = dbn.get_metadata(book_id, get_cover=False)
                 mi.cover_data = [None, dbn.cover(book_id, as_image=True)]
-                mi.path = dbn._field_for('path', book_id)
+                mi.path = dbn.get_book_path(book_id, sep='/')
                 mi.format_files = dbn.format_files(book_id)
                 mi.marked = db.data.get_marked(book_id)
                 mi.field_metadata = db.field_metadata


### PR DESCRIPTION
Add a get_book_path() method to Cache. DRY, "migrate" the LibraryDatabase.path methode that as no equivalent in the new api and also allow a more clear behavior if you want use a unsafe book_id.