### PR TITLE
Add OAuth 2.0 support for email sending

### DIFF
--- a/src/calibre/gui2/dialogs/oauth_reauth.py
+++ b/src/calibre/gui2/dialogs/oauth_reauth.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+# License: GPLv3 Copyright: 2026, Kovid Goyal <kovid at kovidgoyal.net>
+
+
+from qt.core import QDialog, QDialogButtonBox, QGridLayout, QIcon, QLabel, QPushButton, QSizePolicy, Qt
+
+from calibre.utils.resources import get_image_path as I
+
+
+class OAuthReauthMessage(QDialog):
+
+    def __init__(self, parent=None, title=None, provider=None):
+        QDialog.__init__(self, parent)
+        self.gui = parent
+        self.setWindowTitle(_('Email Authorization Required'))
+        self.setWindowIcon(QIcon(I('mail.png')))
+
+        l = QGridLayout(self)
+        self.setLayout(l)
+
+        la = QLabel()
+        la.setPixmap(QIcon(I('dialog_warning.png')).pixmap(64, 64))
+        la.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        l.addWidget(la, 0, 0, Qt.AlignmentFlag.AlignTop)
+
+        pname = {'gmail': 'Google', 'outlook': 'Microsoft'}.get(provider, provider or 'your email provider')
+        msg = _(
+            '<h3>Email Authorization Expired</h3>'
+            '<p>Your {0} authorization has expired or been revoked. '
+            'This can happen if you changed your password, revoked access, '
+            'or the authorization expired due to inactivity.</p>'
+            '<p>Click <b>Re-authorize</b> to set up email again.</p>'
+        ).format(pname)
+        if title:
+            msg = _('<p>Failed to email: {0}</p>').format(title) + msg
+
+        self.msg = QLabel(msg)
+        self.msg.setWordWrap(True)
+        l.addWidget(self.msg, 0, 1)
+
+        bb = QDialogButtonBox()
+        self.reauth_btn = QPushButton(_('&Re-authorize'))
+        self.reauth_btn.setIcon(QIcon(I('config.png')))
+        self.reauth_btn.clicked.connect(self.do_reauth)
+        bb.addButton(self.reauth_btn, QDialogButtonBox.ButtonRole.AcceptRole)
+        bb.addButton(QDialogButtonBox.StandardButton.Close)
+        bb.rejected.connect(self.reject)
+        l.addWidget(bb, 1, 0, 1, 2)
+
+        self.resize(450, 250)
+
+    def do_reauth(self):
+        self.accept()
+        if self.gui is not None:
+            try:
+                self.gui.iactions['Preferences'].do_config(
+                    initial_plugin=('Sharing', 'Email'), close_after_initial=True)
+            except Exception:
+                pass
+
+
+if __name__ == '__main__':
+    from calibre.gui2 import Application
+    app = Application([])
+    d = OAuthReauthMessage(title='Test Book', provider='gmail')
+    d.exec()

--- a/src/calibre/gui2/dialogs/oauth_setup.py
+++ b/src/calibre/gui2/dialogs/oauth_setup.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python
+# License: GPLv3 Copyright: 2026, Kovid Goyal <kovid at kovidgoyal.net>
+
+
+from qt.core import (
+    QApplication, QComboBox, QDialog, QEvent, QFormLayout, QGroupBox,
+    QHBoxLayout, QLabel, QProgressDialog, QPushButton, Qt, QTextBrowser, QVBoxLayout,
+)
+
+from calibre.gui2 import error_dialog, info_dialog
+
+
+class OAuth2SetupDialog(QDialog):
+
+    GMAIL_DOMAINS = ('@gmail.com', '@googlemail.com')
+    OUTLOOK_DOMAINS = ('@outlook.com', '@hotmail.com', '@live.com', '@msn.com')
+
+    def __init__(self, parent, provider='gmail', email=''):
+        super().__init__(parent)
+        self.setWindowTitle(_('Setup OAuth 2.0 Authentication'))
+        self.resize(550, 400)
+        self.tokens = None
+        self.email_address = email
+        from calibre.utils.oauth2 import get_available_providers
+        self.available_providers = get_available_providers()
+        self.provider, self.provider_detected = self._detect_provider(email, provider)
+        self.setup_ui()
+
+    def _detect_provider(self, email, fallback='gmail'):
+        from calibre.utils.oauth2 import is_provider_available
+        available_names = [p[0] for p in self.available_providers]
+        email_lower = email.lower()
+        if any(email_lower.endswith(d) for d in self.GMAIL_DOMAINS):
+            if is_provider_available('gmail'):
+                return 'gmail', True
+        elif any(email_lower.endswith(d) for d in self.OUTLOOK_DOMAINS):
+            if is_provider_available('outlook'):
+                return 'outlook', True
+        if fallback in available_names:
+            return fallback, False
+        if available_names:
+            return available_names[0], False
+        return fallback, False
+
+    def setup_ui(self):
+        layout = QVBoxLayout(self)
+
+        header = QLabel(_('<h3>Setup OAuth 2.0 Authentication</h3>'
+            '<p>OAuth 2.0 is the recommended authentication method for Gmail and Outlook. '
+            'It is more secure than using passwords and does not require app-specific passwords.</p>'))
+        header.setWordWrap(True)
+        layout.addWidget(header)
+
+        provider_group = QGroupBox(_('Email Provider'))
+        provider_layout = QFormLayout(provider_group)
+        self.provider_combo = QComboBox()
+        for provider_id, provider_display in self.available_providers:
+            self.provider_combo.addItem(_(provider_display), provider_id)
+        idx = self.provider_combo.findData(self.provider)
+        if idx >= 0:
+            self.provider_combo.setCurrentIndex(idx)
+
+        if self.provider_detected:
+            provider_name = {'gmail': 'Gmail', 'outlook': 'Outlook'}.get(self.provider, self.provider)
+            self.provider_label = QLabel(f'<b>{provider_name}</b>')
+            provider_layout.addRow(_('Provider:'), self.provider_label)
+            self.provider_combo.hide()
+        elif len(self.available_providers) > 1:
+            self.provider_note = QLabel(_('<i>Could not detect provider from email domain.</i>'))
+            self.provider_note.setWordWrap(True)
+            provider_layout.addRow(self.provider_note)
+            provider_layout.addRow(_('Provider:'), self.provider_combo)
+        elif len(self.available_providers) == 1:
+            provider_name = self.available_providers[0][1]
+            self.provider_label = QLabel(f'<b>{provider_name}</b>')
+            provider_layout.addRow(_('Provider:'), self.provider_label)
+            self.provider_combo.hide()
+        layout.addWidget(provider_group)
+
+        instructions_group = QGroupBox(_('Instructions'))
+        instructions_layout = QVBoxLayout(instructions_group)
+        instructions = QTextBrowser()
+        instructions.setOpenExternalLinks(False)
+        instructions.setMaximumHeight(120)
+        instructions.setHtml(_('<ol>'
+            '<li>Click "Authorize" below</li>'
+            '<li>Your web browser will open to the provider\'s login page</li>'
+            '<li>Sign in and grant calibre permission to send email</li>'
+            '<li>The browser will redirect back automatically</li>'
+            '</ol>'
+            '<p><b>Note:</b> Calibre never sees your password.</p>'))
+        instructions_layout.addWidget(instructions)
+        layout.addWidget(instructions_group)
+
+        self.status_label = QLabel()
+        self.status_label.setWordWrap(True)
+        layout.addWidget(self.status_label)
+
+        button_layout = QHBoxLayout()
+        button_layout.addStretch()
+        self.authorize_button = QPushButton(_('Authorize'))
+        self.authorize_button.setDefault(True)
+        self.authorize_button.clicked.connect(self.start_oauth_flow)
+        button_layout.addWidget(self.authorize_button)
+        self.cancel_button = QPushButton(_('Cancel'))
+        self.cancel_button.clicked.connect(self.reject)
+        button_layout.addWidget(self.cancel_button)
+        layout.addLayout(button_layout)
+
+    def get_selected_provider(self):
+        return self.provider if self.provider_detected else self.provider_combo.currentData()
+
+    def start_oauth_flow(self):
+        provider = self.get_selected_provider()
+        self.authorize_button.setEnabled(False)
+        self.cancel_button.setEnabled(False)
+        self.status_label.setText(_('Starting authorization...'))
+
+        progress = QProgressDialog(
+            _('Waiting for authorization in browser...\n\nThis dialog will close automatically when done.'),
+            _('Cancel'), 0, 0, self)
+        progress.setWindowTitle(_('OAuth Authorization'))
+        progress.setWindowModality(Qt.WindowModality.WindowModal)
+        progress.setMinimumDuration(0)
+        progress.setValue(0)
+
+        from threading import Thread
+
+        class FlowCompleteEvent(QEvent):
+            EVENT_TYPE = QEvent.Type(QEvent.registerEventType())
+            def __init__(self, success, error_msg):
+                super().__init__(self.EVENT_TYPE)
+                self.success = success
+                self.error_msg = error_msg
+
+        self.FlowCompleteEvent = FlowCompleteEvent
+
+        def run_flow():
+            try:
+                from calibre.utils.oauth2 import OAuth2Error, start_oauth_flow as do_oauth_flow
+                self.tokens = do_oauth_flow(provider)
+                QApplication.instance().postEvent(self, FlowCompleteEvent(True, None))
+            except OAuth2Error as e:
+                QApplication.instance().postEvent(self, FlowCompleteEvent(False, str(e)))
+            except Exception as e:
+                QApplication.instance().postEvent(self, FlowCompleteEvent(False, str(e)))
+
+        def handle_flow_complete(event):
+            progress.close()
+            if event.success:
+                self.status_label.setText(_('<b style="color: green;">Authorization successful!</b>'))
+                info_dialog(self, _('Success'), _('OAuth 2.0 authorization was successful!'), show=True)
+                self.accept()
+            else:
+                self.status_label.setText(_('<b style="color: red;">Authorization failed</b>'))
+                self.authorize_button.setEnabled(True)
+                self.cancel_button.setEnabled(True)
+                error_dialog(self, _('Authorization Failed'),
+                    _('OAuth 2.0 authorization failed:\n\n{error}').format(error=event.error_msg or _('Unknown error')), show=True)
+
+        self.handle_flow_complete = handle_flow_complete
+
+        def cancel_flow():
+            progress.close()
+            self.status_label.setText(_('Authorization cancelled'))
+            self.authorize_button.setEnabled(True)
+            self.cancel_button.setEnabled(True)
+
+        progress.canceled.connect(cancel_flow)
+        Thread(target=run_flow, daemon=True).start()
+
+    def event(self, e):
+        if hasattr(self, 'FlowCompleteEvent') and isinstance(e, self.FlowCompleteEvent):
+            self.handle_flow_complete(e)
+            return True
+        return super().event(e)
+
+    def get_tokens(self):
+        return self.tokens
+
+
+if __name__ == '__main__':
+    from calibre.gui2 import Application
+    app = Application([])
+    d = OAuth2SetupDialog(None, provider='gmail', email='test@gmail.com')
+    d.exec()
+    print('Got tokens:', d.tokens.keys() if d.tokens else 'None')

--- a/src/calibre/gui2/ui.py
+++ b/src/calibre/gui2/ui.py
@@ -1087,6 +1087,22 @@ class Main(MainWindow, MainWindowMixin, DeviceMixin, EmailMixin,  # {{{
                     self._modeless_dialogs.append(d)
                 return
 
+            if 'calibre.utils.oauth2.OAuth2ReauthenticationRequired' in job.details:
+                if not minz:
+                    from calibre.gui2.dialogs.oauth_reauth import OAuthReauthMessage
+                    title = provider = None
+                    if job.description and job.description.startswith(_('Email ')):
+                        title = job.description[len(_('Email ')):].partition(' ' + _('to') + ' ')[0]
+                    if 'Google' in job.details:
+                        provider = 'gmail'
+                    elif 'Microsoft' in job.details:
+                        provider = 'outlook'
+                    d = OAuthReauthMessage(self, title=title, provider=provider)
+                    d.setModal(False)
+                    d.show()
+                    self._modeless_dialogs.append(d)
+                return
+
             if 'calibre.ebooks.oeb.transforms.split.SplitError' in job.details:
                 title = job.description.split(':')[-1].partition('(')[-1][:-1]
                 msg = _('<p><b>Failed to convert: %s')%title

--- a/src/calibre/utils/oauth2.py
+++ b/src/calibre/utils/oauth2.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python
+# License: GPLv3 Copyright: 2026, Kovid Goyal <kovid at kovidgoyal.net>
+
+
+'''
+OAuth 2.0 authentication for SMTP email sending (PKCE flow).
+'''
+
+import base64
+import hashlib
+import json
+import os
+import socket
+import threading
+import time
+import webbrowser
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import parse_qs, urlencode, urlparse
+
+from calibre import browser as get_browser
+
+
+class OAuth2Error(Exception):
+    pass
+
+
+def generate_pkce_pair():
+    code_verifier = base64.urlsafe_b64encode(os.urandom(32)).decode('utf-8').rstrip('=')
+    code_challenge = base64.urlsafe_b64encode(hashlib.sha256(code_verifier.encode('utf-8')).digest()).decode('utf-8').rstrip('=')
+    return code_verifier, code_challenge
+
+
+def generate_xoauth2_string(email, access_token):
+    # Format: user={email}\x01auth=Bearer {token}\x01\x01
+    auth_string = f'user={email}\x01auth=Bearer {access_token}\x01\x01'
+    return base64.b64encode(auth_string.encode('utf-8')).decode('utf-8')
+
+
+def find_available_port(start_port=8080, max_attempts=10):
+    for port in range(start_port, start_port + max_attempts):
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                s.bind(('localhost', port))
+                return port
+        except OSError:
+            continue
+    return None
+
+
+class OAuth2Provider:
+
+    name = None
+    client_id = None
+    client_secret = None
+    auth_url = None
+    token_url = None
+    scopes = []
+
+    def __init__(self, redirect_uri=None):
+        self.redirect_uri = redirect_uri or 'http://localhost:8080/oauth2callback'
+
+    def get_authorization_url(self, state, code_challenge):
+        params = {
+            'client_id': self.client_id,
+            'redirect_uri': self.redirect_uri,
+            'response_type': 'code',
+            'scope': ' '.join(self.scopes),
+            'state': state,
+            'code_challenge': code_challenge,
+            'code_challenge_method': 'S256',
+            'access_type': 'offline',
+            'prompt': 'consent',
+        }
+        return f'{self.auth_url}?{urlencode(params)}'
+
+    def exchange_code_for_tokens(self, code, code_verifier):
+        br = get_browser()
+        data = {
+            'client_id': self.client_id,
+            'code': code,
+            'code_verifier': code_verifier,
+            'grant_type': 'authorization_code',
+            'redirect_uri': self.redirect_uri,
+        }
+        if self.client_secret is not None:
+            data['client_secret'] = self.client_secret
+
+        try:
+            response = br.open_novisit(self.token_url, data=urlencode(data).encode('utf-8'), timeout=30)
+            result = json.loads(response.read())
+
+            if 'error' in result:
+                error_msg = result.get('error_description', result['error'])
+                if 'redirect_uri_mismatch' in result.get('error', ''):
+                    error_msg += f'\nRedirect URI: {self.redirect_uri}'
+                elif 'invalid_client' in result.get('error', ''):
+                    error_msg += f'\nClient ID: {self.client_id}'
+                raise OAuth2Error(f'Token exchange failed: {error_msg}')
+
+            result['expires_at'] = int(time.time()) + result.get('expires_in', 3600)
+            return result
+        except Exception as e:
+            if isinstance(e, OAuth2Error):
+                raise
+            error_body = ''
+            if hasattr(e, 'read'):
+                try:
+                    error_body = e.read()
+                    if isinstance(error_body, bytes):
+                        error_body = error_body.decode('utf-8', 'replace')
+                except Exception:
+                    pass
+            if error_body:
+                try:
+                    err_json = json.loads(error_body)
+                    error_details = err_json.get('error_description') or err_json.get('error') or error_body
+                except json.JSONDecodeError:
+                    error_details = error_body
+            else:
+                error_details = str(e)
+            raise OAuth2Error(f'Token exchange failed: {error_details}')
+
+    def refresh_access_token(self, refresh_token):
+        br = get_browser()
+        data = {
+            'client_id': self.client_id,
+            'refresh_token': refresh_token,
+            'grant_type': 'refresh_token',
+        }
+        if self.client_secret is not None:
+            data['client_secret'] = self.client_secret
+        try:
+            response = br.open_novisit(self.token_url, data=urlencode(data).encode('utf-8'), timeout=30)
+            result = json.loads(response.read())
+            if 'error' in result:
+                raise OAuth2Error(f'Token refresh failed: {result.get("error_description", result["error"])}')
+            result['expires_at'] = int(time.time()) + result.get('expires_in', 3600)
+            if 'refresh_token' not in result:
+                result['refresh_token'] = refresh_token
+            return result
+        except OAuth2Error:
+            raise
+        except Exception as e:
+            raise OAuth2Error(f'Token refresh failed: {e}')
+
+
+class GmailOAuth2Provider(OAuth2Provider):
+    name = 'gmail'
+    client_id = os.environ.get('CALIBRE_GMAIL_CLIENT_ID', '410090137009-6f4jgjvsvcmtr1kqbtcro2j76rb7pio4.apps.googleusercontent.com')
+    client_secret = os.environ.get('CALIBRE_GMAIL_CLIENT_SECRET', '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')
+    auth_url = 'https://accounts.google.com/o/oauth2/v2/auth'
+    token_url = 'https://oauth2.googleapis.com/token'
+    scopes = ['https://mail.google.com/']
+
+
+class OutlookOAuth2Provider(OAuth2Provider):
+    name = 'outlook'
+    client_id = os.environ.get('CALIBRE_OUTLOOK_CLIENT_ID', '')  # register at portal.azure.com
+    client_secret = os.environ.get('CALIBRE_OUTLOOK_CLIENT_SECRET')
+    auth_url = 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize'
+    token_url = 'https://login.microsoftonline.com/common/oauth2/v2.0/token'
+    scopes = ['https://outlook.office.com/SMTP.Send', 'offline_access']
+
+
+PROVIDERS = {
+    'gmail': GmailOAuth2Provider,
+    'outlook': OutlookOAuth2Provider,
+}
+
+PROVIDER_DISPLAY_NAMES = {'gmail': 'Gmail', 'outlook': 'Outlook/Hotmail/Office 365'}
+
+
+def get_provider(provider_name):
+    if provider_name not in PROVIDERS:
+        raise OAuth2Error(f'Unknown OAuth provider: {provider_name}')
+    return PROVIDERS[provider_name]()
+
+
+def get_available_providers():
+    return [(name, PROVIDER_DISPLAY_NAMES.get(name, name))
+            for name, cls in PROVIDERS.items() if cls.client_id]
+
+
+def is_provider_available(provider_name):
+    return provider_name in PROVIDERS and bool(PROVIDERS[provider_name].client_id)
+
+
+class OAuth2CallbackHandler(BaseHTTPRequestHandler):
+
+    def log_message(self, format, *args):
+        pass
+
+    def do_GET(self):
+        parsed = urlparse(self.path)
+
+        if parsed.path != '/oauth2callback':
+            self.send_error(404)
+            return
+
+        query = parse_qs(parsed.query)
+
+        if 'error' in query:
+            self.server.oauth_error = query['error'][0]
+            error_desc = query.get('error_description', [''])[0]
+            html = f'''
+            <html>
+            <head>
+                <meta charset="UTF-8">
+                <title>Authorization Failed</title>
+                <style>
+                    body {{ font-family: sans-serif; text-align: center; padding: 50px; }}
+                    h1 {{ color: #c62828; }}
+                </style>
+            </head>
+            <body>
+                <h1>Authorization Failed</h1>
+                <p>Error: {self.server.oauth_error}</p>
+                <p>{error_desc}</p>
+                <p>You can close this window.</p>
+            </body>
+            </html>
+            '''
+        elif 'code' in query and 'state' in query:
+            self.server.authorization_code = query['code'][0]
+            self.server.state = query['state'][0]
+            html = '''
+            <html>
+            <head>
+                <meta charset="UTF-8">
+                <title>Authorization Successful</title>
+                <style>
+                    body { font-family: sans-serif; text-align: center; padding: 50px; }
+                    h1 { color: #2e7d32; }
+                </style>
+            </head>
+            <body>
+                <h1>Authorization Successful!</h1>
+                <p>You can close this window and return to calibre.</p>
+            </body>
+            </html>
+            '''
+        else:
+            self.send_error(400, 'Missing required parameters')
+            return
+
+        self.send_response(200)
+        self.send_header('Content-type', 'text/html')
+        self.end_headers()
+        self.wfile.write(html.encode('utf-8'))
+        threading.Thread(target=self.server.shutdown).start()
+
+
+class OAuth2BrowserFlow:
+
+    def __init__(self, provider, start_port=8080):
+        self.provider = provider
+        self.start_port = start_port
+
+    def start_authorization_flow(self, timeout=300):
+        port = find_available_port(start_port=self.start_port)
+        if port is None:
+            raise OAuth2Error(f'No available port for OAuth callback (tried {self.start_port}-{self.start_port + 9})')
+
+        self.provider.redirect_uri = f'http://localhost:{port}/oauth2callback'
+        code_verifier, code_challenge = generate_pkce_pair()
+        state = base64.urlsafe_b64encode(os.urandom(32)).decode('utf-8').rstrip('=')
+        auth_url = self.provider.get_authorization_url(state, code_challenge)
+
+        server = HTTPServer(('localhost', port), OAuth2CallbackHandler)
+        server.oauth_error = None
+        server.authorization_code = None
+        server.state = None
+
+        if not webbrowser.open(auth_url):
+            raise OAuth2Error(f'Failed to open browser. Please open: {auth_url}')
+
+        server_thread = threading.Thread(target=server.serve_forever)
+        server_thread.daemon = True
+        server_thread.start()
+
+        start_time = time.time()
+        while server_thread.is_alive() and (time.time() - start_time) < timeout:
+            time.sleep(0.5)
+
+        if server_thread.is_alive():
+            server.shutdown()
+            raise OAuth2Error(f'Authorization timeout after {timeout} seconds')
+        if server.oauth_error:
+            raise OAuth2Error(f'Authorization failed: {server.oauth_error}')
+        if not server.authorization_code:
+            raise OAuth2Error('No authorization code received')
+        if server.state != state:
+            raise OAuth2Error('State mismatch - possible CSRF attack')
+
+        return self.provider.exchange_code_for_tokens(server.authorization_code, code_verifier)
+
+
+class OAuth2TokenManager:
+
+    def __init__(self, provider, tokens=None):
+        self.provider = provider
+        self.tokens = tokens or {}
+
+    def get_valid_token(self):
+        if not self.tokens:
+            raise OAuth2Error('No tokens available. Please authorize first.')
+        expires_at = self.tokens.get('expires_at', 0)
+        if time.time() >= (expires_at - 300):  # 5 min buffer
+            if 'refresh_token' not in self.tokens:
+                raise OAuth2Error('No refresh token available. Please re-authorize.')
+            self.tokens = self.provider.refresh_access_token(self.tokens['refresh_token'])
+        return self.tokens
+
+    def is_valid(self):
+        if not self.tokens or 'access_token' not in self.tokens:
+            return False
+        return time.time() < (self.tokens.get('expires_at', 0) - 300)
+
+
+def start_oauth_flow(provider_name, start_port=8080):
+    flow = OAuth2BrowserFlow(get_provider(provider_name), start_port=start_port)
+    return flow.start_authorization_flow()
+
+
+def get_token_manager(provider_name, tokens=None):
+    return OAuth2TokenManager(get_provider(provider_name), tokens)
+
+
+def refresh_token_if_needed(provider_name, tokens):
+    token_mgr = get_token_manager(provider_name, tokens)
+    new_tokens = token_mgr.get_valid_token()
+    return new_tokens, new_tokens != tokens


### PR DESCRIPTION
This adds OAuth 2.0 authentication for Gmail and Outlook, making it easier to set up email sending without dealing with app passwords or "less secure apps" settings.

**Why**
My mother uses calibre to send books to her Kindle, but she's not technical and has struggled with configuring SMTP credentials. OAuth simplifies this to just clicking "Authorize" and logging into her Google account. Our whole family has been using calibre for years with various e-readers and we're really happy this project exists - wanted to contribute something back.

**What's included**
- OAuth 2.0 with PKCE flow for Gmail (Outlook support ready but disabled)
- XOAUTH2 SMTP authentication
- Simple setup dialog that auto-detects provider from email domain
- For custom domains the UI lets the user select the provider manually. 
- Automatic token refresh

**For the maintainer**
I've registered a Google OAuth app for testing, but the client ID and secret in the code are only for demonstration. You should replace them with your own:

**Gmail setup:**
1. Go to https://console.cloud.google.com/
2. Create a project (or use existing)
3. Enable Gmail API
4. Go to Credentials → Create Credentials → OAuth client ID
5. Select "Desktop app"
6. Copy client ID and secret into GmailOAuth2Provider in oauth2.py

**Outlook setup (optional):**
1. Go to https://portal.azure.com/ -> App registrations
2. New registration, select "Accounts in any organizational directory and personal Microsoft accounts"
3. Add redirect URI: http://localhost:8080/oauth2callback (Web type)
4. Copy Application (client) ID into OutlookOAuth2Provider

Alternatively, delete the hardcoded values and users can set CALIBRE_GMAIL_CLIENT_ID, CALIBRE_GMAIL_CLIENT_SECRET, and CALIBRE_OUTLOOK_CLIENT_ID environment variables.

Please let me know if you want me to make any changes? 