### PR TITLE
Fix viewer not updating dark/light mode on system theme change

### DIFF
--- a/src/pyj/read_book/iframe.pyj
+++ b/src/pyj/read_book/iframe.pyj
@@ -453,6 +453,7 @@ class IframeBoss:
     def change_color_scheme(self, data):
         if data.color_scheme and data.color_scheme.foreground and data.color_scheme.background:
             opts.color_scheme = data.color_scheme
+            opts.is_dark_theme = v'!!data.color_scheme.is_dark_theme'
             apply_colors()
             set_color_scheme_class()
 


### PR DESCRIPTION
When the system color scheme changes (e.g. light to dark), the viewer's `change_color_scheme` handler updates `opts.color_scheme` but never updates `opts.is_dark_theme`, which remains at its initialization value.

This causes `set_color_scheme_class()` to use a stale value, so the `calibre-viewer-dark-colors` / `calibre-viewer-light-colors` class on `<body>` never updates. When `override_book_colors` is set to `"dark"`, the CSS override rule only matches when the dark class is present — so the book content stays in the old theme.

**Fix:** Update `opts.is_dark_theme` from the incoming color scheme data before calling `apply_colors()` and `set_color_scheme_class()`.