### PR TITLE
Reduce Atlantic output size - enable compression and scaling

### DIFF
--- a/recipes/atlantic_com.recipe
+++ b/recipes/atlantic_com.recipe
@@ -86,6 +86,9 @@ class TheAtlantic(BasicNewsRecipe):
     language = 'en'
     encoding = 'utf-8'
 
+    compress_news_images = True
+    scale_news_images_to_device = True
+
     keep_only_tags = [
         dict(itemprop=['headline']),
         classes(


### PR DESCRIPTION
The Atlantic.com recipe has been producing huge output files (over 200MB for me).

Enabling `compress_news_images` and `scale_news_images_to_device` matches what most other recipes in this directory already do.

Manually tested, output under 5MB.