### PR TITLE
propublica: drop the "ProPublica is a nonprofit newsroom" blurb

### DIFF
--- a/recipes/propublica.recipe
+++ b/recipes/propublica.recipe
@@ -31,7 +31,8 @@ class ProPublicaRecipe(BasicNewsRecipe):
         classes('title-wrapper content-wrapper article-header lead-art article-body')
     ]
     remove_tags = [
-        classes('email-signup story-tools newsletter topics-list')
+        classes('email-signup story-tools newsletter topics-list'),
+        classes('wp-block-propublica-notes--top'),
     ]
     remove_tags_after = classes('article-body')
 


### PR DESCRIPTION
The ProPublica WordPress theme prepends a standing "ProPublica is a nonprofit newsroom that investigates abuses of power..." block to every article body, wrapped as `<div class="wp-block-propublica-notes--top wp-block-propublica-note">`.

This fix extends remove_tags to strip it via the --top BEM modifier. (The bare wp-block-propublica-note class is reused for in-body editor's-note boxes that should pass through, so the modifier scopes the strip to the top-of-article boilerplate only.)