### PR TITLE
latimes: drop the Twitter Follow link from the byline

### DIFF
--- a/recipes/latimes.recipe
+++ b/recipes/latimes.recipe
@@ -98,6 +98,15 @@ class LATimes(BasicNewsRecipe):
                 img.parent.extract()
             else:
                 img['src'] = img['data-src']
+        # Drop the Twitter "Follow" link from each byline. The anchor wraps
+        # an SVG <use> sprite reference that points at a <shape> in a
+        # sibling <svg> elsewhere in the source document; that cross-
+        # document reference can't resolve in the converted EPUB, so the
+        # anchor renders as an empty icon slot followed by the orphan word
+        # "Follow" next to the byline. The "Staff Writer" <span> sibling
+        # is not a descendant of the anchor, so the rubric stays in place.
+        for a in soup.findAll('a', attrs={'data-social-trigger': 'enhancedByline'}):
+            a.decompose()
         return soup
 
     def find_articles(self, index, pattern):


### PR DESCRIPTION
LATimes bylines contain an <a data-social-trigger="enhancedByline"> wrapping an SVG <use> sprite reference and the literal text "Follow". The sprite targets a <shape> ID in a sibling <svg> elsewhere in the source document — that cross-document reference can't resolve in the converted EPUB, so the anchor renders as an empty icon slot followed a badly placed "Follow."

This fix decomposes the anchor in preprocess_html. The "Staff Writer" <span> sibling is not a descendant, so the rubric stays in place.