### PR TITLE
chicago_tribune: switch cover source from frontpages.com to kiosko.net

### DIFF
--- a/recipes/chicago_tribune.recipe
+++ b/recipes/chicago_tribune.recipe
@@ -36,10 +36,8 @@ class ChicagoTribune(BasicNewsRecipe):
     '''
 
     def get_cover_url(self):
-        soup = self.index_to_soup('https://www.frontpages.com/us-newspapers/')
-        for img in soup.findAll('img', src=True):
-            if 'chicago-tribune' in img['src']:
-                return 'https://www.frontpages.com' + img['src']
+        soup = self.index_to_soup('https://en.kiosko.net/us/np/chicago_tribune.html')
+        return 'https:' + soup.find('img', attrs={'id': 'portada'})['src']
 
     keep_only_tags = [
         classes('headlines header-features coauthor-avatar-container article-body'),


### PR DESCRIPTION
frontpages.com no longer ships the `<img src>` server-side (it's now
JS-injected), so the existing scrape returns None and issues ship
without a cover.

Reads the cover from kiosko.net instead, using the same
`<img id="portada">` pattern as `globaltimes.recipe`.