### PR TITLE
fix: add better timeout to fts wait

### DIFF
--- a/src/calibre/db/tests/fts_api.py
+++ b/src/calibre/db/tests/fts_api.py
@@ -53,7 +53,7 @@ class FTSAPITest(BaseTest):
         self.libraries_to_close.append(ans)
         return ans
 
-    def wait_for_fts_to_finish(self, fts, timeout=10):
+    def wait_for_fts_to_finish(self, fts, timeout=30):
         import apsw
         if fts.pool.initialized:
             st = time.monotonic()


### PR DESCRIPTION
Running the tests on a slow QEMU aarch64 Linux virtual machine results in the following failure:

```
       > test_winutil (calibre.test_build.BuildTest.test_winutil) ... skipped 'winutil is windows only' [0.0 s]
       > test_wpd (calibre.test_build.BuildTest.test_wpd) ... skipped 'WPD is windows only' [0.0 s]
       > test_zeroconf (calibre.test_build.BuildTest.test_zeroconf) ... ok [3.6 s]
       > test_forked_map (calibre.utils.forked_map.find_tests.<locals>.TestForkedMap.test_forked_map) ... ok [1.2 s]
       >
       > ======================================================================
       > FAIL: test_fts_search (calibre.db.tests.fts_api.FTSAPITest.test_fts_search)
       > ----------------------------------------------------------------------
       > Traceback (most recent call last):
       >   File "/build/calibre-8.12.0/src/calibre/db/tests/fts_api.py", line 149, in test_fts_search
       >     self.assertFalse(fts.all_currently_dirty())
       >     ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
       > AssertionError: [(2, 'MD')] is not false
       >
       > ----------------------------------------------------------------------
       > Ran 342 tests in 476.872s
       >
       > FAILED (failures=1, skipped=10)
```

This appears to be a timing issue: on slower systems, the FTS layer may not flush all_currently_dirty() before the assertion check is performed.

Increasing the test timeout resolves the problem.
