### PR TITLE
Move cover size control into list toolbar

### DIFF
--- a/resources/content-server/base.css
+++ b/resources/content-server/base.css
@@ -449,13 +449,6 @@ progress::-moz-progress-bar { background-color: var(--primary-color); }
     touch-action: pan-y pinch-zoom;
 }
 
-/* Reserve one row for cover-grid size dock (toolbar at bottom of book list / local books). */
-:root.cs-cover-grid-dock-visible #BOOK_LIST_CONTAINER_ID,
-:root.cs-cover-grid-dock-visible .local-books-list {
-    padding-bottom: calc(var(--cs-cover-grid-dock-height, 3.25rem) + 0.85rem + env(safe-area-inset-bottom, 0px));
-    box-sizing: border-box;
-}
-
 /* Custom category dialog */
 .cs-custom-category-dialog {
     width: 100%;

--- a/src/pyj/book_list/cover_grid.pyj
+++ b/src/pyj/book_list/cover_grid.pyj
@@ -145,6 +145,34 @@ def on_cover_grid_size_input(ev):
     apply_cover_grid_pct_css()
 
 
+def sync_cover_grid_size_control(control, mode):
+    if not control:
+        return
+    r = control.querySelector('.cs-cover-grid-size-range')
+    if r:
+        r.value = str(get_cover_grid_pct())
+    if mode is 'cover_grid':
+        ensure_cover_grid_resize_listener()
+        apply_cover_grid_pct_css()
+        set_css(control, display='inline-flex')
+    else:
+        set_css(control, display='none')
+
+
+def create_cover_grid_size_control(mode):
+    lab = E.span(class_='cs-cover-grid-size-label')
+    lab.textContent = _('Cover size')
+    r = E.input(type='range', class_='cs-cover-grid-size-range', min=str(COVER_GRID_PCT_MIN), max=str(COVER_GRID_PCT_MAX), step='0.025')
+    r.value = str(get_cover_grid_pct())
+    r.title = _('Adjust cover grid tile size')
+    r.addEventListener('input', on_cover_grid_size_input)
+    control = E.div(lab, r, class_='cs-cover-grid-size-control')
+    control.setAttribute('role', 'group')
+    control.setAttribute('aria-label', _('Cover grid size'))
+    sync_cover_grid_size_control(control, mode)
+    return control
+
+
 def build_cover_grid_size_dock():
     lab = E.span(class_='cs-cover-grid-size-label')
     lab.textContent = _('Cover size')
@@ -343,6 +371,27 @@ def cover_grid_css():
         min_width='3rem',
         width='auto',
         max_width='32rem',
+        margin='0',
+    )
+    ans += build_rule('.cs-cover-grid-size-control',
+        display='inline-flex',
+        align_items='center',
+        gap='0.65rem',
+        flex='1 1 15rem',
+        min_width='min(100%, 13rem)',
+        max_width='24rem',
+        box_sizing='border-box',
+    )
+    ans += build_rule('.cs-cover-grid-size-control .cs-cover-grid-size-label',
+        font_size='0.88rem',
+        font_weight='600',
+        opacity='0.88',
+        white_space='nowrap',
+        flex_shrink='0',
+    )
+    ans += build_rule('.cs-cover-grid-size-control .cs-cover-grid-size-range',
+        flex='1 1 auto',
+        min_width='3rem',
         margin='0',
     )
     return ans

--- a/src/pyj/book_list/cover_grid.pyj
+++ b/src/pyj/book_list/cover_grid.pyj
@@ -6,9 +6,7 @@ from dom import clear, set_css, build_rule
 from elementmaker import E
 from gettext import gettext as _
 
-from book_list.constants import book_list_container_id
 from book_list.globals import get_session_data
-from book_list.router import is_reading_book
 
 
 COVER_GRID_CLASS = 'book-list-cover-grid'
@@ -18,14 +16,6 @@ COVER_GRID_PCT_DEFAULT = Math.round(100 * COVER_GRID_VIEWPORT_FRAC)
 # Viewport percentage (slider): ~8% = many columns, ~45% = large tiles / few columns.
 COVER_GRID_PCT_MIN = 8
 COVER_GRID_PCT_MAX = 45
-GRID_SIZE_DOCK_ID = 'cs-cover-grid-size-dock'
-
-
-def current_book_list_panel_id():
-    c = document.getElementById(book_list_container_id)
-    if not c or not c.dataset:
-        return ''
-    return c.dataset.panel or ''
 
 
 THUMBNAIL_MAX_WIDTH = 3 * 85
@@ -120,21 +110,6 @@ def ensure_cover_grid_resize_listener():
     window.addEventListener('resize', on_resize, False)
 
 
-def sync_cover_grid_size_dock(mode):
-    if is_reading_book():
-        hide_cover_grid_size_dock()
-        return
-    panel = current_book_list_panel_id()
-    # Only the main book list / downloaded-books list show the grid; sub-panels replace content.
-    list_ok = panel is 'book_list' or panel is 'local_books'
-    bl = document.getElementById(book_list_container_id)
-    bl_visible = bl and bl.style.display is not 'none'
-    if mode is 'cover_grid' and list_ok and bl_visible:
-        ensure_cover_grid_size_dock()
-    else:
-        hide_cover_grid_size_dock()
-
-
 def on_cover_grid_size_input(ev):
     v = parseFloat(ev.target.value)
     if v != v:
@@ -173,41 +148,6 @@ def create_cover_grid_size_control(mode):
     return control
 
 
-def build_cover_grid_size_dock():
-    lab = E.span(class_='cs-cover-grid-size-label')
-    lab.textContent = _('Cover size')
-    r = E.input(type='range', class_='cs-cover-grid-size-range', min=str(COVER_GRID_PCT_MIN), max=str(COVER_GRID_PCT_MAX), step='0.025')
-    r.value = str(get_cover_grid_pct())
-    r.title = _('Adjust cover grid tile size')
-    r.addEventListener('input', on_cover_grid_size_input)
-    dock = E.div(lab, r, id=GRID_SIZE_DOCK_ID, class_='cs-cover-grid-size-dock')
-    dock.setAttribute('role', 'region')
-    dock.setAttribute('aria-label', _('Cover grid size'))
-    return dock
-
-
-def ensure_cover_grid_size_dock():
-    el = document.getElementById(GRID_SIZE_DOCK_ID)
-    if not el:
-        el = build_cover_grid_size_dock()
-        document.body.appendChild(el)
-    else:
-        r = el.querySelector('.cs-cover-grid-size-range')
-        if r:
-            r.value = str(get_cover_grid_pct())
-    ensure_cover_grid_resize_listener()
-    apply_cover_grid_pct_css()
-    set_css(el, display='flex')
-    document.documentElement.classList.add('cs-cover-grid-dock-visible')
-
-
-def hide_cover_grid_size_dock():
-    el = document.getElementById(GRID_SIZE_DOCK_ID)
-    if el:
-        set_css(el, display='none')
-    document.documentElement.classList.remove('cs-cover-grid-dock-visible')
-
-
 def cover_grid_thumb_size():
     # Match CSS: width is pct of .book-list-cover-grid container (not full viewport).
     frac = get_cover_grid_pct() / 100
@@ -233,7 +173,7 @@ def cover_grid_css():
     sel = grid_root
     item_sel = sel + ' > a'
     margin_unit = 'px'
-    ans = ':root { --cs-cover-grid-pct: %s; --cs-cover-grid-dock-height: 3.25rem; }\n' % COVER_GRID_PCT_DEFAULT
+    ans = ':root { --cs-cover-grid-pct: %s; }\n' % COVER_GRID_PCT_DEFAULT
     # NOTE: overflow must be visible so cover shadows are not clipped.
     # Tile px, column count, and column-gap are set from JS (sync_cover_grid_tile_px).
     ans += '.book-list-cover-grid { --cs-cover-tile-px: 120px; }\n'
@@ -339,39 +279,6 @@ def cover_grid_css():
         height='100%',
         display='block',
         object_fit='cover'
-    )
-    # Bottom dock: slider to resize grid (cover grid mode only; shown via JS).
-    ans += build_rule('.cs-cover-grid-size-dock',
-        display='none',
-        position='fixed',
-        bottom='0',
-        left='var(--cs-sidebar-width, 240px)',
-        right='0',
-        z_index='60',
-        box_sizing='border-box',
-        min_height='var(--cs-cover-grid-dock-height, 3.25rem)',
-        align_items='center',
-        gap='0.65rem',
-        flex_wrap='nowrap',
-        padding='0.35rem 0.85rem',
-        padding_bottom='calc(0.35rem + env(safe-area-inset-bottom, 0px))',
-        background='var(--calibre-color-window-background)',
-        border_top='1px solid var(--cs-surface-border)',
-        color='inherit',
-    )
-    ans += build_rule('.cs-cover-grid-size-dock .cs-cover-grid-size-label',
-        font_size='0.88rem',
-        font_weight='600',
-        opacity='0.88',
-        white_space='nowrap',
-        flex_shrink='0',
-    )
-    ans += build_rule('.cs-cover-grid-size-dock .cs-cover-grid-size-range',
-        flex='1 1 auto',
-        min_width='3rem',
-        width='auto',
-        max_width='32rem',
-        margin='0',
     )
     ans += build_rule('.cs-cover-grid-size-control',
         display='inline-flex',

--- a/src/pyj/book_list/local_books.pyj
+++ b/src/pyj/book_list/local_books.pyj
@@ -10,7 +10,6 @@ from book_list.router import home, open_book
 from book_list.top_bar import add_button, create_top_bar
 from book_list.library_data import library_data
 from book_list.ui import set_panel_handler
-from book_list.cover_grid import sync_cover_grid_size_dock
 from book_list.views import DEFAULT_MODE, get_view_mode, setup_view_mode, populate_book_list_toolbar
 from dom import clear, ensure_id
 from modals import create_custom_dialog, error_dialog
@@ -273,13 +272,12 @@ def apply_view_mode(mode):
     if mode is 'custom_list' and not library_data.field_metadata:
         mode = DEFAULT_MODE
     if book_list_data.mode is mode:
-        sync_cover_grid_size_dock(mode)
-        return
+        return mode
     setup_view_mode(mode, book_list_data)
     clear_grid()
     render_books()
-    sync_cover_grid_size_dock(mode)
     update_empty_message()
+    return mode
 
 
 def create_search_box():
@@ -308,14 +306,17 @@ def create_books_list(container, books, search_query=None):
     pw = create_pager_widget()
     pw.top_row.appendChild(create_search_box())
     pw.set_top_row_visibility(True)
-    populate_book_list_toolbar(pw.middle_row, False, apply_view_mode)
+    mode = get_view_mode()
+    if mode is 'custom_list' and not library_data.field_metadata:
+        mode = DEFAULT_MODE
+    populate_book_list_toolbar(pw.middle_row, False, apply_view_mode, mode)
     pw.set_middle_row_visibility(True)
     pw.set_enabled(False, False)
 
     container.appendChild(pw.container)
     container.appendChild(E.div(data_component='empty_message', style='display: none; margin: 1rem 0'))
     container.appendChild(E.div(data_component='book_list'))
-    apply_view_mode(get_view_mode())
+    apply_view_mode(mode)
 
 
 def show_recent_stage2(books, search_query=None):

--- a/src/pyj/book_list/router.pyj
+++ b/src/pyj/book_list/router.pyj
@@ -86,12 +86,6 @@ def apply_url(ignore_handler):
     if not ignore_handler:
         handler = mode_handlers[data.mode] or default_mode_handler
         handler(data)
-    try:
-        cb = window.cs_sync_cover_grid_dock
-        if cb:
-            cb()
-    except Exception:
-        pass
 
 
 def request_full_screen_if_wanted():

--- a/src/pyj/book_list/views.pyj
+++ b/src/pyj/book_list/views.pyj
@@ -448,7 +448,14 @@ def populate_book_list_toolbar(toolbar_el, include_sort, on_view_mode_change=Non
     clear(toolbar_el)
     try:
         current_mode = initial_mode or get_view_mode()
+    except Exception:
+        current_mode = DEFAULT_MODE
+    cover_grid_size_control = None
+    try:
         cover_grid_size_control = create_cover_grid_size_control(current_mode)
+    except Exception:
+        pass
+    try:
         mode_wrap, mode_sel = create_select(
             _('Change book list mode'), current_mode, cover_grid=_('Cover grid'),
             details_list=_('Detailed list'), custom_list=_('Custom list'))
@@ -464,10 +471,15 @@ def populate_book_list_toolbar(toolbar_el, include_sort, on_view_mode_change=Non
                     current_mode = apply_view_mode(requested_mode) or requested_mode
                 mode_sel.dataset.currentMode = current_mode
                 mode_sel.value = current_mode
-                sync_cover_grid_size_control(cover_grid_size_control, current_mode)
+                if cover_grid_size_control:
+                    sync_cover_grid_size_control(cover_grid_size_control, current_mode)
         )
         toolbar_el.appendChild(mode_wrap)
-        toolbar_el.appendChild(cover_grid_size_control)
+    except Exception:
+        pass
+    try:
+        if cover_grid_size_control:
+            toolbar_el.appendChild(cover_grid_size_control)
     except Exception:
         pass
     if not include_sort:

--- a/src/pyj/book_list/views.pyj
+++ b/src/pyj/book_list/views.pyj
@@ -11,7 +11,7 @@ from book_list.add import add_books_panel
 from book_list.cover_grid import (
     append_item as cover_grid_append_item, cover_grid_css,
     create_item as create_cover_grid_item, description as COVER_GRID_DESCRIPTION,
-    init as init_cover_grid, sync_cover_grid_size_dock
+    init as init_cover_grid, create_cover_grid_size_control, sync_cover_grid_size_control
 )
 from book_list.custom_list import (
     append_item as custom_list_append_item, create_item as create_custom_list_item,
@@ -203,7 +203,7 @@ def apply_view_mode(mode=DEFAULT_MODE):
         book_list_data.shown_book_ids = set()
         clear_grid()
         render_ids()
-    sync_cover_grid_size_dock(mode)
+    return mode
 
 
 # More button {{{
@@ -442,12 +442,13 @@ def clear_book_list_inner(inner):
         clear(inner)
 
 
-def populate_book_list_toolbar(toolbar_el, include_sort, on_view_mode_change=None):
+def populate_book_list_toolbar(toolbar_el, include_sort, on_view_mode_change=None, initial_mode=None):
     if not toolbar_el:
         return
     clear(toolbar_el)
     try:
-        current_mode = get_view_mode()
+        current_mode = initial_mode or get_view_mode()
+        cover_grid_size_control = create_cover_grid_size_control(current_mode)
         mode_wrap, mode_sel = create_select(
             _('Change book list mode'), current_mode, cover_grid=_('Cover grid'),
             details_list=_('Detailed list'), custom_list=_('Custom list'))
@@ -456,11 +457,13 @@ def populate_book_list_toolbar(toolbar_el, include_sort, on_view_mode_change=Non
             if m and m is not get_view_mode():
                 get_session_data().set('view_mode', m)
                 if on_view_mode_change:
-                    on_view_mode_change(m)
+                    m = on_view_mode_change(m) or m
                 else:
-                    apply_view_mode(m)
+                    m = apply_view_mode(m) or m
+                sync_cover_grid_size_control(cover_grid_size_control, m)
         )
         toolbar_el.appendChild(mode_wrap)
+        toolbar_el.appendChild(cover_grid_size_control)
     except Exception:
         pass
     if not include_sort:
@@ -787,9 +790,3 @@ set_panel_handler('book_list^search', init_search_panel)
 set_panel_handler('book_list^choose_mode', create_mode_panel)
 set_panel_handler('book_list^search^prefs', tb_config_panel_handler())
 set_panel_handler('book_list^more_actions', create_more_actions_panel)
-
-try:
-    window.cs_sync_cover_grid_dock = def():
-        sync_cover_grid_size_dock(get_view_mode())
-except Exception:
-    pass

--- a/src/pyj/book_list/views.pyj
+++ b/src/pyj/book_list/views.pyj
@@ -452,15 +452,19 @@ def populate_book_list_toolbar(toolbar_el, include_sort, on_view_mode_change=Non
         mode_wrap, mode_sel = create_select(
             _('Change book list mode'), current_mode, cover_grid=_('Cover grid'),
             details_list=_('Detailed list'), custom_list=_('Custom list'))
+        mode_sel.dataset.currentMode = current_mode
         mode_sel.addEventListener('change', def(ev):
-            m = mode_sel.value
-            if m and m is not get_view_mode():
-                get_session_data().set('view_mode', m)
+            requested_mode = mode_sel.value
+            current_mode = mode_sel.dataset.currentMode
+            if requested_mode and requested_mode is not current_mode:
+                get_session_data().set('view_mode', requested_mode)
                 if on_view_mode_change:
-                    m = on_view_mode_change(m) or m
+                    current_mode = on_view_mode_change(requested_mode) or requested_mode
                 else:
-                    m = apply_view_mode(m) or m
-                sync_cover_grid_size_control(cover_grid_size_control, m)
+                    current_mode = apply_view_mode(requested_mode) or requested_mode
+                mode_sel.dataset.currentMode = current_mode
+                mode_sel.value = current_mode
+                sync_cover_grid_size_control(cover_grid_size_control, current_mode)
         )
         toolbar_el.appendChild(mode_wrap)
         toolbar_el.appendChild(cover_grid_size_control)

--- a/src/pyj/book_list/views.pyj
+++ b/src/pyj/book_list/views.pyj
@@ -442,46 +442,42 @@ def clear_book_list_inner(inner):
         clear(inner)
 
 
+def create_optional_cover_grid_size_control(mode):
+    try:
+        return create_cover_grid_size_control(mode)
+    except Exception as err:
+        console.warn('Failed to create cover grid size toolbar control')
+        console.warn(err)
+
+
 def populate_book_list_toolbar(toolbar_el, include_sort, on_view_mode_change=None, initial_mode=None):
     if not toolbar_el:
         return
     clear(toolbar_el)
-    try:
-        current_mode = initial_mode or get_view_mode()
-    except Exception:
-        current_mode = DEFAULT_MODE
     cover_grid_size_control = None
-    try:
-        cover_grid_size_control = create_cover_grid_size_control(current_mode)
-    except Exception:
-        pass
-    try:
-        mode_wrap, mode_sel = create_select(
-            _('Change book list mode'), current_mode, cover_grid=_('Cover grid'),
-            details_list=_('Detailed list'), custom_list=_('Custom list'))
-        mode_sel.dataset.currentMode = current_mode
-        mode_sel.addEventListener('change', def(ev):
-            requested_mode = mode_sel.value
-            current_mode = mode_sel.dataset.currentMode
-            if requested_mode and requested_mode is not current_mode:
-                get_session_data().set('view_mode', requested_mode)
-                if on_view_mode_change:
-                    current_mode = on_view_mode_change(requested_mode) or requested_mode
-                else:
-                    current_mode = apply_view_mode(requested_mode) or requested_mode
-                mode_sel.dataset.currentMode = current_mode
-                mode_sel.value = current_mode
-                if cover_grid_size_control:
-                    sync_cover_grid_size_control(cover_grid_size_control, current_mode)
-        )
-        toolbar_el.appendChild(mode_wrap)
-    except Exception:
-        pass
-    try:
-        if cover_grid_size_control:
-            toolbar_el.appendChild(cover_grid_size_control)
-    except Exception:
-        pass
+    current_mode = initial_mode or get_view_mode()
+    mode_wrap, mode_sel = create_select(
+        _('Change book list mode'), current_mode, cover_grid=_('Cover grid'),
+        details_list=_('Detailed list'), custom_list=_('Custom list'))
+    mode_sel.dataset.currentMode = current_mode
+    mode_sel.addEventListener('change', def(ev):
+        requested_mode = mode_sel.value
+        current_mode = mode_sel.dataset.currentMode
+        if requested_mode and requested_mode is not current_mode:
+            get_session_data().set('view_mode', requested_mode)
+            if on_view_mode_change:
+                current_mode = on_view_mode_change(requested_mode) or requested_mode
+            else:
+                current_mode = apply_view_mode(requested_mode) or requested_mode
+            mode_sel.dataset.currentMode = current_mode
+            mode_sel.value = current_mode
+            if cover_grid_size_control:
+                sync_cover_grid_size_control(cover_grid_size_control, current_mode)
+    )
+    toolbar_el.appendChild(mode_wrap)
+    cover_grid_size_control = create_optional_cover_grid_size_control(current_mode)
+    if cover_grid_size_control:
+        toolbar_el.appendChild(cover_grid_size_control)
     if not include_sort:
         return
     def toggle_sort_order(ev=None):


### PR DESCRIPTION
Move the cover grid size slider from the global footer dock into the book list toolbar.

This keeps the sizing control local to the list view, reuses the shared toolbar used by downloaded books, and removes the old body-level dock hook and padding.

Validated with a direct RapydScript compile of src/pyj/srv.pyj using rapydscript-ng.
