### PR TITLE
vox: fetch live pages so byline, breadcrumb, and dek aren't dropped

### DIFF
--- a/recipes/vox.recipe
+++ b/recipes/vox.recipe
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # vim:fileencoding=utf-8
-from calibre.web.feeds.news import BasicNewsRecipe
+from calibre.web.feeds.news import BasicNewsRecipe, classes
 
 
 class AdvancedUserRecipe1716097549(BasicNewsRecipe):
@@ -19,6 +19,22 @@ class AdvancedUserRecipe1716097549(BasicNewsRecipe):
     ignore_duplicate_articles = {'title', 'url'}
     scale_news_images = 600, 800
     compress_news_images = True
+
+    use_embedded_content = False
+    auto_cleanup = False
+
+    keep_only_tags = [
+        # Lede block: section breadcrumb (e.g. "Future Perfect"), h1
+        # title, dek, byline, publication timestamp, and hero image.
+        classes('duet--article--lede'),
+        # Article body container.
+        classes('duet--layout--entry-body'),
+    ]
+
+    remove_tags = [
+        # Social share row appended after the byline.
+        classes('duet--article--share-buttons'),
+    ]
 
     feeds          = [
         ('All Articles', 'https://www.vox.com/rss/index.xml'),


### PR DESCRIPTION
Vox's RSS feeds carry the article body inline in `<content type="html">`, and BasicNewsRecipe uses that embedded copy when present. The embedded copy is missing the byline, the section breadcrumb (e.g. "Future Perfect"), the dek, and the publication timestamp — all of which live only on the live page.

Sets `use_embedded_content = False` so the live page is fetched, and selects the lede block (breadcrumb + h1 + dek + byline + timestamp + hero image) and body container explicitly via `keep_only_tags`. Drops the social-share row via `remove_tags`.