### PR TITLE
Search all downloaded books offline

### DIFF
--- a/src/pyj/book_list/local_books.pyj
+++ b/src/pyj/book_list/local_books.pyj
@@ -22,9 +22,65 @@ BOOK_LIST_CONTAINER_CLASS = 'book-list-container'
 CLASS_NAME = 'local-books-list'
 
 book_list_data = {}
+SEARCH_IGNORED_METADATA_FIELDS = {
+    'comments': True,
+    'comments#markdown#': True,
+    'data_files': True,
+    'format_sizes': True,
+    'items_with_notes': True,
+    'link_maps': True,
+    'urls_from_identifiers': True,
+}
 
 def component(name):
     return document.getElementById(book_list_data.container_id).querySelector(f'[data-component="{name}"]')
+
+
+def add_search_text(parts, value):
+    if value is None or value is undefined:
+        return
+    if Array.isArray(value):
+        for x in value:
+            add_search_text(parts, x)
+    elif jstype(value) is 'object':
+        for key in Object.keys(value):
+            parts.push(key)
+            add_search_text(parts, value[key])
+    else:
+        parts.push(str(value))
+
+
+def metadata_search_text(metadata):
+    parts = v'[]'
+    if metadata:
+        for key in Object.keys(metadata):
+            if not SEARCH_IGNORED_METADATA_FIELDS[key]:
+                add_search_text(parts, metadata[key])
+    return parts.join('\n').toLowerCase()
+
+
+def normalize_local_search_query(query):
+    return (query or '').toLowerCase().replace(/\s+/g, ' ').trim()
+
+
+def matching_book_indices_for_query(book_data, book_indices, query):
+    tokens = [x for x in normalize_local_search_query(query).split(' ') if x]
+    if not tokens.length:
+        return list(book_indices)
+    ans = []
+    for book_idx in book_indices:
+        book = book_data[book_idx]
+        text = book._local_books_search_text
+        if text is undefined:
+            text = book._local_books_search_text = metadata_search_text(book.metadata)
+        matched = True
+        for token in tokens:
+            if text.indexOf(token) < 0:
+                matched = False
+                break
+        if matched:
+            ans.append(book_idx)
+    return ans
 
 
 def clear_grid():
@@ -50,13 +106,13 @@ def delete_book(book, book_idx):
         if err_string:
             error_dialog(_('Failed to delete book'), err_string)
             return
-        books = [book_list_data.book_data[i] for i in book_list_data.books if i is not book_idx]
-        show_recent_stage2.call(book_list_data.container_id, books)
+        books = [book_list_data.book_data[i] for i in book_list_data.all_books if i is not book_idx]
+        show_recent_stage2.call(book_list_data.container_id, books, book_list_data.search_query)
     )
 
 
 def confirm_delete_all():
-    num_of_books = book_list_data.books?.length
+    num_of_books = book_list_data.all_books?.length
     if not num_of_books:
         return
     create_custom_dialog(_('Are you sure?'), def(parent, close_modal):
@@ -87,10 +143,10 @@ def confirm_delete_all():
 
 def delete_all(msg_parent, close_modal):
     db = get_db()
-    books = list(book_list_data.books)
+    books = list(book_list_data.all_books)
 
     def refresh():
-        show_recent_stage2.call(book_list_data.container_id, [book_list_data.book_data[i] for i in books])
+        show_recent_stage2.call(book_list_data.container_id, [book_list_data.book_data[i] for i in books], book_list_data.search_query)
 
     def delete_one():
         if not books.length:
@@ -170,11 +226,34 @@ def render_book(book_idx):
 
 def render_books(books):
     div = component('book_list')
-    books = books or book_list_data.books
+    if books is None:
+        books = book_list_data.books
     for book_idx in books:
         child = render_book(book_idx)
         if child is not None:
             book_list_data.append_item(div, child)
+
+
+def update_empty_message():
+    msg = component('empty_message')
+    if not msg:
+        return
+    if book_list_data.books.length:
+        msg.style.display = 'none'
+        return
+    msg.style.display = 'block'
+    msg.textContent = (
+        _('No downloaded books match your search') if normalize_local_search_query(book_list_data.search_query) else
+        _('No downloaded books present')
+    )
+
+
+def apply_search(query):
+    book_list_data.search_query = query or ''
+    book_list_data.books = matching_book_indices_for_query(book_list_data.book_data, book_list_data.all_books, query)
+    clear_grid()
+    render_books()
+    update_empty_message()
 
 
 def apply_view_mode(mode):
@@ -190,38 +269,55 @@ def apply_view_mode(mode):
     clear_grid()
     render_books()
     sync_cover_grid_size_dock(mode)
+    update_empty_message()
 
 
-def create_books_list(container, books):
+def create_search_box():
+    box = E.div(data_component='search_box', style='padding: 1rem 1rem 0')
+    search = E.input(
+        type='search', name='search-downloaded-books', value=book_list_data.search_query,
+        placeholder=_('Search downloaded books'), title=_('Search downloaded books'), autocomplete='off',
+        style='box-sizing: border-box; width: 100%; font-size: 1rem; padding: 0.5rem')
+    search.addEventListener('input', def(event): apply_search(this.value);)
+    box.appendChild(search)
+    return box
+
+
+def create_books_list(container, books, search_query=None):
     clear(container)
     book_list_data.container_id = ensure_id(container)
     book_list_data.book_data = {i:book for i, book in enumerate(books)}
-    book_list_data.books = list(range(books.length))
+    book_list_data.all_books = list(range(books.length))
+    book_list_data.search_query = search_query or ''
+    book_list_data.books = matching_book_indices_for_query(book_list_data.book_data, book_list_data.all_books, search_query)
     book_list_data.mode = None
     book_list_data.thumbnail_cache = {}
     container.classList.add(BOOK_LIST_CONTAINER_CLASS)
     if not books.length:
         container.appendChild(E.div(
+            data_component='empty_message',
             style='margin: 1rem 0',
             _('No downloaded books present')
         ))
         return
 
+    container.appendChild(create_search_box())
     pager = E.div(data_component='pager')
     toolbar_el = E.div()
     pager.appendChild(toolbar_el)
     populate_book_list_toolbar(toolbar_el, False, apply_view_mode)
 
     container.appendChild(pager)
+    container.appendChild(E.div(data_component='empty_message', style='display: none; margin: 1rem 0'))
     container.appendChild(E.div(data_component='book_list'))
     apply_view_mode(get_view_mode())
 
 
-def show_recent_stage2(books):
+def show_recent_stage2(books, search_query=None):
     container = document.getElementById(this)
     if not container:
         return
-    create_books_list(container, books)
+    create_books_list(container, books, search_query)
 
 
 def show_recent():
@@ -234,7 +330,7 @@ def show_recent():
         conditional_timeout(container.id, 5, show_recent)
         return
     if db.is_ok:
-        db.get_recently_read_books(show_recent_stage2.bind(container.id), 200)
+        db.get_downloaded_books(show_recent_stage2.bind(container.id))
     else:
         error_dialog(_('Database not initialized'),
             db.initialize_error_msg)

--- a/src/pyj/book_list/local_books.pyj
+++ b/src/pyj/book_list/local_books.pyj
@@ -36,7 +36,7 @@ def component(name):
     return document.getElementById(book_list_data.container_id).querySelector(f'[data-component="{name}"]')
 
 
-def add_search_text(parts, value):
+def add_search_text(parts, value, include_object_keys=False):
     if value is None or value is undefined:
         return
     if Array.isArray(value):
@@ -44,7 +44,8 @@ def add_search_text(parts, value):
             add_search_text(parts, x)
     elif jstype(value) is 'object':
         for key in Object.keys(value):
-            parts.push(key)
+            if include_object_keys:
+                parts.push(key)
             add_search_text(parts, value[key])
     else:
         parts.push(str(value))
@@ -55,7 +56,7 @@ def metadata_search_text(metadata):
     if metadata:
         for key in Object.keys(metadata):
             if not SEARCH_IGNORED_METADATA_FIELDS[key]:
-                add_search_text(parts, metadata[key])
+                add_search_text(parts, metadata[key], key is 'identifiers')
     return parts.join('\n').toLowerCase()
 
 
@@ -226,7 +227,7 @@ def render_book(book_idx):
 
 def render_books(books):
     div = component('book_list')
-    if books is None:
+    if books is None or books is undefined:
         books = book_list_data.books
     for book_idx in books:
         child = render_book(book_idx)

--- a/src/pyj/book_list/local_books.pyj
+++ b/src/pyj/book_list/local_books.pyj
@@ -22,21 +22,16 @@ BOOK_LIST_CONTAINER_CLASS = 'book-list-container'
 CLASS_NAME = 'local-books-list'
 
 book_list_data = {}
-SEARCH_IGNORED_METADATA_FIELDS = {
-    'comments': True,
-    'comments#markdown#': True,
-    'data_files': True,
-    'format_sizes': True,
-    'items_with_notes': True,
-    'link_maps': True,
-    'urls_from_identifiers': True,
-}
+LOCAL_SEARCH_METADATA_FIELDS = [
+    'title', 'authors', 'author_sort', 'publisher', 'series', 'tags',
+    'formats', 'identifiers', 'languages', 'lang_names'
+]
 
 def component(name):
     return document.getElementById(book_list_data.container_id).querySelector(f'[data-component="{name}"]')
 
 
-def add_search_text(parts, value, include_object_keys=False):
+def add_search_text(parts, value):
     if value is None or value is undefined:
         return
     if Array.isArray(value):
@@ -44,19 +39,33 @@ def add_search_text(parts, value, include_object_keys=False):
             add_search_text(parts, x)
     elif jstype(value) is 'object':
         for key in Object.keys(value):
-            if include_object_keys:
-                parts.push(key)
             add_search_text(parts, value[key])
     else:
         parts.push(str(value))
 
 
+def add_search_mapping_text(parts, value, include_keys=False):
+    if value is None or value is undefined:
+        return
+    if jstype(value) is 'object' and not Array.isArray(value):
+        for key in Object.keys(value):
+            if include_keys:
+                parts.push(key)
+            add_search_text(parts, value[key])
+    else:
+        add_search_text(parts, value)
+
+
 def metadata_search_text(metadata):
     parts = v'[]'
     if metadata:
-        for key in Object.keys(metadata):
-            if not SEARCH_IGNORED_METADATA_FIELDS[key]:
-                add_search_text(parts, metadata[key], key is 'identifiers')
+        for key in LOCAL_SEARCH_METADATA_FIELDS:
+            if key is 'identifiers':
+                add_search_mapping_text(parts, metadata[key], include_keys=True)
+            elif key is 'lang_names':
+                add_search_mapping_text(parts, metadata[key])
+            else:
+                add_search_text(parts, metadata[key])
     return parts.join('\n').toLowerCase()
 
 

--- a/src/pyj/read_book/db.pyj
+++ b/src/pyj/read_book/db.pyj
@@ -439,8 +439,7 @@ class DB:
             else:
                 proceed(data)
 
-    def get_recently_read_books(self, proceed, limit):
-        limit = limit or 3
+    def get_books_by_recent_date(self, proceed, limit=None):
         c = self.idb.transaction(['books'], 'readonly').objectStore('books').index('recent_index').openCursor(None, 'prev')
         books = v'[]'
         c.onerror = def(event):
@@ -450,11 +449,17 @@ class DB:
             cursor = ev.target.result
             if cursor:
                 books.push(cursor.value)
-            if books.length >= limit or not cursor:
+            if (limit is not None and books.length >= limit) or not cursor:
                 proceed(books)
                 return
             if cursor:
                 cursor.continue()
+
+    def get_recently_read_books(self, proceed, limit):
+        self.get_books_by_recent_date(proceed, limit or 3)
+
+    def get_downloaded_books(self, proceed):
+        self.get_books_by_recent_date(proceed)
 
     def has_book_matching(self, library_id, book_id, proceed):
         # Should really be using a multiEntry index to avoid iterating over all

--- a/src/pyj/test.pyj
+++ b/src/pyj/test.pyj
@@ -7,6 +7,7 @@ import traceback
 import initialize  # noqa: unused-import
 import test_date  # noqa: unused-import
 import test_utils  # noqa: unused-import
+import test_local_books  # noqa: unused-import
 import read_book.test_cfi  # noqa: unused-import
 import test_annotations  # noqa: unused-import
 

--- a/src/pyj/test_local_books.pyj
+++ b/src/pyj/test_local_books.pyj
@@ -45,6 +45,7 @@ def local_book_search_metadata_text():
     assert_equal(text.indexOf('title') >= 0, True)
     assert_equal(text.indexOf('author') >= 0, True)
     assert_equal(text.indexOf('isbn') >= 0, True)
+    assert_equal(text.indexOf('authors'), -1)
     assert_equal(text.indexOf('not searchable'), -1)
 
 

--- a/src/pyj/test_local_books.pyj
+++ b/src/pyj/test_local_books.pyj
@@ -1,0 +1,59 @@
+# vim:fileencoding=utf-8
+# License: GPL v3 Copyright: 2026, Hassan Raza <raihassanraza10 at gmail.com>
+from __python__ import hash_literals
+
+from book_list.local_books import (
+    matching_book_indices_for_query, metadata_search_text,
+    normalize_local_search_query,
+)
+from testing import assert_equal, test
+
+
+def sample_books():
+    return {
+        0: {'metadata': {
+            'title': 'Dune Messiah',
+            'authors': ['Frank Herbert'],
+            'tags': ['Science Fiction', 'Arrakis'],
+            'formats': ['EPUB'],
+            'identifiers': {'isbn': '9780593098233'},
+        }},
+        1: {'metadata': {
+            'title': 'The Left Hand of Darkness',
+            'authors': ['Ursula K. Le Guin'],
+            'publisher': 'Ace Books',
+            'series': 'Hainish Cycle',
+            'formats': ['AZW3'],
+        }},
+    }
+
+
+@test
+def local_book_search_query_normalization():
+    assert_equal(normalize_local_search_query('  Dune   Messiah  '), 'dune messiah')
+    assert_equal(normalize_local_search_query(None), '')
+
+
+@test
+def local_book_search_metadata_text():
+    text = metadata_search_text({
+        'title': 'Title',
+        'authors': ['Author'],
+        'identifiers': {'isbn': '123'},
+        'comments': 'not searchable',
+    })
+    assert_equal(text.indexOf('title') >= 0, True)
+    assert_equal(text.indexOf('author') >= 0, True)
+    assert_equal(text.indexOf('isbn') >= 0, True)
+    assert_equal(text.indexOf('not searchable'), -1)
+
+
+@test
+def local_book_search_matches_all_terms():
+    books = sample_books()
+    indices = [0, 1]
+    assert_equal(matching_book_indices_for_query(books, indices, ''), indices)
+    assert_equal(matching_book_indices_for_query(books, indices, 'dune frank'), [0])
+    assert_equal(matching_book_indices_for_query(books, indices, 'science epub'), [0])
+    assert_equal(matching_book_indices_for_query(books, indices, 'ursula hainish'), [1])
+    assert_equal(matching_book_indices_for_query(books, indices, 'missing'), [])

--- a/src/pyj/test_local_books.pyj
+++ b/src/pyj/test_local_books.pyj
@@ -40,13 +40,18 @@ def local_book_search_metadata_text():
         'title': 'Title',
         'authors': ['Author'],
         'identifiers': {'isbn': '123'},
+        'lang_names': {'eng': 'English'},
         'comments': 'not searchable',
+        'unknown_field': 'hidden value',
     })
     assert_equal(text.indexOf('title') >= 0, True)
     assert_equal(text.indexOf('author') >= 0, True)
     assert_equal(text.indexOf('isbn') >= 0, True)
+    assert_equal(text.indexOf('123') >= 0, True)
+    assert_equal(text.indexOf('english') >= 0, True)
     assert_equal(text.indexOf('authors'), -1)
     assert_equal(text.indexOf('not searchable'), -1)
+    assert_equal(text.indexOf('hidden value'), -1)
 
 
 @test

--- a/src/pyj/test_local_books.pyj
+++ b/src/pyj/test_local_books.pyj
@@ -4,7 +4,7 @@ from __python__ import hash_literals
 
 from book_list.local_books import (
     matching_book_indices_for_query, metadata_search_text,
-    normalize_local_search_query,
+    normalize_local_search_query
 )
 from testing import assert_equal, test
 


### PR DESCRIPTION
Adds a search box to the Downloaded books view.

The view now lists all downloaded books instead of a capped recent subset, and filters them locally using cached metadata from IndexedDB. Search matches simple terms across explicit metadata fields like title, authors, series, tags, formats, identifiers, publisher, and language names.

Also adds RapydScript tests for the local matching behavior.