### PR TITLE
newrepublicmag: enable compress_news_images so auto_size takes effect

### DIFF
--- a/recipes/newrepublicmag.recipe
+++ b/recipes/newrepublicmag.recipe
@@ -46,6 +46,7 @@ class NewRepublicMagazine(BasicNewsRecipe):
     remove_attributes = ['height', 'width']
     ignore_duplicate_articles = {'title', 'url'}
     remove_empty_feeds = True
+    compress_news_images = True
     compress_news_images_auto_size = 6
     requires_version = (5, 0, 0)
 


### PR DESCRIPTION
The `newrepublicmag` recipe has `compress_news_images_auto_size = 6` but no
`compress_news_images = True`. The auto_size attribute is only consulted when
the boolean is enabled, so as written the setting is a no-op and images ship
at full resolution.

This one-line patch adds the boolean. Same fix pattern as cf021eb9b
("Reduce Atlantic output - enable compression and scaling"), where the
Atlantic recipe was missing the same setting.