### PR TITLE
tls_mag: force Safari UA so CloudFront serves the real page

### DIFF
--- a/recipes/tls_mag.recipe
+++ b/recipes/tls_mag.recipe
@@ -44,6 +44,17 @@ class TLS(BasicNewsRecipe):
         }
     }
 
+    def get_browser(self, *args, **kwargs):
+        # Default Chrome UA is served a CloudFront CAPTCHA page that
+        # lacks the rel=shortlink Link header parse_index needs to
+        # extract the WordPress issue id. Safari UA gets the real page.
+        kwargs['user_agent'] = (
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) '
+            'AppleWebKit/605.1.15 (KHTML, like Gecko) '
+            'Version/17.0 Safari/605.1.15'
+        )
+        return BasicNewsRecipe.get_browser(self, *args, **kwargs)
+
     def parse_index(self):
         issue = 'https://www.the-tls.com/issues/current-issue/'
 


### PR DESCRIPTION
the-tls.com is fronted by CloudFront, which serves Calibre's default Chrome UA a CAPTCHA page instead of the issue page. The CAPTCHA response lacks the rel=shortlink Link header that parse_index reads to extract the WordPress issue id, so the recipe crashes at soup.find('link', rel='shortlink')['href'].

Overrides get_browser to force a Safari UA, which CloudFront passes through cleanly.