### PR TITLE
Confine extra file globs

### DIFF
--- a/src/calibre/db/backend.py
+++ b/src/calibre/db/backend.py
@@ -2098,10 +2098,16 @@ class DB:
         full_book_path = os.path.abspath(os.path.join(self.library_path, book_path))
         if pattern:
             from pathlib import Path
+            try:
+                path_from_root(full_book_path, pattern, case_sensitive=self.is_case_sensitive)
+            except ValueError:
+                return
             def iterator():
                 p = Path(full_book_path)
                 for x in p.glob(pattern):
-                    yield str(x)
+                    path = str(x)
+                    if is_path_inside(full_book_path, path, case_sensitive=self.is_case_sensitive):
+                        yield path
         else:
             def iterator():
                 for dirpath, dirnames, filenames in os.walk(full_book_path):

--- a/src/calibre/db/tests/filesystem.py
+++ b/src/calibre/db/tests/filesystem.py
@@ -179,11 +179,20 @@ class FilesystemTest(BaseTest):
             cache.copy_extra_file_to(1, bad_relpath, buf)
         self.assertEqual(buf.getvalue(), b'')
 
-        cache.add_extra_files(1, {'safe': BytesIO(b'safe')})
+        cache.add_extra_files(1, {'safe': BytesIO(b'safe'), 'data/inside': BytesIO(b'inside')})
         self.assertEqual(cache.rename_extra_files(1, {bad_relpath: 'moved'}), set())
         self.assertEqual(cache.rename_extra_files(1, {'safe': bad_relpath}), set())
         self.assertEqual(read(victim, 'rb'), b'outside')
-        self.assertEqual({e.relpath for e in cache.list_extra_files(1)}, {'safe'})
+
+        def listed(pattern):
+            return {e.relpath for e in cache.list_extra_files(1, use_cache=False, pattern=pattern)}
+
+        self.assertEqual(listed('data/**/*'), {'data/inside'})
+        sibling_pattern = '../' + os.path.basename(sibling) + '/*'
+        for pattern in (sibling_pattern, 'data/../../' + os.path.basename(sibling) + '/*',
+                        sibling_pattern.replace('/', '\\'), os.path.join(sibling, '*')):
+            self.assertEqual(listed(pattern), set())
+        self.assertEqual({e.relpath for e in cache.list_extra_files(1)}, {'safe', 'data/inside'})
 
         self.assertEqual(cache.remove_extra_files(1, [bad_relpath], permanent=True), {})
         self.assertEqual(read(victim, 'rb'), b'outside')


### PR DESCRIPTION
Fixes extra file listing with glob patterns so patterns cannot escape the book dir.

Adds a regression test for valid data file globs and traversal or absolute patterns.