### PR TITLE
Reject invalid HTTP Content-Length framing

### DIFF
--- a/src/calibre/srv/http_request.py
+++ b/src/calibre/srv/http_request.py
@@ -200,6 +200,26 @@ def read_headers(readline):
 # }}}
 
 
+def parse_content_length(values):
+    ans = None
+    for value in values:
+        try:
+            if isinstance(value, bytes):
+                raw = value.strip()
+            else:
+                raw = value.strip().encode('ascii')
+        except UnicodeEncodeError:
+            raise ValueError('Content-Length is not a valid decimal integer')
+        if not raw.isdigit():
+            raise ValueError('Content-Length is not a valid decimal integer')
+        val = int(raw)
+        if ans is None:
+            ans = val
+        elif val != ans:
+            raise ValueError('Conflicting Content-Length headers')
+    return 0 if ans is None else ans
+
+
 class HTTPRequest(Connection):
 
     request_handler = None
@@ -308,10 +328,11 @@ class HTTPRequest(Connection):
             self.finalize_headers(parser.hdict)
 
     def finalize_headers(self, inheaders):
-        request_content_length = int(inheaders.get('Content-Length', 0))
-        if request_content_length > self.max_request_body_size:
-            return self.simple_response(http.client.REQUEST_ENTITY_TOO_LARGE,
-                f'The entity sent with the request exceeds the maximum allowed bytes ({self.max_request_body_size}).')
+        content_length_values = inheaders.get('Content-Length', all=True)
+        try:
+            request_content_length = parse_content_length(content_length_values)
+        except ValueError as e:
+            return self.simple_response(http.client.BAD_REQUEST, str(e))
         # Persistent connection support
         if self.response_protocol is HTTP11:
             # Both server and client are HTTP/1.1
@@ -329,6 +350,8 @@ class HTTPRequest(Connection):
                 te = [x.strip().lower() for x in rte.split(',') if x.strip()]
         chunked_read = False
         if te:
+            if content_length_values:
+                return self.simple_response(http.client.BAD_REQUEST, 'Cannot specify both Transfer-Encoding and Content-Length')
             for enc in te:
                 if enc == 'chunked':
                     chunked_read = True
@@ -336,6 +359,10 @@ class HTTPRequest(Connection):
                     # Note that, even if we see "chunked", we must reject
                     # if there is an extension we don't recognize.
                     return self.simple_response(http.client.NOT_IMPLEMENTED, f'Unknown transfer encoding: {enc!r}')
+
+        if request_content_length > self.max_request_body_size:
+            return self.simple_response(http.client.REQUEST_ENTITY_TOO_LARGE,
+                f'The entity sent with the request exceeds the maximum allowed bytes ({self.max_request_body_size}).')
 
         if inheaders.get('Expect', '').lower() == '100-continue':
             buf = BytesIO((HTTP11 + ' 100 Continue\r\n\r\n').encode('ascii'))

--- a/src/calibre/srv/tests/http.py
+++ b/src/calibre/srv/tests/http.py
@@ -234,6 +234,24 @@ class TestHTTP(BaseTest):
             self.ae(r.status, http.client.OK)
             self.ae(r.read(), b'testbody')
 
+            def bad_request(raw, msg):
+                conn = server.connect()
+                r = raw_send(conn, raw)
+                self.ae(r.status, http.client.BAD_REQUEST)
+                self.assertIn(msg, r.read())
+
+            # Identical Content-Length headers are harmless, conflicting or
+            # malformed ones are rejected before the body is read.
+            r = raw_send(server.connect(), b'POST /test HTTP/1.1\r\nContent-Length: 4\r\nContent-Length: 4\r\n\r\nbody')
+            self.ae(r.status, http.client.OK)
+            self.ae(r.read(), b'testbody')
+            bad_request(b'POST /test HTTP/1.1\r\nContent-Length: -1\r\n\r\nbody', b'Content-Length is not a valid decimal integer')
+            bad_request(b'POST /test HTTP/1.1\r\nContent-Length: abc\r\n\r\nbody', b'Content-Length is not a valid decimal integer')
+            bad_request(b'POST /test HTTP/1.1\r\nContent-Length: 4\r\nContent-Length: 5\r\n\r\nbodyx', b'Conflicting Content-Length headers')
+            bad_request(
+                b'POST /test HTTP/1.1\r\nTransfer-Encoding: chunked\r\nContent-Length: 200\r\n\r\n4\r\nbody\r\n0\r\n\r\n',
+                b'Cannot specify both Transfer-Encoding and Content-Length')
+
             # Test POST with chunked transfer encoding
             conn.request('POST', '/test', headers={'Transfer-Encoding': 'chunked'})
             conn.send(b'4\r\nbody\r\na\r\n1234567890\r\n0\r\n\r\n')


### PR DESCRIPTION
Reject malformed or conflicting Content-Length headers in the content server request parser.

This also rejects requests that send both Transfer-Encoding and Content-Length, so ambiguous request framing is handled before reading the body.

Validation:
- .venv/bin/python setup.py test --test-module srv --test-name http_basic
- python3.14 -m py_compile src/calibre/srv/http_request.py src/calibre/srv/tests/http.py
- git diff --check
