### PR TITLE
latimes: narrow article regex to today+yesterday, strip picture wrappers

### DIFF
--- a/recipes/latimes.recipe
+++ b/recipes/latimes.recipe
@@ -2,6 +2,7 @@
 
 import re
 from collections import defaultdict
+from datetime import date, timedelta
 
 from calibre.web.feeds.news import BasicNewsRecipe
 
@@ -72,7 +73,14 @@ class LATimes(BasicNewsRecipe):
 
     def parse_index(self):
         index = 'https://www.latimes.com/'
-        pat = r'^https://www\.latimes\.com/[^/]+?/story/20\d{2}-\d{2}-\d{2}/\S+'
+        # Constrain the date path-segment to today+yesterday so the section
+        # indexes don't pull in arbitrary older articles. Same idea as
+        # chicago_tribune.recipe's inline tdy/yest filter (just expressed as
+        # a regex alternation since latimes uses re.compile).
+        tdy = date.today().strftime('%Y-%m-%d')
+        yest = (date.today() - timedelta(days=1)).strftime('%Y-%m-%d')
+        pat = (r'^https://www\.latimes\.com/[^/]+?/story/('
+               + tdy + '|' + yest + r')/\S+')
         articles = self.find_articles(index, pat)
         for collection in DIR_COLLECTIONS:
             if self.test:
@@ -98,6 +106,22 @@ class LATimes(BasicNewsRecipe):
                 img.parent.extract()
             else:
                 img['src'] = img['data-src']
+        # Strip <picture> wrappers and viewport sizing hints. <source srcset>
+        # URLs are remote and never load in an EPUB (no network at read
+        # time), and sizes="100vw" on the <img> tells the reader to render
+        # at full viewport width — combined with the image's natural aspect
+        # ratio that overflows pages for portrait photos. Drop <source>,
+        # unwrap <picture> so the <img> rises to its parent, and remove the
+        # sizes/fetchpriority hints so the reader respects the image's
+        # embedded dimensions.
+        for src in soup.findAll('source'):
+            src.decompose()
+        for picture in soup.findAll('picture'):
+            picture.unwrap()
+        for img in soup.findAll('img'):
+            for attr in ('sizes', 'fetchpriority'):
+                if attr in img.attrs:
+                    del img[attr]
         return soup
 
     def find_articles(self, index, pattern):


### PR DESCRIPTION
Two issues fixed in LATimes:

1. The /story/YYYY-MM-DD/ regex in parse_index was date-agnostic, so each section walk pulled articles from arbitrary past dates. This fix narrows the date path-segment to today+yesterday — same idea as chicago_tribune.recipe's inline tdy/yest filter (just expressed as a regex alternation since latimes uses re.compile).

2. LAT wraps each photo in <picture><sourcesrcset="remote-webp"/> <img sizes="100vw" fetchpriority="high"src="local.jpg"/></picture>. The <source> URLs never load in EPUB (remote, no network at readtime), and sizes="100vw" tells the reader to render at full viewport width — combined with the image's natural aspect ratio that overflows portrait photos onto the next page. Decomposes <source>, unwraps <picture>, and removes the sizes/fetchpriority hints so readers respect the image's embedded dimensions.