### PR TITLE
Parse Connection header tokens

### DIFF
--- a/src/calibre/srv/http_request.py
+++ b/src/calibre/srv/http_request.py
@@ -13,7 +13,7 @@ from calibre import as_unicode, force_unicode
 from calibre.ptempfile import SpooledTemporaryFile
 from calibre.srv.errors import HTTPSimpleResponse
 from calibre.srv.loop import READ, WRITE, Connection
-from calibre.srv.utils import HTTP1, HTTP11, Accumulator, MultiDict
+from calibre.srv.utils import HTTP1, HTTP11, Accumulator, MultiDict, connection_header_tokens
 from polyglot.builtins import error_message
 from polyglot.urllib import unquote
 
@@ -334,12 +334,11 @@ class HTTPRequest(Connection):
         except ValueError as e:
             return self.simple_response(http.client.BAD_REQUEST, str(e))
         # Persistent connection support
-        if self.response_protocol is HTTP11:
-            # Both server and client are HTTP/1.1
-            if inheaders.get('Connection', '') == 'close':
-                self.close_after_response = True
+        connection = connection_header_tokens(inheaders.get('Connection', ''))
+        if 'close' in connection:
+            self.close_after_response = True
         # Either the server or client (or both) are HTTP/1.0
-        elif inheaders.get('Connection', '') != 'Keep-Alive':
+        elif self.response_protocol is not HTTP11 and 'keep-alive' not in connection:
             self.close_after_response = True
 
         # Transfer-Encoding support

--- a/src/calibre/srv/tests/http.py
+++ b/src/calibre/srv/tests/http.py
@@ -300,16 +300,33 @@ class TestHTTP(BaseTest):
 
             # Test closing
             server.loop.opts.timeout = 10  # ensure socket is not closed because of timeout
-            conn.request('GET', '/close', headers={'Connection':'close'})
+            def assert_no_active_connections():
+                server.loop.wakeup()
+                num = 10
+                while num and server.loop.num_active_connections != 0:
+                    time.sleep(0.01)
+                    num -= 1
+                self.ae(server.loop.num_active_connections, 0)
+
+            conn.request('GET', '/close', headers={'Connection':'Close, Upgrade'})
             r = conn.getresponse()
             self.ae(r.status, 200), self.ae(r.read(), b'close')
-            server.loop.wakeup()
-            num = 10
-            while num and server.loop.num_active_connections != 0:
-                time.sleep(0.01)
-                num -= 1
-            self.ae(server.loop.num_active_connections, 0)
+            assert_no_active_connections()
             self.assertIsNone(conn.sock)
+
+            conn = server.connect()
+            r = raw_send(conn, b'GET /close HTTP/1.0\r\nConnection: keep-alive, close\r\n\r\n')
+            self.ae(r.status, 200), self.ae(r.read(), b'close')
+            self.assertIsNone(r.getheader('Connection'))
+            assert_no_active_connections()
+            conn.close()
+
+            conn = server.connect()
+            r = raw_send(conn, b'GET /keep-alive HTTP/1.0\r\nConnection: keep-alive, upgrade\r\n\r\n')
+            self.ae(r.status, 200), self.ae(r.read(), b'keep-alive')
+            self.ae(r.getheader('Connection'), 'Keep-Alive')
+            self.assertIsNotNone(conn.sock)
+            conn.close()
 
             # Test timeout
             server.loop.opts.timeout = 0.1

--- a/src/calibre/srv/utils.py
+++ b/src/calibre/srv/utils.py
@@ -31,6 +31,10 @@ DESIRED_SEND_BUFFER_SIZE = 16 * 1024  # windows 7 uses an 8KB sndbuf
 encode_name, decode_name
 
 
+def connection_header_tokens(value):
+    return {x.strip().lower() for x in value.split(',') if x.strip()}
+
+
 def http_date(timeval=None):
     return str(formatdate(timeval=timeval, usegmt=True))
 

--- a/src/calibre/srv/web_socket.py
+++ b/src/calibre/srv/web_socket.py
@@ -16,7 +16,7 @@ from threading import Lock
 from calibre import as_unicode
 from calibre.srv.http_response import HTTPConnection, create_http_handler
 from calibre.srv.loop import RDWR, READ, WRITE, Connection, HandleInterrupt, ServerLoop
-from calibre.srv.utils import DESIRED_SEND_BUFFER_SIZE
+from calibre.srv.utils import DESIRED_SEND_BUFFER_SIZE, connection_header_tokens
 from calibre.utils.speedups import ReadOnlyFileBuffer
 from calibre_extensions.speedup import utf8_decode
 from calibre_extensions.speedup import websocket_mask as fast_mask
@@ -274,7 +274,7 @@ class WebSocketConnection(HTTPConnection):
     def finalize_headers(self, inheaders):
         upgrade = inheaders.get('Upgrade', '')
         key = inheaders.get('Sec-WebSocket-Key', None)
-        conn = {x.strip().lower() for x in inheaders.get('Connection', '').split(',')}
+        conn = connection_header_tokens(inheaders.get('Connection', ''))
         if key is None or upgrade.lower() != 'websocket' or 'upgrade' not in conn:
             return HTTPConnection.finalize_headers(self, inheaders)
         ver = inheaders.get('Sec-WebSocket-Version', 'Unknown')


### PR DESCRIPTION
Parse Connection as case-insensitive comma-separated tokens.

This fixes HTTP/1.1 close, HTTP/1.0 keep-alive, and close winning when both tokens are present.

Validation: .venv/bin/python setup.py test --test-module srv --test-name http_basic; .venv/bin/python setup.py test --test-module srv --test-name websocket_basic; python3.14 -m py_compile src/calibre/srv/http_request.py src/calibre/srv/web_socket.py src/calibre/srv/utils.py src/calibre/srv/tests/http.py; git diff --check
