### PR TITLE
newcriterion: update parse_index and login for WordPress migration

### DIFF
--- a/recipes/thenewcriterion.recipe
+++ b/recipes/thenewcriterion.recipe
@@ -9,14 +9,6 @@ __copyright__ = '2019, Darko Miletic <darko.miletic at gmail.com>'
 www.newcriterion.com
 '''
 
-try:
-    from urllib.parse import urlencode
-except ImportError:
-    from urllib import urlencode
-import re
-
-from mechanize import Request
-
 from calibre import strftime
 from calibre.ptempfile import PersistentTemporaryFile
 from calibre.web.feeds.news import BasicNewsRecipe
@@ -55,47 +47,43 @@ class TheNewCriterion(BasicNewsRecipe):
 
     def get_browser(self):
         br = BasicNewsRecipe.get_browser(self)
-        br.open('https://www.newcriterion.com/')
         if self.username is not None and self.password is not None:
-            data = urlencode({'login': self.username, 'password': self.password})
-            header = {
-                'X-OCTOBER-REQUEST-HANDLER': 'onSignin',
-                'X-Requested-With': 'XMLHttpRequest',
-                'DNT':'1',
-                'X-OCTOBER-REQUEST-PARTIALS':'',
-                'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
-            }
-            request = Request('https://www.newcriterion.com/', data, header)
-            br.open(request)
+            br.set_cookie('wordpress_test_cookie', 'WP+Cookie+check', '.newcriterion.com')
+            br.open('https://newcriterion.com/wp-login.php')
+            br.select_form(name='loginform')
+            br['log'] = self.username
+            br['pwd'] = self.password
+            br.submit()
         return br
 
     def parse_index(self):
-        part = strftime('/issues/%Y/') + str(int(strftime('%m')))
-        partf = part + '/'
-        currentIssue_url = 'https://www.newcriterion.com' + part
-        soup1 = self.index_to_soup(currentIssue_url)
+        months = ('january', 'february', 'march', 'april', 'may', 'june',
+                  'july', 'august', 'september', 'october', 'november', 'december')
+        slug = months[int(strftime('%m')) - 1] + '-' + strftime('%Y')
+        currentIssue_url = 'https://newcriterion.com/issues/' + slug + '/'
         self.log(currentIssue_url)
-        rsr = re.compile('^' + partf + '.+$')
+        soup1 = self.index_to_soup(currentIssue_url)
         date = strftime(' %B %Y')
         articles = []
-        subset = soup1.find('div', id='main')
-        for item in subset.findAll('a', href=True):
-            relurl = str(item['href'])
-            if rsr.search(relurl):
-                title = ''
-                description = ''
-                if item.find('div'):
-                    title = self.tag_to_string(item.div.h1).strip()
-                    description = self.tag_to_string(item.div.p)
-                else:
-                    title = self.tag_to_string(item.h1).strip()
-                    description = self.tag_to_string(item.p)
-                articles.append({
-                    'title': title,
-                    'date': date,
-                    'url': 'https://www.newcriterion.com' + relurl,
-                    'description': description
-                })
+        subset = soup1.find('div', attrs={'class': 'issue-layout'})
+        if subset is None:
+            return []
+        for art in subset.findAll('article', attrs={'class': 'article-display'}):
+            h2 = art.find('h2')
+            if h2 is None:
+                continue
+            a = h2.find('a', href=True)
+            if a is None or '/article/' not in a['href']:
+                continue
+            title = self.tag_to_string(a).strip()
+            excerpt = art.find('p', attrs={'class': 'post-excerpt'})
+            description = self.tag_to_string(excerpt).strip() if excerpt else ''
+            articles.append({
+                'title': title,
+                'date': date,
+                'url': a['href'],
+                'description': description,
+            })
         return [(self.title, articles)]
 
     def get_obfuscated_article(self, url):


### PR DESCRIPTION
newcriterion.com moved from October CMS to WordPress. The old recipe looked for <div id="main"> and an /issues/YYYY/M/ URL pattern, so parse_index crashed with AttributeError. This patch rewrites parse_index for the new markup. (Also ports get_browser from the old October-CMS XHR signin endpoint to standard wp-login.php form submission, and drops the now-unused urlencode, mechanize.Request, and re imports.)