### PR TITLE
pages count: support fixed-layout

### DIFF
--- a/src/calibre/ebooks/oeb/polish/utils.py
+++ b/src/calibre/ebooks/oeb/polish/utils.py
@@ -317,3 +317,26 @@ def insert_self_closing(parent, item, index=None):
         item.tail = parent[idx-1].tail
         if idx == len(parent)-1:
             parent[idx-1].tail = parent.text
+
+
+def fixed_layout_data(container):
+    '''
+    Return a dict of the various data for a fixed-layout rendering.
+    Return None if not supported.
+    '''
+    if not container.opf_version:
+        return None
+    if container.opf_version_parsed < (3, 0):
+        return None
+    if not container.opf_xpath('//opf:metadata/opf:meta[@name="fixed-layout" and @content="true"]'):
+        return None
+    rslt = {
+        'fixed-layout': True,
+        'rendition': {},
+        'original-resolution': None,
+    }
+    for rendition in container.opf_xpath('//opf:metadata/opf:meta[starts-with(@property,"rendition:")]'):
+        rslt['rendition'][rendition.attrib['property'].split(':', 1)[1]] = rendition.text
+    for item in container.opf_xpath('//opf:metadata/opf:meta[@name="original-resolution" and @content]'):
+        rslt['original-resolution'] = item.attrib['content']
+    return rslt

--- a/src/calibre/library/page_count.py
+++ b/src/calibre/library/page_count.py
@@ -19,6 +19,7 @@ from calibre.ebooks.oeb.polish.container import Container as ContainerBase
 from calibre.ebooks.oeb.polish.parsing import decode_xml, parse
 from calibre.ebooks.oeb.polish.pretty import NON_NAMESPACED_BLOCK_TAGS
 from calibre.ebooks.oeb.polish.toc import get_toc
+from calibre.ebooks.oeb.polish.utils import fixed_layout_data
 from calibre.ptempfile import TemporaryDirectory, override_base_dir
 from calibre.utils.cleantext import clean_xml_chars
 from calibre.utils.ipc import eintr_retry_call
@@ -163,12 +164,14 @@ def count_pages_oeb(pathtoebook: str, tdir: str, executor: Executor | None = Non
     nulllog = DevNull()
     book_fmt, opfpath, input_fmt = extract_book(pathtoebook, tdir, log=nulllog, only_input_plugin=True)
     container = SimpleContainer(tdir, opfpath, nulllog)
+    spine = {name for name, is_linear in container.spine_names}
+    if fixed_layout_data(container):
+        return len(spine)
     tocobj = get_toc(container, verify_destinations=False)
     if page_list := getattr(tocobj, 'page_list', ()):
         uniq_page_numbers = frozenset(map(itemgetter('pagenum'), page_list))
         if len(uniq_page_numbers) > 50:
             return len(uniq_page_numbers)
-    spine = {name for name, is_linear in container.spine_names}
     paths = {container.get_file_path_for_processing(name, allow_modification=False) for name in spine}
     paths = {p for p in paths if os.path.isfile(p)}
 
@@ -206,7 +209,7 @@ def count_pages(pathtoebook: str, executor: Executor | None = None) -> int:
 
 class Server:
 
-    ALGORITHM = 3
+    ALGORITHM = 4
 
     def __init__(self, max_jobs_per_worker: int = 2048):
         self.worker: subprocess.Popen | None = None


### PR DESCRIPTION
If the ePub is a fixed-layout, use the html count as proper page count.

Adding a `fixed_layout_data()` to retrive the various data for a fixed-layout rendering.
The 'original-resolution' property seem not official, but could be usefull if commonly use.

I also change the algorithm version, but I let you decide if is a soft change (only on request by user) or a hard one (forced recount the all library).
Probably not worst it a hard for such niche case.