### PR TITLE
Respect content server book restrictions in FTS and data file endpoints

### DIFF
--- a/src/calibre/srv/content.py
+++ b/src/calibre/srv/content.py
@@ -537,11 +537,18 @@ def data_file(rd, fname, path, stat_result):
     return rd.filesystem_file_with_custom_etag(share_open(path, 'rb'), stat_result.st_dev, stat_result.st_ino, stat_result.st_size, stat_result.st_mtime)
 
 
-@endpoint('/data-files/get/{book_id}/{relpath}/{library_id=None}', types={'book_id': int})
-def get_data_file(ctx, rd, book_id, relpath, library_id):
+def get_db_for_data_file(ctx, rd, book_id, library_id):
     db = get_db(ctx, rd, library_id)
     if db is None:
         raise HTTPNotFound(f'Library {library_id} not found')
+    if not ctx.has_id(rd, db, book_id):
+        raise BookNotFound(book_id, db)
+    return db
+
+
+@endpoint('/data-files/get/{book_id}/{relpath}/{library_id=None}', types={'book_id': int})
+def get_data_file(ctx, rd, book_id, relpath, library_id):
+    db = get_db_for_data_file(ctx, rd, book_id, library_id)
     for ef in db.list_extra_files(book_id, pattern=DATA_FILE_PATTERN):
         if ef.relpath == relpath:
             return data_file(rd, relpath.rpartition('/')[2], ef.file_path, ef.stat_result)
@@ -557,9 +564,7 @@ def strerr(e: Exception):
 
 @endpoint('/data-files/upload/{book_id}/{library_id=None}', needs_db_write=True, methods={'POST'}, types={'book_id': int}, postprocess=json)
 def upload_data_files(ctx, rd, book_id, library_id):
-    db = get_db(ctx, rd, library_id)
-    if db is None:
-        raise HTTPNotFound(f'Library {library_id} not found')
+    db = get_db_for_data_file(ctx, rd, book_id, library_id)
     files = {}
     try:
         recvd = load_json_file(rd.request_body_file)
@@ -580,9 +585,7 @@ def upload_data_files(ctx, rd, book_id, library_id):
 
 @endpoint('/data-files/remove/{book_id}/{library_id=None}', needs_db_write=True, methods={'POST'}, types={'book_id': int}, postprocess=json)
 def remove_data_files(ctx, rd, book_id, library_id):
-    db = get_db(ctx, rd, library_id)
-    if db is None:
-        raise HTTPNotFound(f'Library {library_id} not found')
+    db = get_db_for_data_file(ctx, rd, book_id, library_id)
     try:
         relpaths = load_json_file(rd.request_body_file)
         if not isinstance(relpaths, list):

--- a/src/calibre/srv/fts.py
+++ b/src/calibre/srv/fts.py
@@ -7,6 +7,14 @@ from calibre.ebooks.metadata import authors_to_string
 from calibre.srv.errors import HTTPBadRequest, HTTPPreconditionRequired, HTTPUnprocessableEntity
 from calibre.srv.routes import endpoint, json
 from calibre.srv.utils import get_library_data
+from calibre.utils.search_query_parser import ParseException
+
+
+def book_ids_from_user_restriction(ctx, rd, db):
+    try:
+        return ctx.get_allowed_book_ids_from_restriction(rd, db)
+    except ParseException:
+        return frozenset()
 
 
 @endpoint('/fts/search', postprocess=json)
@@ -31,9 +39,10 @@ def fts_search(ctx, rd):
     qid = rd.query.get('query_id')
     if qid:
         ans['query_id'] = qid
-    book_ids = None
+    book_ids = book_ids_from_user_restriction(ctx, rd, db)
     if rd.query.get('restriction'):
-        book_ids = db.search('', restriction=rd.query.get('restriction'), allow_templates=False)
+        restricted_ids = db.search('', restriction=rd.query.get('restriction'), allow_templates=False)
+        book_ids = restricted_ids if book_ids is None else book_ids & restricted_ids
 
     def add_metadata(result):
         result.pop('id', None)
@@ -114,6 +123,9 @@ def fts_snippets(ctx, rd, book_ids):
         bids = frozenset(map(int, book_ids.split(',')))
     except Exception:
         raise HTTPBadRequest('Invalid list of book ids')
+    allowed_book_ids = book_ids_from_user_restriction(ctx, rd, db)
+    if allowed_book_ids is not None:
+        bids &= allowed_book_ids
     try:
         ssz = int(rd.query.get('snippet_size', 32))
     except Exception:

--- a/src/calibre/srv/tests/ajax.py
+++ b/src/calibre/srv/tests/ajax.py
@@ -93,6 +93,8 @@ class ContentTest(LibraryBaseTest):
             db = server.handler.router.ctx.library_broker.get(None)
             db.set_pref('virtual_libraries', {'1':'id:1', '12':'id:1 or id:2'})
             db.set_field('tags', {1: ['present'], 3: ['missing']})
+            db.add_extra_files(1, {'data/visible.txt': BytesIO(b'visible')})
+            db.add_extra_files(3, {'data/hidden.txt': BytesIO(b'hidden')})
             self.assertTrue(db.has_id(3))
             server.handler.ctx.user_manager.add_user('12', 'test', restriction={
                 'library_restrictions':{os.path.basename(db.backend.library_path): 'id:1 or id:2'}})
@@ -157,6 +159,27 @@ class ContentTest(LibraryBaseTest):
             # content.py
             ok(url_for('/get', what='thumb', book_id=1))
             nf(url_for('/get', what='thumb', book_id=3))
+            ae(ok(url_for('/data-files/get', book_id=1, relpath='data/visible.txt')), b'visible')
+            nf(url_for('/data-files/get', book_id=3, relpath='data/hidden.txt'))
+            nf(url_for('/data-files/upload', book_id=3), method='POST')
+            nf(url_for('/data-files/remove', book_id=3), method='POST')
+
+            # fts.py
+            def fake_fts_search(query, use_stemming=True, return_text=True, process_each_result=None, restrict_to_book_ids=None, **kwargs):
+                candidate_ids = {1, 3} if restrict_to_book_ids is None else set(restrict_to_book_ids) & {1, 3}
+                for book_id in sorted(candidate_ids):
+                    result = {'id': book_id, 'book_id': book_id, 'format': 'TXT', 'text': 'matching text'}
+                    yield process_each_result(result) if process_each_result else result
+
+            db.is_fts_enabled = lambda: True
+            db.fts_indexing_progress = lambda: (0, 0, None)
+            db.fts_search = fake_fts_search
+            data = ok('/fts/search?' + urlencode({'query': 'matching'}))
+            ae({x['book_id'] for x in data['results']}, {1})
+            data = ok('/fts/search?' + urlencode({'query': 'matching', 'restriction': 'tags:missing'}))
+            ae({x['book_id'] for x in data['results']}, set())
+            data = ok('/fts/snippets/1,3?' + urlencode({'query': 'matching'}))
+            ae(set(map(int, data['snippets'])), {1})
 
             # Not going test legacy and opds as they are too painful
     # }}}


### PR DESCRIPTION
This fixes a couple of content server paths that were not applying the current user’s book restriction consistently.

FTS search now restricts results to the books the user is allowed to see, and still intersects that with any explicit FTS query restriction. FTS snippets also filters the requested book ids through the user restriction.

Data file get/upload/remove now checks access to the target book before reading or modifying its extra files.

I also extended the existing server restriction test to cover these paths. The test checks allowed and hidden data files, FTS results, FTS query restriction intersection, and FTS snippets.

Tested with:
python setup.py test --test-module srv --test-name srv_restrictions