### PR TITLE
wash_post_print: tag subhead and image captions for styling hooks

### DIFF
--- a/recipes/wash_post_print.recipe
+++ b/recipes/wash_post_print.recipe
@@ -94,13 +94,13 @@ class wapoprint(BasicNewsRecipe):
         text = data.get('label', {}).get('basic', {}).get('text', '')
         label = f'<p class="time">{text}</p>' if text else ''
         title = '<h1>' + data['headlines']['basic'] + '</h1>'
-        subhead = '<p class="subt">' + data['description'].get('basic', '') + '</h3>'
+        subhead = '<h3 class="subhead">' + data['description'].get('basic', '') + '</h3>'
 
         promo_img = ''
         if data.get('promo_items', {}).get('basic', {}).get('type', '') == 'image':
             pi = data['promo_items']['basic']
             promo_img = (
-                '<p><div class="img"><img src="{}"><div>{}</div></div></p>'.format(
+                '<p><div class="img"><img src="{}"><div class="caption">{}</div></div></p>'.format(
                     pi['url'], pi['credits_caption_display']
                 )
             )
@@ -122,12 +122,12 @@ class wapoprint(BasicNewsRecipe):
                 body += '<p>' + x['content'] + '</p>'
             elif x['type'] == 'video':
                 if 'promo_image' in x:
-                    body += '<p><div class="img"><img src="{}"><div>{}</div></div></p>'.format(
+                    body += '<p><div class="img"><img src="{}"><div class="caption">{}</div></div></p>'.format(
                         x['promo_image']['url'], x['description'].get('basic', '')
                     )
             elif x['type'] == 'image':
                 img_ = (
-                    '<p><div class="img"><img src="{}"><div>{}</div></div></p>'.format(
+                    '<p><div class="img"><img src="{}"><div class="caption">{}</div></div></p>'.format(
                         x['url'], x['credits_caption_display']
                     )
                 )


### PR DESCRIPTION
recipe emits dek as `<p class="subt">...</h3>'. opening and closing tags are mismatched, leaving the dek without a clean hook. also, captions (promo, video, image) emit as a bare <div> with no class.

my fixed recipe emits the subhead as `<h3 class="subhead">...</h3>` (matched pair) and tags each image-caption div with `class="caption"`. This change gives downstream stylesheets proper targets.