### PR TITLE
Protect rooted file paths from traversal

### DIFF
--- a/src/calibre/db/backend.py
+++ b/src/calibre/db/backend.py
@@ -62,11 +62,12 @@ from calibre.utils.filenames import (
     atomic_rename,
     copyfile_using_links,
     copytree_using_links,
-    get_long_path_name,
     hardlink_file,
     is_case_sensitive,
     is_fat_filesystem,
+    is_path_inside,
     make_long_path_useable,
+    path_from_root,
     remove_dir_if_empty,
     samefile,
 )
@@ -1685,9 +1686,7 @@ class DB:
 
     def is_path_inside_book_dir(self, path, book_relpath, sub_path):
         book_path = os.path.abspath(os.path.join(self.library_path, book_relpath, sub_path))
-        book_path = os.path.normcase(get_long_path_name(book_path)).rstrip(os.sep)
-        path = os.path.normcase(get_long_path_name(os.path.abspath(path))).rstrip(os.sep)
-        return path.startswith(book_path + os.sep)
+        return is_path_inside(book_path, path)
 
     def apply_to_format(self, book_id, path, fname, fmt, func, missing_value=None):
         path = self.format_abspath(book_id, fmt, fname, path)
@@ -2077,8 +2076,9 @@ class DB:
 
     def copy_extra_file_to(self, book_id, book_path, relpath, stream_or_path):
         full_book_path = os.path.abspath(os.path.join(self.library_path, book_path))
-        extra_file_path = os.path.abspath(os.path.join(full_book_path, relpath))
-        if not extra_file_path.startswith(full_book_path):
+        try:
+            extra_file_path = path_from_root(full_book_path, relpath)
+        except ValueError:
             raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), relpath)
         src_path = make_long_path_useable(extra_file_path)
         if isinstance(stream_or_path, str):
@@ -2135,8 +2135,9 @@ class DB:
         bookdir = os.path.join(self.library_path, book_path)
         errors = {}
         for relpath in relpaths:
-            path = os.path.abspath(os.path.join(bookdir, relpath))
-            if not self.normpath(path).startswith(self.normpath(bookdir)):
+            try:
+                path = path_from_root(bookdir, relpath)
+            except ValueError:
                 continue
             try:
                 if permanent:
@@ -2160,8 +2161,11 @@ class DB:
 
     def rename_extra_file(self, relpath, newrelpath, book_path, replace=True):
         bookdir = os.path.join(self.library_path, book_path)
-        src = os.path.abspath(os.path.join(bookdir, relpath))
-        dest = os.path.abspath(os.path.join(bookdir, newrelpath))
+        try:
+            src = path_from_root(bookdir, relpath)
+            dest = path_from_root(bookdir, newrelpath)
+        except ValueError:
+            return False
         src, dest = make_long_path_useable(src), make_long_path_useable(dest)
         if src == dest or not os.path.exists(src):
             return False
@@ -2176,8 +2180,9 @@ class DB:
 
     def add_extra_file(self, relpath, stream, book_path, replace=True, auto_rename=False):
         bookdir = os.path.join(self.library_path, book_path)
-        dest = os.path.abspath(os.path.join(bookdir, relpath))
-        if not self.normpath(dest).startswith(self.normpath(bookdir)):
+        try:
+            dest = path_from_root(bookdir, relpath)
+        except ValueError:
             return None
         if not replace and os.path.exists(make_long_path_useable(dest)):
             if not auto_rename:

--- a/src/calibre/db/backend.py
+++ b/src/calibre/db/backend.py
@@ -1686,7 +1686,7 @@ class DB:
 
     def is_path_inside_book_dir(self, path, book_relpath, sub_path):
         book_path = os.path.abspath(os.path.join(self.library_path, book_relpath, sub_path))
-        return is_path_inside(book_path, path)
+        return is_path_inside(book_path, path, case_sensitive=self.is_case_sensitive)
 
     def apply_to_format(self, book_id, path, fname, fmt, func, missing_value=None):
         path = self.format_abspath(book_id, fmt, fname, path)
@@ -2077,7 +2077,7 @@ class DB:
     def copy_extra_file_to(self, book_id, book_path, relpath, stream_or_path):
         full_book_path = os.path.abspath(os.path.join(self.library_path, book_path))
         try:
-            extra_file_path = path_from_root(full_book_path, relpath)
+            extra_file_path = path_from_root(full_book_path, relpath, case_sensitive=self.is_case_sensitive)
         except ValueError:
             raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), relpath)
         src_path = make_long_path_useable(extra_file_path)
@@ -2136,7 +2136,7 @@ class DB:
         errors = {}
         for relpath in relpaths:
             try:
-                path = path_from_root(bookdir, relpath)
+                path = path_from_root(bookdir, relpath, case_sensitive=self.is_case_sensitive)
             except ValueError:
                 continue
             try:
@@ -2162,8 +2162,8 @@ class DB:
     def rename_extra_file(self, relpath, newrelpath, book_path, replace=True):
         bookdir = os.path.join(self.library_path, book_path)
         try:
-            src = path_from_root(bookdir, relpath)
-            dest = path_from_root(bookdir, newrelpath)
+            src = path_from_root(bookdir, relpath, case_sensitive=self.is_case_sensitive)
+            dest = path_from_root(bookdir, newrelpath, case_sensitive=self.is_case_sensitive)
         except ValueError:
             return False
         src, dest = make_long_path_useable(src), make_long_path_useable(dest)
@@ -2181,7 +2181,7 @@ class DB:
     def add_extra_file(self, relpath, stream, book_path, replace=True, auto_rename=False):
         bookdir = os.path.join(self.library_path, book_path)
         try:
-            dest = path_from_root(bookdir, relpath)
+            dest = path_from_root(bookdir, relpath, case_sensitive=self.is_case_sensitive)
         except ValueError:
             return None
         if not replace and os.path.exists(make_long_path_useable(dest)):

--- a/src/calibre/db/tests/filesystem.py
+++ b/src/calibre/db/tests/filesystem.py
@@ -160,6 +160,34 @@ class FilesystemTest(BaseTest):
         self.assertEqual(cache.rename_extra_files(1, {'B': 'data/c'}), set())
         self.assertEqual(cache.rename_extra_files(1, {'B': 'data/c'}, replace=True), {'B'})
 
+    def test_extra_file_paths_are_confined_to_book_dir(self):
+        cl = self.cloned_library
+        cache = self.init_cache(cl)
+        bookdir = os.path.dirname(cache.format_abspath(1, 'FMT1'))
+        sibling = bookdir + ' sibling'
+        os.makedirs(sibling)
+        bad_relpath = '../' + os.path.basename(sibling) + '/victim'
+        victim = os.path.join(sibling, 'victim')
+        with open(victim, 'wb') as f:
+            f.write(b'outside')
+
+        self.assertEqual(cache.add_extra_files(1, {bad_relpath: BytesIO(b'bad')}), {bad_relpath: False})
+        self.assertEqual(read(victim, 'rb'), b'outside')
+
+        buf = BytesIO()
+        with self.assertRaises(FileNotFoundError):
+            cache.copy_extra_file_to(1, bad_relpath, buf)
+        self.assertEqual(buf.getvalue(), b'')
+
+        cache.add_extra_files(1, {'safe': BytesIO(b'safe')})
+        self.assertEqual(cache.rename_extra_files(1, {bad_relpath: 'moved'}), set())
+        self.assertEqual(cache.rename_extra_files(1, {'safe': bad_relpath}), set())
+        self.assertEqual(read(victim, 'rb'), b'outside')
+        self.assertEqual({e.relpath for e in cache.list_extra_files(1)}, {'safe'})
+
+        self.assertEqual(cache.remove_extra_files(1, [bad_relpath], permanent=True), {})
+        self.assertEqual(read(victim, 'rb'), b'outside')
+
     @unittest.skipUnless(iswindows, 'Windows only')
     def test_windows_atomic_move(self):
         'Test book file open in another process when changing metadata'

--- a/src/calibre/gui2/viewer/web_view.py
+++ b/src/calibre/gui2/viewer/web_view.py
@@ -44,7 +44,7 @@ from calibre.gui2.viewer import link_prefix_for_location_links, performance_moni
 from calibre.gui2.viewer.config import get_session_pref, load_viewer_profiles, save_viewer_profile, viewer_config_dir, vprefs
 from calibre.gui2.viewer.tts import TTS
 from calibre.srv.code import get_translations_data
-from calibre.utils.filenames import make_long_path_useable
+from calibre.utils.filenames import make_long_path_useable, path_from_root
 from calibre.utils.localization import _, localize_user_manual_link
 from calibre.utils.resources import get_path as P
 from calibre.utils.serialize import json_loads
@@ -74,9 +74,10 @@ def get_path_for_name(name):
     bdir = getattr(set_book_path, 'path', None)
     if bdir is None:
         return
-    path = os.path.abspath(os.path.join(bdir, name))
-    if path.startswith(bdir):
-        return path
+    try:
+        return path_from_root(bdir, name)
+    except ValueError:
+        pass
 
 
 def get_data(name):
@@ -103,12 +104,12 @@ def background_image(encoded_fname=''):
             return mt, data
         except FileNotFoundError:
             return 'image/jpeg', b''
-    fname = bytes.fromhex(encoded_fname).decode()
-    base = os.path.abspath(os.path.join(viewer_config_dir, 'background-images')) + os.sep
-    img_path = os.path.abspath(os.path.join(base, fname))
+    try:
+        fname = bytes.fromhex(encoded_fname).decode('utf-8')
+        img_path = path_from_root(os.path.abspath(os.path.join(viewer_config_dir, 'background-images')), fname, reject_colon=True)
+    except (ValueError, UnicodeDecodeError):
+        return 'image/jpeg', b''
     mt = guess_type(fname)[0] or 'image/jpeg'
-    if not img_path.startswith(base):
-        return mt, b''
     try:
         with open(make_long_path_useable(img_path), 'rb') as f:
             return mt, f.read()
@@ -123,8 +124,12 @@ def get_mathjax_dir():
 
 def handle_mathjax_request(rq, name):
     mathjax_dir = get_mathjax_dir()
-    path = os.path.abspath(os.path.join(mathjax_dir, '..', name))
-    if path.startswith(mathjax_dir):
+    mathjax_name = name.partition('/')[2]
+    try:
+        path = path_from_root(mathjax_dir, mathjax_name)
+    except ValueError:
+        pass
+    else:
         mt = guess_type(name)
         try:
             with open(path, 'rb') as f:
@@ -136,9 +141,9 @@ def handle_mathjax_request(rq, name):
         if name.endswith('/startup.js'):
             raw = P('pdf-mathjax-loader.js', data=True, allow_user_override=False) + raw
         send_reply(rq, mt, raw)
-    else:
-        prints(f'Failed to get mathjax file: {name} outside mathjax directory', file=sys.stderr)
-        rq.fail(QWebEngineUrlRequestJob.Error.RequestFailed)
+        return
+    prints(f'Failed to get mathjax file: {name} outside mathjax directory', file=sys.stderr)
+    rq.fail(QWebEngineUrlRequestJob.Error.RequestFailed)
 
 
 class UrlSchemeHandler(QWebEngineUrlSchemeHandler):

--- a/src/calibre/gui2/viewer/web_view.py
+++ b/src/calibre/gui2/viewer/web_view.py
@@ -106,7 +106,7 @@ def background_image(encoded_fname=''):
             return 'image/jpeg', b''
     try:
         fname = bytes.fromhex(encoded_fname).decode('utf-8')
-        img_path = path_from_root(os.path.abspath(os.path.join(viewer_config_dir, 'background-images')), fname, reject_colon=True)
+        img_path = path_from_root(os.path.abspath(os.path.join(viewer_config_dir, 'background-images')), fname, reject_colon=iswindows)
     except (ValueError, UnicodeDecodeError):
         return 'image/jpeg', b''
     mt = guess_type(fname)[0] or 'image/jpeg'

--- a/src/calibre/srv/books.py
+++ b/src/calibre/srv/books.py
@@ -20,7 +20,7 @@ from calibre.srv.metadata import book_as_json
 from calibre.srv.render_book import RENDER_VERSION
 from calibre.srv.routes import endpoint, json
 from calibre.srv.utils import get_db, get_library_data
-from calibre.utils.filenames import rmtree
+from calibre.utils.filenames import path_from_root, rmtree
 from calibre.utils.localization import _
 from calibre.utils.resources import get_path as P
 from calibre.utils.serialize import json_dumps
@@ -187,9 +187,10 @@ def book_file(ctx, rd, book_id, fmt, size, mtime, name):
     if not ctx.has_id(rd, db, book_id):
         raise BookNotFound(book_id, db)
     bhash = book_hash(db.library_id, book_id, fmt, size, mtime)
-    base = abspath(os.path.join(books_cache_dir(), 'f'))
-    mpath = abspath(os.path.join(base, bhash, name))
-    if not mpath.startswith(base):
+    base = abspath(os.path.join(books_cache_dir(), 'f', bhash))
+    try:
+        mpath = path_from_root(base, name)
+    except ValueError:
         raise HTTPNotFound(f'No book file with hash: {bhash} and name: {name}')
     try:
         return rd.filesystem_file_with_custom_etag(open(mpath, 'rb'), bhash, name)

--- a/src/calibre/srv/content.py
+++ b/src/calibre/srv/content.py
@@ -31,7 +31,7 @@ from calibre.srv.routes import endpoint, json
 from calibre.srv.utils import get_db, get_use_roman, http_date
 from calibre.utils.config_base import tweaks
 from calibre.utils.date import timestampfromdt
-from calibre.utils.filenames import ascii_filename, atomic_rename, make_long_path_useable
+from calibre.utils.filenames import ascii_filename, atomic_rename, make_long_path_useable, path_from_root
 from calibre.utils.img import image_from_data, scale_image
 from calibre.utils.localization import _
 from calibre.utils.resources import get_image_path as I
@@ -236,11 +236,10 @@ def static(ctx, rd, what):
     if not what:
         raise HTTPNotFound()
     base = P('content-server', allow_user_override=False)
-    path = os.path.abspath(os.path.join(base, *what.split('/')))
-    if not path.startswith(base) or ':' in what:
+    try:
+        path = path_from_root(base, what, reject_colon=True)
+    except ValueError:
         raise HTTPNotFound('Naughty, naughty!')
-    path = os.path.relpath(path, base).replace(os.sep, '/')
-    path = P('content-server/' + path)
     try:
         return share_open(path, 'rb')
     except OSError:
@@ -269,16 +268,16 @@ def icon(ctx, rd, which):
         raise HTTPNotFound()
     if which.startswith('_'):
         base = os.path.join(config_dir, 'tb_icons')
-        path = os.path.abspath(os.path.join(base, *which[1:].split('/')))
-        if not path.startswith(base) or ':' in which:
+        try:
+            path = path_from_root(base, which[1:], reject_colon=True)
+        except ValueError:
             raise HTTPNotFound('Naughty, naughty!')
     else:
         base = P('images', allow_user_override=False)
-        path = os.path.abspath(os.path.join(base, *which.split('/')))
-        if not path.startswith(base) or ':' in which:
+        try:
+            path = path_from_root(base, which, reject_colon=True)
+        except ValueError:
             raise HTTPNotFound('Naughty, naughty!')
-        path = os.path.relpath(path, base).replace(os.sep, '/')
-        path = P('images/' + path)
     if sz == 'full':
         try:
             return share_open(path, 'rb')
@@ -309,9 +308,9 @@ def icon(ctx, rd, which):
 @endpoint('/reader-background/{encoded_fname}', android_workaround=True)
 def reader_background(ctx, rd, encoded_fname):
     base = os.path.abspath(os.path.normpath(os.path.join(config_dir, 'viewer', 'background-images')))
-    fname = bytes.fromhex(encoded_fname)
-    q = os.path.abspath(os.path.normpath(os.path.join(base, fname)))
-    if not q.startswith(base):
+    try:
+        q = path_from_root(base, bytes.fromhex(encoded_fname).decode('utf-8'), reject_colon=True)
+    except (ValueError, UnicodeDecodeError):
         raise HTTPNotFound(f'Reader background {encoded_fname} not found')
     try:
         return share_open(make_long_path_useable(q), 'rb')

--- a/src/calibre/srv/content.py
+++ b/src/calibre/srv/content.py
@@ -309,7 +309,7 @@ def icon(ctx, rd, which):
 def reader_background(ctx, rd, encoded_fname):
     base = os.path.abspath(os.path.normpath(os.path.join(config_dir, 'viewer', 'background-images')))
     try:
-        q = path_from_root(base, bytes.fromhex(encoded_fname).decode('utf-8'), reject_colon=True)
+        q = path_from_root(base, bytes.fromhex(encoded_fname).decode('utf-8'), reject_colon=iswindows)
     except (ValueError, UnicodeDecodeError):
         raise HTTPNotFound(f'Reader background {encoded_fname} not found')
     try:

--- a/src/calibre/srv/tests/ajax.py
+++ b/src/calibre/srv/tests/ajax.py
@@ -6,6 +6,7 @@ __copyright__ = '2015, Kovid Goyal <kovid at kovidgoyal.net>'
 
 import json
 import os
+from base64 import standard_b64encode
 from compression import zlib
 from functools import partial
 from http.client import FORBIDDEN, NOT_FOUND, OK
@@ -83,6 +84,42 @@ class ContentTest(LibraryBaseTest):
             self.assertIsNone(data['1']['payload']['new_book_id'])
             self.assertTrue(source_db.has_id(1))
             self.ae(target_db.all_book_ids(), target_book_ids)
+
+    # }}}
+
+    def test_data_file_paths_are_confined_to_book_dir(self):  # {{{
+        with self.create_server(auth=True, auth_mode='basic') as server:
+            server.handler.ctx.user_manager.add_user('12', 'test')
+            db = server.handler.router.ctx.library_broker.get(None)
+            bookdir = os.path.dirname(db.format_abspath(1, 'FMT1'))
+            sibling = bookdir + ' sibling'
+            os.makedirs(sibling)
+            victim = os.path.join(sibling, 'victim')
+            with open(victim, 'wb') as f:
+                f.write(b'outside')
+
+            conn = server.connect()
+            url_for = server.handler.router.url_for
+            bad_name = '../../' + os.path.basename(sibling) + '/victim'
+            r, data = make_request(
+                conn, url_for('/data-files/upload', book_id=1), prefix='', method='POST',
+                username='12', password='test',
+                headers={'Content-Type': 'application/json'}, data=json.dumps([{
+                    'name': bad_name,
+                    'data_url': 'data:application/octet-stream;base64,' + standard_b64encode(b'bad').decode('ascii'),
+                }]).encode('utf-8'))
+            self.ae(r.status, OK)
+            with open(victim, 'rb') as f:
+                self.ae(f.read(), b'outside')
+            self.assertNotIn('data/' + bad_name, data['data_files'])
+
+            r, data = make_request(
+                conn, url_for('/data-files/remove', book_id=1), prefix='', method='POST',
+                username='12', password='test',
+                headers={'Content-Type': 'application/json'}, data=json.dumps(['data/' + bad_name]).encode('utf-8'))
+            self.ae(r.status, OK)
+            with open(victim, 'rb') as f:
+                self.ae(f.read(), b'outside')
 
     # }}}
 

--- a/src/calibre/utils/copy_files_test.py
+++ b/src/calibre/utils/copy_files_test.py
@@ -12,7 +12,7 @@ from calibre import walk
 from calibre.constants import iswindows
 
 from .copy_files import copy_tree, rename_files
-from .filenames import nlinks_file
+from .filenames import is_path_inside, nlinks_file, path_from_root
 
 if iswindows:
     from calibre_extensions import winutil
@@ -64,6 +64,21 @@ class TestCopyFiles(unittest.TestCase):
         rename_files(renames)
         contents = set(os.listdir(self.tdir)) - {'base', 'src'}
         self.ae(contents, {'One', 'three'})
+
+    def test_rooted_path_containment(self):
+        root = os.path.join(self.tdir, 'Root')
+        sibling = os.path.join(self.tdir, 'Root sibling')
+        os.makedirs(root), os.makedirs(sibling)
+        good = path_from_root(root, 'data/file.txt')
+        self.ae(good, os.path.join(root, 'data', 'file.txt'))
+        self.assertTrue(is_path_inside(root, good))
+        self.assertTrue(is_path_inside(os.path.join(self.tdir, 'ROOT'), good, case_sensitive=False))
+        for bad in '../Root sibling/file.txt', 'data/../../Root sibling/file.txt', '/tmp/x', 'C:/x', 'C:x', 'data//x', 'data/./x':
+            with self.assertRaises(ValueError):
+                path_from_root(root, bad)
+        self.assertTrue(path_from_root(root, 'name:with-colon.txt').endswith('name:with-colon.txt'))
+        with self.assertRaises(ValueError):
+            path_from_root(root, 'name:with-colon.txt', reject_colon=True)
 
     def test_pread_all(self):
         from calibre_extensions.speedup import pread_all

--- a/src/calibre/utils/filenames.py
+++ b/src/calibre/utils/filenames.py
@@ -4,6 +4,7 @@ meaning as possible.
 '''
 
 import errno
+import ntpath
 import os
 import shutil
 import time
@@ -631,6 +632,47 @@ def copytree_using_links(path, dest, dest_is_parent=True, filecopyfunc=copyfile)
                 filecopyfunc(src, df)
 
 
+def _normalize_path_for_containment(path, case_sensitive=True):
+    ans = os.path.abspath(path)
+    return ans if case_sensitive else os.path.normcase(ans).lower()
+
+
+def is_path_inside(parent: str, child: str, allow_parent: bool = False, case_sensitive: bool = True) -> bool:
+    ' Check if child is under parent, using lexical path component boundaries. '
+    parent = _normalize_path_for_containment(parent, case_sensitive=case_sensitive)
+    child = _normalize_path_for_containment(child, case_sensitive=case_sensitive)
+    try:
+        if os.path.commonpath((parent, child)) != parent:
+            return False
+    except ValueError:
+        return False
+    return allow_parent or child != parent
+
+
+def path_from_root(root: str, path: str, allow_root: bool = False, reject_colon: bool = False) -> str:
+    '''
+    Resolve a relative path under root. Raises ValueError for absolute paths,
+    drive-qualified paths, traversal components, or paths outside root.
+    '''
+    if not isinstance(path, str):
+        raise ValueError('path must be text')
+    if reject_colon and ':' in path:
+        raise ValueError('colon not allowed in path')
+    if not path:
+        if allow_root:
+            return os.path.abspath(root)
+        raise ValueError('empty path not allowed')
+    if os.path.isabs(path) or ntpath.isabs(path) or os.path.splitdrive(path)[0] or ntpath.splitdrive(path)[0]:
+        raise ValueError('absolute paths are not allowed')
+    parts = path.replace('\\', '/').split('/')
+    if any(x in ('', '.', '..') for x in parts):
+        raise ValueError('invalid path component')
+    ans = os.path.abspath(os.path.join(root, *parts))
+    if not is_path_inside(root, ans, allow_parent=allow_root):
+        raise ValueError('path is outside root')
+    return ans
+
+
 def is_existing_subpath(child: str, parent: str) -> bool:
     ' Check if child is under parent. If either child or parent dont exist, returns False. '
     try:
@@ -638,11 +680,7 @@ def is_existing_subpath(child: str, parent: str) -> bool:
         child = os.path.realpath(child, strict=True)
     except OSError:
         return False
-    parent = os.path.abspath(parent)
-    child = os.path.abspath(child)
-    if not parent.endswith(os.sep):
-        parent += os.sep
-    return child.startswith(parent)
+    return is_path_inside(parent, child)
 
 
 rmtree = shutil.rmtree

--- a/src/calibre/utils/filenames.py
+++ b/src/calibre/utils/filenames.py
@@ -649,7 +649,9 @@ def is_path_inside(parent: str, child: str, allow_parent: bool = False, case_sen
     return allow_parent or child != parent
 
 
-def path_from_root(root: str, path: str, allow_root: bool = False, reject_colon: bool = False) -> str:
+def path_from_root(
+    root: str, path: str, allow_root: bool = False, reject_colon: bool = False, case_sensitive: bool = True
+) -> str:
     '''
     Resolve a relative path under root. Raises ValueError for absolute paths,
     drive-qualified paths, traversal components, or paths outside root.
@@ -668,7 +670,7 @@ def path_from_root(root: str, path: str, allow_root: bool = False, reject_colon:
     if any(x in ('', '.', '..') for x in parts):
         raise ValueError('invalid path component')
     ans = os.path.abspath(os.path.join(root, *parts))
-    if not is_path_inside(root, ans, allow_parent=allow_root):
+    if not is_path_inside(root, ans, allow_parent=allow_root, case_sensitive=case_sensitive):
         raise ValueError('path is outside root')
     return ans
 


### PR DESCRIPTION
This adds a small shared helper for keeping user-provided paths inside an expected root, then uses it for served local files and extra-file operations.

It rejects absolute paths, parent-directory traversal, drive/UNC paths, and sibling-directory escapes without adding compatibility shims.

Tests cover the shared helper, DB extra-file paths, and an authenticated content-server data-file escape case.