### PR TITLE
Move book list quick actions to top bar

### DIFF
--- a/TODO
+++ b/TODO
@@ -13,9 +13,6 @@ in srv/code.py
 
 The scrollbars in dark mode have very low contrast
 
-Remove the quick actions form the sidebar. Put the plus and random in the top
-bar at the right on the book list pages.
-
 Viewer UI needs to be re styled to match overall server UI
 
 Review appearance of all pages in light and dark mode

--- a/src/pyj/book_list/sidebar.pyj
+++ b/src/pyj/book_list/sidebar.pyj
@@ -10,7 +10,6 @@ from gettext import gettext as _
 from book_list.router import home
 from book_list.globals import get_session_data
 from book_list.ui import show_panel
-from book_list.views import show_subsequent_panel
 from book_list.custom_category_icon_picker import create_custom_category_icon_picker, normalize_custom_category_icon
 from widgets import create_button
 
@@ -100,21 +99,6 @@ def create_sidebar():
     reader_link = nav_link(_('Downloaded books'), go_reader, _('Read previously downloaded books'), icon='cloud-download')
     g1.appendChild(reader_link)
     left.appendChild(g1)
-
-    left.appendChild(E.div(class_='cs-nav-divider'))
-
-    # Group 1.5: quick actions
-    left.appendChild(E.div(svgicon('random'), E.span(_('Quick actions')), class_='cs-nav-group-title'))
-    g1_5 = E.div(class_='cs-nav-group')
-    go_add_books = def():
-        show_subsequent_panel('book_list^add')
-    add_books_nav = nav_link(_('Add books'), go_add_books, _('Add books to the library'), icon='plus')
-    g1_5.appendChild(add_books_nav)
-    go_random = def():
-        show_panel('book_details', {'book_id': '0'})
-    random_link = nav_link(_('A random book'), go_random, _('Choose a random book from the library'), icon='random')
-    g1_5.appendChild(random_link)
-    left.appendChild(g1_5)
 
     left.appendChild(E.div(class_='cs-nav-divider'))
 

--- a/src/pyj/book_list/views.pyj
+++ b/src/pyj/book_list/views.pyj
@@ -774,30 +774,6 @@ def create_mode_panel(container_id):
 
 # }}}
 
-# More actions {{{
-
-def create_more_actions_panel(container_id):
-    container = document.getElementById(container_id)
-    create_top_bar(container, title=_('More actions…'), action=back, icon='close')
-    items = [
-        create_item(_('Book list mode'), subtitle=_('Change how the list of books is displayed'), action=def():
-                    show_panel('book_list^choose_mode', replace=True)
-        ),
-        create_item(_('A random book'), subtitle=_('Choose a random book from the library'), action=def():
-                    query = {'book_id':'0'}
-                    show_panel('book_details', query=query, replace=True)
-        ),
-    ]
-    vls = all_virtual_libraries()
-    if vls and Object.keys(vls).length > 0:
-        items.insert(1, create_item(_('Choose Virtual library'), subtitle=_('Browse books in a Virtual library'), action=def():
-                     show_panel('book_list^vl', replace=True)
-        ))
-    container.appendChild(E.div())
-    create_item_list(container.lastChild, items)
-    enable_escape_key(container, back)
-# }}}
-
 # Adding books {{{
 def create_add_panel(container_id):
     if not library_data.sortable_fields:
@@ -815,4 +791,3 @@ set_panel_handler('book_list^vl', create_vl_panel)
 set_panel_handler('book_list^search', init_search_panel)
 set_panel_handler('book_list^choose_mode', create_mode_panel)
 set_panel_handler('book_list^search^prefs', tb_config_panel_handler())
-set_panel_handler('book_list^more_actions', create_more_actions_panel)

--- a/src/pyj/book_list/views.pyj
+++ b/src/pyj/book_list/views.pyj
@@ -34,7 +34,7 @@ from book_list.router import back, home, push_state, update_window_title
 from book_list.search import (
     init as init_search_panel, set_apply_search, tb_config_panel_handler
 )
-from book_list.top_bar import create_top_bar, set_title_tooltip
+from book_list.top_bar import add_button, create_top_bar, set_title_tooltip
 from book_list.custom_category_icon_picker import create_custom_category_icon_picker
 from book_list.ui import query_as_href, set_panel_handler, show_panel
 from dom import add_extra_css, build_rule, clear, ensure_id, set_css, svgicon
@@ -136,6 +136,19 @@ def save_scroll_position():
 def show_subsequent_panel(name, query=None, replace=False):
     save_scroll_position()
     show_panel(name, query, replace)
+
+
+def show_add_books():
+    show_subsequent_panel('book_list^add')
+
+
+def show_random_book():
+    show_subsequent_panel('book_details', {'book_id': '0'})
+
+
+def add_book_list_top_bar_buttons(container):
+    add_button(container, 'plus', show_add_books, _('Add books to the library'))
+    add_button(container, 'random', show_random_book, _('Choose a random book from the library'))
 
 
 def on_book_click(book_id, evt):
@@ -639,6 +652,7 @@ def init(container_id):
     title = interface_data.library_map[lid]
     update_window_title(title)
     create_top_bar(container, title=title, action=def(): save_scroll_position(), home();, icon='home')
+    add_book_list_top_bar_buttons(container)
 
     inner = E.div(class_=CLASS_NAME)
     container.appendChild(inner)


### PR DESCRIPTION
Moves the add and random book actions from the sidebar to the book list top bar.

Also removes the stale book list more actions panel.

Tested with rapydscript --only-module srv and test_rs.