### PR TITLE
Expanded functionality for WolneLektury store

### DIFF
--- a/src/calibre/gui2/store/stores/wolnelektury_plugin.py
+++ b/src/calibre/gui2/store/stores/wolnelektury_plugin.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-store_version = 5  # Needed for dynamic plugin loading
+store_version = 6  # Needed for dynamic plugin loading
 
 __license__ = 'GPL 3'
 __copyright__ = '2012-2023, Tomasz Długosz <tomek3d@gmail.com>'
@@ -28,6 +28,7 @@ try:
 except ImportError:
     from lxml.html import fromstring as safe_html_fromstring
 
+import json
 
 class WolneLekturyStore(BasicStoreConfig, StorePlugin):
 
@@ -51,6 +52,7 @@ class WolneLekturyStore(BasicStoreConfig, StorePlugin):
         url = 'https://wolnelektury.pl/szukaj?q=' + quote_plus(query)
 
         br = browser()
+        price = '0,00 zł'
 
         counter = max_results
         with closing(br.open(url, timeout=timeout)) as f:
@@ -59,24 +61,43 @@ class WolneLekturyStore(BasicStoreConfig, StorePlugin):
                 if counter <= 0:
                     break
 
-                id = ''.join(data.xpath('.//figure/a/@href'))
-                if not id:
+                try:
+                    id = ''.join(data.xpath('.//figure/a/@href')).split('/')[3]
+                except IndexError:
                     continue
 
                 title = ''.join(data.xpath('.//h2/a/text()'))
                 author = ', '.join(data.xpath('.//h3/a/text()'))
                 cover_url = ''.join(data.xpath('.//figure/a/img/@src'))
-                price = '0,00 zł'
-
-                counter -= 1
 
                 s = SearchResult()
                 s.cover_url = 'https://wolnelektury.pl' + cover_url.strip()
                 s.title = title.strip()
                 s.author = author
                 s.price = price
-                s.detail_item = 'https://wolnelektury.pl' + id
+                s.detail_item = "https://wolnelektury.pl/katalog/lektura/" + id
+                
+                s.downloads.update(self._search_formats(id, timeout=timeout))
+                
                 s.formats = ', '.join(s.downloads.keys())
                 s.drm = SearchResult.DRM_UNLOCKED
 
+                counter -= 1
+
                 yield s
+
+    def _search_formats(self, id: str, timeout: int = 60) -> dict[str, str]:
+        # formats used by the site and calibre (as of 01.05.2026)
+        ALLOWED_FORMATS: tuple[str,...] = ("pdf", "epub", "mobi", "txt", "html", "fb2")
+        result: dict[str, str] = {}
+        br=browser()
+        url = f"https://wolnelektury.pl/api/books/{id}/?format=json"
+        with closing(br.open(url, timeout=timeout)) as page:
+            parsed_data = json.load(page)
+            for ext in ALLOWED_FORMATS:
+                if (book_url := parsed_data.get(ext)) is None:
+                    continue
+                if book_url != "":
+                    result[ext] = book_url
+        
+        return result


### PR DESCRIPTION
At the moment WolneLektury are only queried for the books, the downloading process has to be performed manually by going into their website. With these changes books can be downloaded directly using calibre menu in all available formats, without opening pages.
