### PR TITLE
[codex] Fix Windows run-local runtime resolution

### DIFF
--- a/run-local
+++ b/run-local
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 import importlib
 import os
+import shutil
+import subprocess
 import sys
 
 
@@ -9,10 +11,50 @@ base = os.path.dirname(sys.run_local)
 src = os.path.join(base, 'src')
 if src not in sys.path:
     sys.path.insert(0, src)
-sys.resources_location = os.path.join(base, 'resources')
-sys.extensions_location = os.path.join(src, 'calibre', 'plugins')
 entry_point = sys.argv[1]
 del sys.argv[1]
+
+
+def windows_runtime_roots():
+    seen = set()
+    for path in (
+        os.environ.get('CALIBRE_RUNTIME_PATH'),
+        os.environ.get('CALIBRE_WINDOWS_INSTALL_ROOT'),
+    ):
+        if not path:
+            continue
+        path = os.path.abspath(path)
+        if os.path.basename(path).lower() == 'app':
+            path = os.path.dirname(path)
+        if path not in seen:
+            seen.add(path)
+            yield path
+    for exe_name in ('calibre.exe', 'calibre-debug.exe', 'calibredb.exe'):
+        exe = shutil.which(exe_name)
+        if not exe:
+            continue
+        root = os.path.dirname(os.path.abspath(exe))
+        if root not in seen:
+            seen.add(root)
+            yield root
+    default_root = os.path.join(os.environ.get('ProgramFiles', r'C:\Program Files'), 'Calibre2')
+    if default_root not in seen:
+        yield default_root
+
+
+if os.name == 'nt':
+    os.environ.setdefault('CALIBRE_DEVELOP_FROM', src)
+    for root in windows_runtime_roots():
+        exe = os.path.join(root, entry_point + '.exe')
+        if os.path.exists(exe):
+            raise SystemExit(subprocess.call([exe] + sys.argv[1:]))
+    raise SystemExit(
+        'Could not find an installed calibre runtime on Windows. Install calibre normally or set '
+        'CALIBRE_RUNTIME_PATH/CALIBRE_WINDOWS_INSTALL_ROOT to the install directory.'
+    )
+
+sys.resources_location = os.path.join(base, 'resources')
+sys.extensions_location = os.path.join(src, 'calibre', 'plugins')
 del src
 del base
 


### PR DESCRIPTION
This change fixes `run-local` on Windows so that a source checkout can be exercised against an installed calibre runtime, which is the workflow documented by calibre itself.

The user-facing problem is that `python run-local calibre` and related entry points failed immediately on Windows with import errors such as `cannot import name 'winutil' from 'calibre_extensions'`. In practice that made it impossible to use the local checkout for testing changes on Windows, including GUI and AI provider work.

The root cause is that the previous `run-local` script assumed a source-style runtime on every platform. On Windows, however, calibre depends on compiled runtime extensions such as `winutil.pyd` that come from the installed application bundle rather than from the source tree. The old script pointed Python at the checkout and never delegated to the installed executables, so the import machinery could not resolve the required binary modules.

This patch updates `run-local` to detect Windows, set `CALIBRE_DEVELOP_FROM` to the checkout's `src` directory, locate an installed calibre runtime, and then invoke the corresponding installed executable for the requested entry point. It supports explicit overrides via `CALIBRE_RUNTIME_PATH` or `CALIBRE_WINDOWS_INSTALL_ROOT`, falls back to executables on `PATH`, and finally tries the default `C:\Program Files\Calibre2` install root. Non-Windows behavior is unchanged.

Validation was targeted. I ran `python run-local calibredb --version` on Windows from the source checkout and verified that it now delegates successfully to the installed runtime while loading Python code from the checkout.
