### PR TITLE
[codex] Add OpenAI-compatible AI provider

### DIFF
--- a/run-local
+++ b/run-local
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 import importlib
 import os
+import shutil
+import subprocess
 import sys
 
 
@@ -9,10 +11,50 @@ base = os.path.dirname(sys.run_local)
 src = os.path.join(base, 'src')
 if src not in sys.path:
     sys.path.insert(0, src)
-sys.resources_location = os.path.join(base, 'resources')
-sys.extensions_location = os.path.join(src, 'calibre', 'plugins')
 entry_point = sys.argv[1]
 del sys.argv[1]
+
+
+def windows_runtime_roots():
+    seen = set()
+    for path in (
+        os.environ.get('CALIBRE_RUNTIME_PATH'),
+        os.environ.get('CALIBRE_WINDOWS_INSTALL_ROOT'),
+    ):
+        if not path:
+            continue
+        path = os.path.abspath(path)
+        if os.path.basename(path).lower() == 'app':
+            path = os.path.dirname(path)
+        if path not in seen:
+            seen.add(path)
+            yield path
+    for exe_name in ('calibre.exe', 'calibre-debug.exe', 'calibredb.exe'):
+        exe = shutil.which(exe_name)
+        if not exe:
+            continue
+        root = os.path.dirname(os.path.abspath(exe))
+        if root not in seen:
+            seen.add(root)
+            yield root
+    default_root = os.path.join(os.environ.get('ProgramFiles', r'C:\Program Files'), 'Calibre2')
+    if default_root not in seen:
+        yield default_root
+
+
+if os.name == 'nt':
+    os.environ.setdefault('CALIBRE_DEVELOP_FROM', src)
+    for root in windows_runtime_roots():
+        exe = os.path.join(root, entry_point + '.exe')
+        if os.path.exists(exe):
+            raise SystemExit(subprocess.call([exe] + sys.argv[1:]))
+    raise SystemExit(
+        'Could not find an installed calibre runtime on Windows. Install calibre normally or set '
+        'CALIBRE_RUNTIME_PATH/CALIBRE_WINDOWS_INSTALL_ROOT to the install directory.'
+    )
+
+sys.resources_location = os.path.join(base, 'resources')
+sys.extensions_location = os.path.join(src, 'calibre', 'plugins')
 del src
 del base
 

--- a/src/calibre/ai/openai_compatible/__init__.py
+++ b/src/calibre/ai/openai_compatible/__init__.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+# License: GPLv3 Copyright: 2026, OpenAI
+
+from calibre.customize import AIProviderPlugin
+
+
+class OpenAICompatible(AIProviderPlugin):
+    name = 'OpenAI compatible'
+    version = (1, 0, 0)
+    description = _(
+        'Generic OpenAI compatible AI services. Use this to connect calibre to self-hosted or third-party services'
+        ' that implement the OpenAI chat completions API.'
+    )
+    author = 'OpenAI'
+    builtin_live_module_name = 'calibre.ai.openai_compatible.backend'
+
+    @property
+    def capabilities(self):
+        from calibre.ai import AICapabilities
+        return AICapabilities.text_to_text

--- a/src/calibre/ai/openai_compatible/backend.py
+++ b/src/calibre/ai/openai_compatible/backend.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python
+# License: GPLv3 Copyright: 2026, OpenAI
+
+import json
+import posixpath
+from collections.abc import Iterable, Iterator, Sequence
+from functools import lru_cache
+from typing import Any, NamedTuple
+from urllib.parse import urlparse, urlunparse
+from urllib.request import Request
+
+from calibre.ai import ChatMessage, ChatMessageType, ChatResponse, ResultBlocked, ResultBlockReason
+from calibre.ai.openai_compatible import OpenAICompatible
+from calibre.ai.prefs import decode_secret, pref_for_provider
+from calibre.ai.utils import chat_with_error_handler, develop_text_chat, download_data, read_streaming_response
+
+module_version = 1
+
+
+def pref(key: str, defval: Any = None) -> Any:
+    return pref_for_provider(OpenAICompatible.name, key, defval)
+
+
+def is_ready_for_use() -> bool:
+    return bool(pref('api_url') and pref('text_model'))
+
+
+class Model(NamedTuple):
+    id: str
+    owner: str
+
+    @classmethod
+    def from_dict(cls, x: dict[str, Any]) -> 'Model':
+        return cls(id=x['id'], owner=x.get('owned_by', 'remote'))
+
+
+def api_url(path: str = '', use_api_url: str | None = None) -> str:
+    base = (pref('api_url') if use_api_url is None else use_api_url) or ''
+    purl = urlparse(base)
+    base_path = (purl.path or '').rstrip('/')
+    if not base_path:
+        base_path = '/v1'
+    elif base_path.endswith('/chat/completions'):
+        base_path = base_path[:-len('/chat/completions')]
+    elif base_path.endswith('/models'):
+        base_path = base_path[:-len('/models')]
+    if path:
+        base_path = posixpath.join(base_path, path)
+    purl = purl._replace(path=base_path)
+    return urlunparse(purl)
+
+
+def raw_api_key(use_api_key: str | None = None) -> str:
+    key = pref('api_key') if use_api_key is None else use_api_key
+    return decode_secret(key) if key else ''
+
+
+@lru_cache(32)
+def request_headers(
+    use_api_key: str | None = None, use_headers: Sequence[tuple[str, str]] | None = None
+) -> tuple[tuple[str, str], ...]:
+    ans = [('Content-Type', 'application/json')]
+    extra_headers = pref('headers', ()) if use_headers is None else use_headers
+    extra_headers = tuple(extra_headers or ())
+    has_auth = False
+    for key, val in extra_headers:
+        if key.lower() == 'authorization':
+            has_auth = True
+        ans.append((key, val))
+    if api_key := raw_api_key(use_api_key):
+        if not has_auth:
+            ans.insert(0, ('Authorization', f'Bearer {api_key}'))
+    return tuple(ans)
+
+
+@lru_cache(8)
+def get_available_models(
+    use_api_url: str | None = None, use_api_key: str | None = None, use_headers: Sequence[tuple[str, str]] | None = None
+) -> dict[str, Model]:
+    url = api_url('models', use_api_url)
+    data = json.loads(download_data(url, request_headers(use_api_key, use_headers)))
+    ans = {}
+    if 'data' in data:
+        for model_data in data['data']:
+            model = Model.from_dict(model_data)
+            ans[model.id] = model
+    return ans
+
+
+def human_readable_model_name(model_id: str) -> str:
+    return model_id
+
+
+def config_widget():
+    from calibre.ai.openai_compatible.config import ConfigWidget
+    return ConfigWidget()
+
+
+def save_settings(config_widget):
+    config_widget.save_settings()
+
+
+def for_assistant(self: ChatMessage) -> dict[str, Any]:
+    if self.type not in (ChatMessageType.assistant, ChatMessageType.system, ChatMessageType.user, ChatMessageType.developer):
+        raise ValueError(f'Unsupported message type: {self.type}')
+    return {'role': self.type.value, 'content': self.query}
+
+
+def coerce_text(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        text = value.get('text')
+        return text if isinstance(text, str) else ''
+    if isinstance(value, list):
+        return ''.join(filter(None, map(coerce_text, value)))
+    return ''
+
+
+def chat_request(
+    data: dict[str, Any], url_override: str | None = None, use_api_key: str | None = None,
+    use_headers: Sequence[tuple[str, str]] | None = None
+) -> Request:
+    url = api_url('chat/completions', url_override)
+    return Request(url, data=json.dumps(data).encode('utf-8'), headers=dict(request_headers(use_api_key, use_headers)), method='POST')
+
+
+def as_chat_responses(d: dict[str, Any], model_id: str) -> Iterator[ChatResponse]:
+    blocked = False
+    for choice in d.get('choices', ()):
+        delta = choice.get('delta') or {}
+        content = coerce_text(delta.get('content'))
+        reasoning = coerce_text(delta.get('reasoning_content'))
+        role = delta.get('role') or 'assistant'
+        if content or reasoning:
+            yield ChatResponse(
+                content=content, reasoning=reasoning, type=ChatMessageType(role), plugin_name=OpenAICompatible.name
+            )
+        if choice.get('finish_reason') == 'content_filter':
+            blocked = True
+    if blocked:
+        yield ChatResponse(exception=ResultBlocked(ResultBlockReason.safety), plugin_name=OpenAICompatible.name)
+        return
+    if usage := d.get('usage'):
+        yield ChatResponse(
+            has_metadata=True, provider=OpenAICompatible.name, model=d.get('model') or model_id,
+            plugin_name=OpenAICompatible.name
+        )
+
+
+def text_chat_implementation(messages: Iterable[ChatMessage], use_model: str = '') -> Iterator[ChatResponse]:
+    model_id = use_model or pref('text_model')
+    temperature = pref('temperature', 0.7)
+    data = {
+        'model': model_id,
+        'messages': [for_assistant(m) for m in messages],
+        'stream': True,
+        'temperature': temperature,
+    }
+    rq = chat_request(data)
+    seen_metadata = False
+    for data in read_streaming_response(rq, OpenAICompatible.name, timeout=pref('timeout', 120)):
+        for response in as_chat_responses(data, model_id):
+            if response.has_metadata:
+                seen_metadata = True
+            yield response
+            if response.exception:
+                return
+    if not seen_metadata:
+        yield ChatResponse(has_metadata=True, provider=OpenAICompatible.name, model=model_id, plugin_name=OpenAICompatible.name)
+
+
+def text_chat(messages: Iterable[ChatMessage], use_model: str = '') -> Iterator[ChatResponse]:
+    yield from chat_with_error_handler(text_chat_implementation(messages, use_model))
+
+
+def develop(use_model: str = '', msg: str = '') -> None:
+    m = (ChatMessage(msg),) if msg else ()
+    develop_text_chat(text_chat, use_model, messages=m)
+
+
+def find_tests():
+    import unittest
+
+    class TestOpenAICompatibleBackend(unittest.TestCase):
+
+        def test_api_url_normalization(self):
+            self.assertEqual(api_url('models', 'http://localhost:1234'), 'http://localhost:1234/v1/models')
+            self.assertEqual(api_url('models', 'http://localhost:1234/v1'), 'http://localhost:1234/v1/models')
+            self.assertEqual(api_url('models', 'https://example.com/custom/api'), 'https://example.com/custom/api/models')
+            self.assertEqual(api_url('chat/completions', 'https://ark.cn-beijing.volces.com/api/v3'), 'https://ark.cn-beijing.volces.com/api/v3/chat/completions')
+            self.assertEqual(api_url('chat/completions', 'https://ark.cn-beijing.volces.com/api/v3/chat/completions'), 'https://ark.cn-beijing.volces.com/api/v3/chat/completions')
+
+        def test_request_headers_allows_missing_headers_pref(self):
+            headers = request_headers()
+            self.assertEqual(headers, (('Content-Type', 'application/json'),))
+
+        def test_parsing_stream_deltas(self):
+            responses = tuple(as_chat_responses({
+                'model': 'demo-model',
+                'choices': [
+                    {'delta': {'role': 'assistant', 'content': 'Hello', 'reasoning_content': 'Think'}, 'finish_reason': None}
+                ],
+                'usage': {'total_tokens': 42},
+            }, 'demo-model'))
+            self.assertEqual(responses[0].content, 'Hello')
+            self.assertEqual(responses[0].reasoning, 'Think')
+            self.assertTrue(responses[-1].has_metadata)
+            self.assertEqual(responses[-1].model, 'demo-model')
+
+    return unittest.defaultTestLoader.loadTestsFromTestCase(TestOpenAICompatibleBackend)
+
+
+if __name__ == '__main__':
+    develop()

--- a/src/calibre/ai/openai_compatible/config.py
+++ b/src/calibre/ai/openai_compatible/config.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python
+# License: GPLv3 Copyright: 2026, OpenAI
+
+from functools import partial
+from typing import Any
+
+from qt.core import (
+    QComboBox,
+    QCompleter,
+    QDoubleSpinBox,
+    QFormLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QListView,
+    QPlainTextEdit,
+    QPushButton,
+    QSpinBox,
+    Qt,
+    QWidget,
+)
+
+from calibre.ai.openai_compatible import OpenAICompatible
+from calibre.ai.prefs import decode_secret, encode_secret, pref_for_provider, set_prefs_for_provider
+from calibre.ai.utils import configure, plugin_for_name
+from calibre.gui2 import error_dialog
+from calibre.gui2.widgets import BusyCursor
+
+pref = partial(pref_for_provider, OpenAICompatible.name)
+
+
+class ConfigWidget(QWidget):
+
+    def __init__(self, parent: QWidget | None = None):
+        super().__init__(parent)
+        l = QFormLayout(self)
+        l.setFieldGrowthPolicy(QFormLayout.FieldGrowthPolicy.ExpandingFieldsGrow)
+
+        la = QLabel('<p>' + _(
+            'Connect calibre to any self-hosted or third-party service that implements the OpenAI compatible'
+            ' <code>/v1/chat/completions</code> API. This is useful for gateways, local servers and other'
+            ' services that are not listed as dedicated providers.'
+        ))
+        la.setWordWrap(True)
+        l.addRow(la)
+
+        self.api_url_edit = a = QLineEdit(self)
+        a.setClearButtonEnabled(True)
+        a.setPlaceholderText(_('For example: {}').format('https://example.com/v1'))
+        l.addRow(_('API &URL:'), a)
+        a.setText(pref('api_url') or '')
+
+        self.api_key_edit = ak = QLineEdit(self)
+        ak.setClearButtonEnabled(True)
+        ak.setPlaceholderText(_('Optional. Sent as Authorization: Bearer <key>'))
+        l.addRow(_('API &key:'), ak)
+        if key := pref('api_key'):
+            ak.setText(decode_secret(key))
+
+        self.headers_edit = he = QPlainTextEdit(self)
+        he.setPlaceholderText(_('Optional HTTP headers, one per line, in the format: Header-Name: Value'))
+        l.addRow(_('HTTP &headers:'), he)
+        he.setPlainText('\n'.join(f'{k}: {v}' for (k, v) in pref('headers') or ()))
+
+        self.timeout_sb = t = QSpinBox(self)
+        t.setRange(15, 600)
+        t.setSingleStep(1)
+        t.setSuffix(_(' seconds'))
+        t.setValue(pref('timeout', 120))
+        l.addRow(_('&Timeout:'), t)
+
+        self.temp_sb = temp = QDoubleSpinBox(self)
+        temp.setRange(0.0, 2.0)
+        temp.setSingleStep(0.1)
+        temp.setValue(pref('temperature', 0.7))
+        temp.setToolTip(_('Controls randomness. Lower values are more deterministic.'))
+        l.addRow(_('T&emperature:'), temp)
+
+        w = QWidget(self)
+        h = QHBoxLayout(w)
+        h.setContentsMargins(0, 0, 0, 0)
+
+        self.model_combo = mc = QComboBox(w)
+        mc.setEditable(True)
+        mc.setInsertPolicy(QComboBox.NoInsert)
+        mc.setView(QListView(mc))
+        mc.setSizeAdjustPolicy(QComboBox.AdjustToContentsOnFirstShow)
+        completer = QCompleter(mc)
+        completer.setCaseSensitivity(Qt.CaseInsensitive)
+        mc.setCompleter(completer)
+
+        if saved_model := pref('text_model') or '':
+            mc.addItem(saved_model)
+            mc.setCurrentText(saved_model)
+
+        self.refresh_btn = rb = QPushButton(_('&Refresh models'), w)
+        rb.clicked.connect(self.refresh_models)
+        h.addWidget(mc, stretch=10)
+        h.addWidget(rb)
+        l.addRow(_('Model for &text tasks:'), w)
+
+        self.model_status = ms = QLabel('', self)
+        ms.setWordWrap(True)
+        ms.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
+        l.addRow('', ms)
+
+    def refresh_models(self):
+        with BusyCursor():
+            try:
+                plugin = plugin_for_name(OpenAICompatible.name)
+                backend = plugin.builtin_live_module
+                backend.get_available_models.cache_clear()
+                encoded_key = encode_secret(self.api_key) if self.api_key else ''
+                models_dict = backend.get_available_models(self.api_url, encoded_key, self.headers)
+                current_text = self.text_model
+                model_ids = sorted(models_dict, key=lambda x: x.lower())
+                self.model_combo.blockSignals(True)
+                self.model_combo.clear()
+                for model_id in model_ids:
+                    self.model_combo.addItem(model_id)
+                self.model_combo.setCurrentText(current_text or (model_ids[0] if model_ids else ''))
+                self.model_combo.blockSignals(False)
+                if model_ids:
+                    sample = ', '.join(model_ids[:3])
+                    msg = _('Found {} models. e.g.: {}').format(len(model_ids), sample)
+                    if len(model_ids) > 3:
+                        msg += _(' (and more)')
+                    self.model_status.setText(msg)
+                    self.model_status.setToolTip('\n'.join(model_ids))
+                else:
+                    self.model_status.setText(_('The server responded, but returned no models.'))
+                    self.model_status.setToolTip('')
+            except Exception as e:
+                self.model_status.setText(_('Failed to refresh models: {}').format(e))
+                self.model_status.setToolTip('')
+
+    @property
+    def api_url(self) -> str:
+        return self.api_url_edit.text().strip()
+
+    @property
+    def api_key(self) -> str:
+        return self.api_key_edit.text().strip()
+
+    @property
+    def text_model(self) -> str:
+        return self.model_combo.currentText().strip()
+
+    @property
+    def timeout(self) -> int:
+        return self.timeout_sb.value()
+
+    @property
+    def temperature(self) -> float:
+        return self.temp_sb.value()
+
+    @property
+    def headers(self) -> tuple[tuple[str, str], ...]:
+        ans = []
+        for line in self.headers_edit.toPlainText().splitlines():
+            if line := line.strip():
+                key, sep, val = line.partition(':')
+                key, val = key.strip(), val.strip()
+                if key and sep and val:
+                    ans.append((key, val))
+        return tuple(ans)
+
+    @property
+    def settings(self) -> dict[str, Any]:
+        ans = {
+            'api_url': self.api_url,
+            'api_key': encode_secret(self.api_key),
+            'text_model': self.text_model,
+            'timeout': self.timeout,
+            'temperature': self.temperature,
+        }
+        if self.headers:
+            ans['headers'] = self.headers
+        return ans
+
+    @property
+    def is_ready_for_use(self) -> bool:
+        return bool(self.api_url and self.text_model)
+
+    def validate(self) -> bool:
+        if not self.api_url:
+            error_dialog(self, _('No API URL'), _('You must specify the URL of the OpenAI compatible API endpoint.'), show=True)
+            return False
+        if not self.text_model:
+            error_dialog(self, _('No model specified'), _('You must specify a model ID to use for text based tasks.'), show=True)
+            return False
+        return True
+
+    def save_settings(self):
+        set_prefs_for_provider(OpenAICompatible.name, self.settings)
+
+
+if __name__ == '__main__':
+    configure(OpenAICompatible.name)

--- a/src/calibre/customize/builtins.py
+++ b/src/calibre/customize/builtins.py
@@ -8,6 +8,7 @@ from calibre.ai.github import GitHubAI
 from calibre.ai.google import GoogleAI
 from calibre.ai.lm_studio import LMStudioAI
 from calibre.ai.ollama import OllamaAI
+from calibre.ai.openai_compatible import OpenAICompatible
 from calibre.ai.open_router import OpenRouterAI
 from calibre.constants import numeric_version
 from calibre.customize import FileTypePlugin, InterfaceActionBase, MetadataReaderPlugin, MetadataWriterPlugin, PreferencesPlugin, StoreBase
@@ -1986,7 +1987,7 @@ plugins += [
 
 # }}}
 
-plugins.extend((OpenRouterAI, GoogleAI, GitHubAI, OllamaAI, LMStudioAI))
+plugins.extend((OpenRouterAI, GoogleAI, GitHubAI, OllamaAI, LMStudioAI, OpenAICompatible))
 
 if __name__ == '__main__':
     # Test load speed

--- a/src/calibre/gui2/llm.py
+++ b/src/calibre/gui2/llm.py
@@ -51,7 +51,7 @@ from calibre.gui2.dialogs.confirm_delete import confirm
 from calibre.gui2.widgets2 import Dialog
 from calibre.utils.icu import primary_sort_key
 from calibre.utils.localization import ui_language_as_english
-from calibre.utils.logging import ERROR, WARN
+from calibre.utils.logging import ERROR, INFO, WARN
 from calibre.utils.short_uuid import uuid4
 from polyglot.binary import as_hex_unicode
 
@@ -203,6 +203,9 @@ class ConverseWidget(QWidget):
         self.current_api_call_number = 0
         self.session_cost = 0.0
         self.session_cost_currency = ''
+        self.current_error_html = ''
+        self.current_error_details = ''
+        self.current_error_level = INFO
         self.update_ai_provider_plugin()
         self.clear_current_conversation()
 
@@ -324,6 +327,16 @@ class ConverseWidget(QWidget):
             self.result_display.add_block(
                 content_for_display, Header(_('{assistant} {activity}').format(
                     assistant=assistant, activity=activity) + '…'), is_response=True)
+        if self.current_error_html:
+            style = ''
+            if self.current_error_level == WARN:
+                style = 'color: orange;'
+            elif self.current_error_level > WARN:
+                style = 'color: red;'
+            err_html = f'<div style="{style}">{self.current_error_html}</div>'
+            if self.current_error_details:
+                err_html += f"<pre>{_('Details:')}\n{escape(self.current_error_details)}</pre>"
+            self.result_display.add_block(err_html)
         self.result_display.re_render()
         self.scroll_to_bottom()
 
@@ -336,6 +349,7 @@ class ConverseWidget(QWidget):
         self.result_display.scroll_to_bottom()
 
     def start_api_call(self, action_prompt: str, **kwargs: Any) -> None:
+        self.clear_current_error()
         if not self.is_ready_for_use:
             self.show_error(f'''<b>{_('AI provider not configured.')}</b> <a href="http://{self.configure_ai_hostname}">{_(
                 'Configure AI provider')}</a>''', is_critical=False)
@@ -375,7 +389,11 @@ class ConverseWidget(QWidget):
             self.conversation_history.finalize_response()
             self.update_cost()
         elif r.exception is not None:
-            self.show_error(f'''{_('Talking to AI failed with error:')} {escape(str(r.exception))}''', details=r.error_details, is_critical=True)
+            self.conversation_history.current_response_completed = True
+            self.conversation_history.api_call_active = False
+            self.current_error_html = f'''{_('Talking to AI failed with error:')} {escape(str(r.exception))}'''
+            self.current_error_details = r.error_details
+            self.current_error_level = ERROR
         else:
             self.conversation_history.accumulator.accumulate(r)
         self.update_ui_state()
@@ -387,6 +405,12 @@ class ConverseWidget(QWidget):
 
     def clear_current_conversation(self) -> None:
         self.conversation_history = ConversationHistory()
+        self.clear_current_error()
+
+    def clear_current_error(self) -> None:
+        self.current_error_html = ''
+        self.current_error_details = ''
+        self.current_error_level = INFO
 
     def update_ui_state(self) -> None:
         if self.conversation_history:

--- a/src/calibre/gui2/llm.py
+++ b/src/calibre/gui2/llm.py
@@ -32,6 +32,7 @@ from qt.core import (
     Qt,
     QTabWidget,
     QTextBrowser,
+    QTimer,
     QUrl,
     QVBoxLayout,
     QWidget,
@@ -66,6 +67,13 @@ def for_display_to_human(self: ChatMessage, is_initial_query: bool = False, cont
     if is_initial_query and (idx := q.find(prompt_sep)) > -1:
         q = q[:idx] + '\n\n' + q[idx + len(prompt_sep):]
     return response_to_html(q, content_type=content_type)
+
+
+def streaming_text_as_html(text: str, emphasize: bool = False) -> str:
+    style = 'white-space: pre-wrap;'
+    if emphasize:
+        style += ' font-style: italic;'
+    return f'<div style="{style}">{escape(text)}</div>'
 
 
 def show_reasoning(reasoning: str, parent: QWidget | None = None):
@@ -241,6 +249,10 @@ class ConverseWidget(QWidget):
         self.layout.addLayout(footer_layout)
 
         self.response_received.connect(self.on_response_from_ai, type=Qt.ConnectionType.QueuedConnection)
+        self.streaming_render_timer = t = QTimer(self)
+        t.setSingleShot(True)
+        t.setInterval(50)
+        t.timeout.connect(self.update_ui_state)
         self.show_initial_message()
         self.update_cost()
 
@@ -320,10 +332,9 @@ class ConverseWidget(QWidget):
         if self.conversation_history.api_call_active:
             a = self.conversation_history.accumulator
             has_content = bool(a.all_content)
-            content_for_display = for_display_to_human(ChatMessage(a.all_content or a.all_reasoning))
+            streaming_text = a.all_content or a.all_reasoning
+            content_for_display = streaming_text_as_html(streaming_text, emphasize=not has_content)
             activity = _('answering') if has_content else _('thinking')
-            if not has_content:
-                content_for_display = '<i>' + content_for_display + '</i>'
             self.result_display.add_block(
                 content_for_display, Header(_('{assistant} {activity}').format(
                     assistant=assistant, activity=activity) + '…'), is_response=True)
@@ -388,15 +399,22 @@ class ConverseWidget(QWidget):
         if r is None:
             self.conversation_history.finalize_response()
             self.update_cost()
+            self.streaming_render_timer.stop()
+            self.update_ui_state()
+            return
         elif r.exception is not None:
             self.conversation_history.current_response_completed = True
             self.conversation_history.api_call_active = False
             self.current_error_html = f'''{_('Talking to AI failed with error:')} {escape(str(r.exception))}'''
             self.current_error_details = r.error_details
             self.current_error_level = ERROR
+            self.streaming_render_timer.stop()
+            self.update_ui_state()
+            return
         else:
             self.conversation_history.accumulator.accumulate(r)
-        self.update_ui_state()
+            if not self.streaming_render_timer.isActive():
+                self.streaming_render_timer.start()
 
     def show_error(self, html: str, is_critical: bool = False, details: str = '') -> None:
         self.clear_current_conversation()


### PR DESCRIPTION
This change adds a new built-in `OpenAI compatible` AI provider for calibre's chat features and follows through on the integration issues found while testing it on Windows.

The user-facing problem is that the built-in AI provider list currently covers only a small set of services. Many gateways, self-hosted deployments, and third-party vendors expose an OpenAI-compatible chat API, but calibre had no generic provider for that shape of service. That meant users could not plug those services into the existing AI conversation UI without writing a dedicated provider.

The root cause was that calibre only shipped provider implementations for a few named services. In addition, the initial pass on the generic provider exposed a couple of integration gaps during real usage: on Windows, `run-local` did not reuse the installed calibre runtime and therefore failed to import required binary extensions such as `winutil`; the first version of the provider also mishandled missing custom headers and over-normalized base URLs, which broke services such as Volcengine Ark that use `/api/v3` rather than `/v1`; and the chat UI re-rendered unfinished markdown on every streamed chunk, which caused visible jitter while responses were arriving.

This patch adds a new built-in provider under `src/calibre/ai/openai_compatible/` with a configuration UI for base URL, API key, optional headers, model selection, timeout, and temperature. The backend uses the OpenAI-style `GET /models` and `POST /chat/completions` flow for text chat, while keeping URL handling generic enough to work with standard `/v1` servers and providers like Volcengine Ark. The provider is registered in the built-in provider list so it appears alongside the existing AI services.

The patch also updates `run-local` on Windows to delegate to an installed calibre runtime while setting `CALIBRE_DEVELOP_FROM`, matching the documented Windows development workflow. That keeps source changes active while still loading the compiled runtime dependencies required by the application. Finally, the AI conversation UI now throttles streamed re-renders and shows in-progress output as plain pre-wrapped text until completion, which removes most of the visible shaking during streaming without changing the final rendered response.

Validation was done with targeted checks. I ran `python -m py_compile` across the modified Python files, exercised `run-local` through `calibredb --version` and `calibre-debug -c ...` on Windows, verified that the new provider is discoverable from the built-in plugin list, checked the Volcengine Ark URL normalization path, and ran the new backend unit tests for the provider logic in isolation. I did not run a full end-to-end GUI automation pass, but the feature was manually iterated against real local usage reports until the provider could be configured and used successfully.
