### PR TITLE
Check library malformed paths and malformed formats

### DIFF
--- a/src/calibre/gui2/dialogs/check_library.py
+++ b/src/calibre/gui2/dialogs/check_library.py
@@ -548,6 +548,24 @@ class CheckLibraryDialog(QDialog):
             id = int(item.data(0, Qt.ItemDataRole.UserRole))
             self.db.set_has_cover(id, True)
 
+    def fix_malformed_paths(self):
+        tl = self.top_level_items['malformed_paths']
+        child_count = tl.childCount()
+        for i in range(child_count):
+            item = tl.child(i)
+            id_ = int(item.data(0, Qt.ItemDataRole.UserRole))
+            lib_path = item.text(2)
+            db_path = self.db.path(id_, index_is_id=True)
+            path_ath_lib = os.path.join(self.db.library_path, lib_path.split(os.sep)[0])
+            path_ath_db = os.path.join(self.db.library_path, db_path.split(os.sep)[0])
+            path_lib = os.path.join(self.db.library_path, lib_path)
+            path_db = os.path.join(self.db.library_path, db_path)
+            os.makedirs(path_ath_db, exist_ok=True)
+            os.rename(path_lib, path_db)
+            dirpath, dirnames, filenames = next(os.walk(path_ath_lib))
+            if not dirnames and not filenames:
+                os.rmdir(path_ath_lib)
+
     def fix_items(self):
         for check in CHECKS:
             attr = check[0]

--- a/src/calibre/gui2/dialogs/check_library.py
+++ b/src/calibre/gui2/dialogs/check_library.py
@@ -566,6 +566,18 @@ class CheckLibraryDialog(QDialog):
             if not dirnames and not filenames:
                 os.rmdir(path_ath_lib)
 
+    def fix_malformed_formats(self):
+        tl = self.top_level_items['malformed_formats']
+        child_count = tl.childCount()
+        for i in range(child_count):
+            item = tl.child(i)
+            id_ = int(item.data(0, Qt.ItemDataRole.UserRole))
+            lib_path = item.text(2)
+            book_path = os.path.join(*lib_path.split(os.sep)[:-1])
+            ext = os.path.splitext(lib_path)[1].strip('.')
+            filename = self.db.new_api.format_files(id_)[ext.upper()] +'.'+ ext.lower()
+            os.rename(os.path.join((self.db.library_path, lib_path)), os.path.join((self.db.library_path, book_path, filename)))
+
     def fix_items(self):
         for check in CHECKS:
             attr = check[0]

--- a/src/calibre/library/check_library.py
+++ b/src/calibre/library/check_library.py
@@ -129,13 +129,11 @@ class CheckLibrary:
                     id_ = m.group(1)
                     # Third check: the id_ must be in the DB and the paths must match
                     if self.is_case_sensitive:
-                        if int(id_) not in self.all_ids or \
-                                db_path not in self.all_dbpaths:
+                        if int(id_) not in self.all_ids or db_path not in self.all_dbpaths:
                             self.extra_titles.append((title_dir, db_path, 0))
                             continue
                     else:
-                        if int(id_) not in self.all_ids or \
-                                db_path.lower() not in self.all_lc_dbpaths:
+                        if int(id_) not in self.all_ids or db_path.lower() not in self.all_lc_dbpaths:
                             self.extra_titles.append((title_dir, db_path, 0))
                             continue
 
@@ -164,14 +162,11 @@ class CheckLibrary:
             path = self.dbpath(id_)
             if not os.path.exists(os.path.join(lib, path)):
                 title_dir = os.path.basename(path)
-                book_formats = frozenset(x for x in
-                            self.db.format_files(id_, index_is_id=True))
+                book_formats = frozenset(x for x in self.db.format_files(id_, index_is_id=True))
                 for fmt in book_formats:
-                    self.missing_formats.append((title_dir,
-                            os.path.join(path, fmt[0]+'.'+fmt[1].lower()), id_))
+                    self.missing_formats.append((title_dir, os.path.join(path, fmt[0]+'.'+fmt[1].lower()), id_))
                 if self.db.has_cover(id_):
-                    self.missing_covers.append((title_dir,
-                            os.path.join(path, COVER_FILE_NAME), id_))
+                    self.missing_covers.append((title_dir, os.path.join(path, COVER_FILE_NAME), id_))
 
     def is_ebook_file(self, filename):
         ext = os.path.splitext(filename)[1]
@@ -202,21 +197,18 @@ class CheckLibrary:
             for fn in unknowns:
                 if fn in missing:  # An unknown format correctly registered
                     continue
-                self.extra_files.append((title_dir,
-                                         os.path.join(db_path, fn), book_id))
+                self.extra_files.append((title_dir, os.path.join(db_path, fn), book_id))
 
             # Check: any book formats that should be there?
             for fn in missing:
                 if fn in unknowns:  # An unknown format correctly registered
                     continue
-                self.missing_formats.append((title_dir,
-                                             os.path.join(db_path, fn), book_id))
+                self.missing_formats.append((title_dir, os.path.join(db_path, fn), book_id))
 
             # Check: any book formats that shouldn't be there?
             extra = formats - book_formats - NORMALS
             for e in extra:
-                self.extra_formats.append((title_dir,
-                                           os.path.join(db_path, e), book_id))
+                self.extra_formats.append((title_dir, os.path.join(db_path, e), book_id))
         else:
             def lc_map(fnames, fset):
                 fn = {}
@@ -236,28 +228,23 @@ class CheckLibrary:
             for lcfn,ccfn in iteritems(lc_map(filenames, unknowns)):
                 if lcfn in missing:  # An unknown format correctly registered
                     continue
-                self.extra_files.append((title_dir, os.path.join(db_path, ccfn),
-                                         book_id))
+                self.extra_files.append((title_dir, os.path.join(db_path, ccfn), book_id))
 
             # Check: any book formats that should be there?
             for lcfn,ccfn in iteritems(lc_map(book_formats, missing)):
                 if lcfn in unknowns:  # An unknown format correctly registered
                     continue
-                self.missing_formats.append((title_dir,
-                                             os.path.join(db_path, ccfn), book_id))
+                self.missing_formats.append((title_dir, os.path.join(db_path, ccfn), book_id))
 
             # Check: any book formats that shouldn't be there?
             extra = formats_lc - book_formats_lc - NORMALS
             for e in lc_map(formats, extra):
-                self.extra_formats.append((title_dir, os.path.join(db_path, e),
-                                           book_id))
+                self.extra_formats.append((title_dir, os.path.join(db_path, e), book_id))
 
         # check cached has_cover
         if self.db.has_cover(book_id):
             if COVER_FILE_NAME not in filenames:
-                self.missing_covers.append((title_dir,
-                        os.path.join(db_path, COVER_FILE_NAME), book_id))
+                self.missing_covers.append((title_dir, os.path.join(db_path, COVER_FILE_NAME), book_id))
         else:
             if COVER_FILE_NAME in filenames:
-                self.extra_covers.append((title_dir,
-                        os.path.join(db_path, COVER_FILE_NAME), book_id))
+                self.extra_covers.append((title_dir, os.path.join(db_path, COVER_FILE_NAME), book_id))


### PR DESCRIPTION
Add the feature to check a malformed paths and/or malformed formats into a library if running on a case sensitive system, and to fix them.