### PR TITLE
the_conversation: disable auto_cleanup so byline and title aren't dropped

### DIFF
--- a/recipes/the_conversation.recipe
+++ b/recipes/the_conversation.recipe
@@ -10,7 +10,28 @@ class TheConversation(BasicNewsRecipe):
     use_embedded_content = False
 
     no_stylesheets = True
-    auto_cleanup = True
+    auto_cleanup = False
+
+    keep_only_tags = [
+        # Hero image + figcaption + h1 title + publication date — nested
+        # inside <figure class="magazine"> on theconversation.com.
+        dict(name='figure', attrs={'class': 'magazine'}),
+        # Byline: author name, institutional affiliation, photo.
+        dict(name='section', attrs={'class': 'content-authors'}),
+        # Article body.
+        dict(attrs={'itemprop': 'articleBody'}),
+        # Disclosure statement ("X does not work for, consult, ..." etc).
+        dict(name='section', attrs={'class': 'content-disclosure-statement'}),
+    ]
+
+    remove_tags = [
+        # Mobile-only collapsed byline summary that duplicates author info.
+        dict(attrs={'class': 'content-authors-synopsis'}),
+        dict(attrs={'class': 'content-authors-toggle'}),
+        # JS-injected promo placeholders interspersed in the body.
+        dict(attrs={'class': 'slot'}),
+        dict(attrs={'class': 'inline-promos-skeleton'}),
+    ]
 
     feeds = [
         ('All Articles', 'https://theconversation.com/au/articles.atom'),


### PR DESCRIPTION
auto_cleanup keeps only `<div itemprop="articleBody">`, but on theconversation.com the title, byline (author name + institutional affiliation), and disclosure statement all live OUTSIDE that body — so articles ship with no title or attribution.

Disables auto_cleanup and explicitly selects the hero+title figure, byline section, body, and disclosure statement via keep_only_tags.

then remove_tags strips a duplicate mobile-only byline and JS-injected promo placeholders.