### PR TITLE
Fix ignored duplicate moves in content server

### DIFF
--- a/src/calibre/db/copy_to_library.py
+++ b/src/calibre/db/copy_to_library.py
@@ -6,6 +6,8 @@ from calibre.db.utils import find_identical_books
 from calibre.utils.config import tweaks
 from calibre.utils.date import now
 
+source_removal_actions = frozenset({'add', 'automerge'})
+
 
 def automerge_book(automerge_action, book_id, mi, identical_book_list, newdb, format_map, extra_file_map):
     seen_fmts = set()

--- a/src/calibre/srv/cdb.py
+++ b/src/calibre/srv/cdb.py
@@ -248,13 +248,13 @@ def cdb_copy_to_library(ctx, rd, target_library_id, library_id):
     if duplicate_action != 'add':
         identical_books_data = db_dest.data_for_find_identical_books()
     to_remove = set()
-    from calibre.db.copy_to_library import copy_one_book
+    from calibre.db.copy_to_library import copy_one_book, source_removal_actions
     for book_id in book_ids:
         try:
             rdata = copy_one_book(
                     book_id, db_src, db_dest, duplicate_action=duplicate_action, automerge_action=automerge_action,
                     preserve_uuid=move_books, preserve_date=preserve_date, identical_books_data=identical_books_data)
-            if move_books:
+            if move_books and rdata['action'] in source_removal_actions:
                 to_remove.add(book_id)
             response[book_id] = {'ok': True, 'payload': rdata}
         except Exception:

--- a/src/calibre/srv/tests/ajax.py
+++ b/src/calibre/srv/tests/ajax.py
@@ -55,6 +55,37 @@ class ContentTest(LibraryBaseTest):
 
     # }}}
 
+    def test_move_duplicate_to_library(self):  # {{{
+        'Test that ignored duplicates are not removed when moving to another library'
+        target_library_path = self.mkdtemp()
+        self.create_db(target_library_path)
+        with self.create_server(libraries=(self.library_path, target_library_path), auth=True, auth_mode='basic') as server:
+            server.handler.ctx.user_manager.add_user('12', 'test')
+            ctx = server.handler.router.ctx
+            library_map = ctx.library_broker.library_map
+            target_library_id = next(
+                library_id for library_id, name in library_map.items()
+                if name == os.path.basename(target_library_path))
+            source_db = ctx.library_broker.get(None)
+            target_db = ctx.library_broker.get(target_library_id)
+            target_book_ids = target_db.all_book_ids()
+            self.assertTrue(source_db.has_id(1))
+            conn = server.connect()
+            r, data = make_request(
+                conn, f'/cdb/copy-to-library/{target_library_id}/{source_db.server_library_id}',
+                username='12', password='test',
+                prefix='', method='POST', headers={'Content-Type': 'application/json'}, data=json.dumps({
+                    'book_ids': [1], 'move': True, 'duplicate_action': 'ignore', 'automerge_action': 'overwrite',
+                }).encode('utf-8'))
+            self.ae(r.status, OK)
+            self.assertTrue(data['1']['ok'])
+            self.ae(data['1']['payload']['action'], 'duplicate')
+            self.assertIsNone(data['1']['payload']['new_book_id'])
+            self.assertTrue(source_db.has_id(1))
+            self.ae(target_db.all_book_ids(), target_book_ids)
+
+    # }}}
+
     def test_ajax_categories(self):  # {{{
         'Test /ajax/categories and /ajax/search'
         with self.create_server() as server:

--- a/src/pyj/book_list/book_details.pyj
+++ b/src/pyj/book_list/book_details.pyj
@@ -1213,14 +1213,15 @@ def do_copy_to_library(book_id, target_library_id, target_library_name):
                 response.payload
             )
             return
-        if response.action is 'duplicate':
+        payload = response.payload
+        if payload.action is 'duplicate':
             warning_dialog(_('Book already exists'), _(
                 'Could not copy as a book with the same title and authors already exists in the {} library').format(target_library_name))
 
-        elif response.action is 'automerge':
+        elif payload.action is 'automerge':
             warning_dialog(_('Book merged'), _(
                 'The files from the book were merged into a book with the same title and authors in the {} library').format(target_library_name))
-        if move:
+        if move and payload.action in ('add', 'automerge'):
             refresh_after_delete(book_id, current_library_id())
 
 


### PR DESCRIPTION
When moving a book to another library from the content server, an ignored duplicate was still removed from the source library.

This changes the move cleanup to only remove the source book when the copy actually added or merged data into the target library. It also fixes the content server UI to read the returned copy result from the response payload, and adds a regression test for ignored duplicate moves.