### PR TITLE
Clean up custom category helpers

### DIFF
--- a/src/pyj/book_list/custom_categories.pyj
+++ b/src/pyj/book_list/custom_categories.pyj
@@ -1,0 +1,72 @@
+# vim:fileencoding=utf-8
+# License: GPL v3 Copyright: 2026, Kovid Goyal <kovid at kovidgoyal.net>
+from __python__ import hash_literals
+
+from book_list.globals import get_session_data
+
+
+CUSTOM_CATEGORIES_SETTING = 'custom_categories'
+
+
+def get_custom_categories():
+    categories = get_session_data().get(CUSTOM_CATEGORIES_SETTING, v'[]') or v'[]'
+    if not Array.isArray(categories):
+        return v'[]'
+    return categories
+
+
+def set_custom_categories(categories):
+    get_session_data().set(CUSTOM_CATEGORIES_SETTING, categories or v'[]')
+
+
+def custom_category_item(name, filter_expr, icon='folder', use_icon=True):
+    name = ((name or '') + '').strip()
+    filter_expr = ((filter_expr or '') + '').strip()
+    if not name or not filter_expr:
+        return None
+    return {'name': name, 'filter': filter_expr, 'icon': ((icon or 'folder') + ''), 'use_icon': use_icon is not False}
+
+
+def custom_category_nav_initial(name):
+    s = ((name or '') + '').strip()
+    if not s:
+        return '·'
+    return s[0]
+
+
+def add_custom_category(item):
+    if not item:
+        return False
+    categories = get_custom_categories()
+    categories.push(item)
+    set_custom_categories(categories)
+    return True
+
+
+def set_custom_category_at(index, item):
+    if not item:
+        return False
+    categories = get_custom_categories()
+    if index < 0 or index >= categories.length:
+        return False
+    categories[index] = item
+    set_custom_categories(categories)
+    return True
+
+
+def remove_custom_category_at(index):
+    categories = get_custom_categories()
+    if index < 0 or index >= categories.length:
+        return False
+    categories.splice(index, 1)
+    set_custom_categories(categories)
+    return True
+
+
+def save_custom_category(item):
+    if not item:
+        return False
+    categories = [x for x in get_custom_categories() if ((x.name or '') + '') is not item.name]
+    categories.unshift(item)
+    set_custom_categories(categories)
+    return True

--- a/src/pyj/book_list/custom_category_dialog.pyj
+++ b/src/pyj/book_list/custom_category_dialog.pyj
@@ -1,0 +1,82 @@
+# vim:fileencoding=utf-8
+# License: GPL v3 Copyright: 2026, Kovid Goyal <kovid at kovidgoyal.net>
+from __python__ import hash_literals
+
+from elementmaker import E
+from gettext import gettext as _
+
+from book_list.custom_categories import custom_category_item
+from book_list.custom_category_icon_picker import create_custom_category_icon_picker
+from modals import create_custom_dialog
+from widgets import create_button
+
+
+def show_custom_category_dialog(
+        title, save_label, on_save, initial_name='', initial_filter='',
+        initial_icon='folder', initial_use_icon=True, on_delete=None, save_icon='check'):
+    create_custom_dialog(title, def(parent, close_modal):
+        name_input = E.input(type='text', value=((initial_name or '') + ''), placeholder=_('Category name'))
+        filter_input = E.input(type='text', value=((initial_filter or '') + ''), placeholder=_('Filter condition'))
+        icon_picker = create_custom_category_icon_picker((initial_icon or 'folder') + '')
+        use_icon_cb = E.input(type='checkbox')
+        use_icon_cb.checked = initial_use_icon is not False
+        icon_section = E.div(class_='cc-icon-section',
+            E.div(class_='cc-row',
+                E.label(_('Icon'), class_='cc-label'),
+                icon_picker.root
+            ),
+        )
+        use_icon_help = E.div(_('When disabled, only the first character of the name is shown while the navigation is collapsed.'), class_='help')
+
+        def sync_icon_section_visibility(ev=None):
+            on = use_icon_cb.checked
+            icon_section.style.display = 'block' if on else 'none'
+            use_icon_help.style.display = 'none' if on else 'block'
+
+        def save_item(ev=None):
+            item = custom_category_item(name_input.value, filter_input.value, icon_picker.get_value(), use_icon_cb.checked)
+            if not item:
+                return
+            if on_save(item) is False:
+                return
+            close_modal()
+
+        def delete_item(ev=None):
+            if on_delete and on_delete() is False:
+                return
+            close_modal()
+
+        dialog = E.div(class_='cs-custom-category-dialog',
+            E.div(class_='cc-row',
+                E.label(_('Category name'), class_='cc-label'),
+                name_input
+            ),
+            E.div(class_='cc-row',
+                E.label(_('Filter condition'), class_='cc-label'),
+                filter_input
+            ),
+            E.div(class_='cc-checkbox-row',
+                use_icon_cb,
+                E.span(_('Show icon in sidebar'), style='margin-left:0.45rem'),
+            ),
+            use_icon_help,
+            icon_section,
+        )
+        actions_class = 'cc-actions-save-cancel'
+        if on_delete:
+            dialog.appendChild(E.div(class_='cc-actions-delete',
+                create_button(_('Delete'), 'trash', delete_item),
+            ))
+        else:
+            actions_class += ' cc-actions-save-cancel--toprule'
+        dialog.appendChild(E.div(class_=actions_class,
+            create_button(_('Cancel'), 'close', def(ev=None): close_modal();),
+            create_button(save_label, save_icon, save_item, highlight=True),
+        ))
+        parent.appendChild(dialog)
+        use_icon_cb.addEventListener('change', sync_icon_section_visibility)
+        sync_icon_section_visibility()
+        setTimeout(def():
+            name_input.focus()
+        , 10)
+    )

--- a/src/pyj/book_list/sidebar.pyj
+++ b/src/pyj/book_list/sidebar.pyj
@@ -10,6 +10,10 @@ from gettext import gettext as _
 from book_list.router import home
 from book_list.globals import get_session_data
 from book_list.ui import show_panel
+from book_list.custom_categories import (
+    add_custom_category, custom_category_item, custom_category_nav_initial,
+    get_custom_categories, remove_custom_category_at, set_custom_category_at
+)
 from book_list.custom_category_icon_picker import create_custom_category_icon_picker, normalize_custom_category_icon
 from widgets import create_button
 
@@ -163,22 +167,6 @@ def create_sidebar():
         if elem and elem.dataset and elem.dataset.active:
             elem.dataset.active = ''
 
-    def custom_category_nav_initial(name):
-        s = ((name or '') + '').strip()
-        if not s:
-            return '·'
-        return s[0]
-
-    def get_custom_categories():
-        sd = get_session_data()
-        categories = sd.get('custom_categories', v'[]') or v'[]'
-        if not Array.isArray(categories):
-            categories = v'[]'
-        return categories
-
-    def set_custom_categories(categories):
-        get_session_data().set('custom_categories', categories or v'[]')
-
     def edit_custom_category(index):
         categories = get_custom_categories()
         item = categories[index] or v'{}'
@@ -205,24 +193,15 @@ def create_sidebar():
                 use_icon_help.style.display = 'none' if on else 'block'
 
             def save_changes(ev=None):
-                name = (name_input.value or '').strip()
-                filter_expr = (filter_input.value or '').strip()
-                if not name or not filter_expr:
+                item = custom_category_item(name_input.value, filter_input.value, icon_picker.get_value(), use_icon_cb.checked)
+                if not set_custom_category_at(index, item):
                     return
-                categories = get_custom_categories()
-                if index < 0 or index >= categories.length:
-                    return
-                categories[index] = {'name': name, 'filter': filter_expr, 'icon': (icon_picker.get_value() or '📁'), 'use_icon': use_icon_cb.checked}
-                set_custom_categories(categories)
                 close_modal()
                 render_custom_categories()
 
             def delete_item(ev=None):
-                categories = get_custom_categories()
-                if index < 0 or index >= categories.length:
+                if not remove_custom_category_at(index):
                     return
-                categories.splice(index, 1)
-                set_custom_categories(categories)
                 close_modal()
                 render_custom_categories()
 
@@ -277,13 +256,9 @@ def create_sidebar():
                 use_icon_help.style.display = 'none' if on else 'block'
 
             def create_item(ev=None):
-                name = (name_input.value or '').strip()
-                filter_expr = (filter_input.value or '').strip()
-                if not name or not filter_expr:
+                item = custom_category_item(name_input.value, filter_input.value, icon_picker.get_value(), use_icon_cb.checked)
+                if not add_custom_category(item):
                     return
-                categories = get_custom_categories()
-                categories.push({'name': name, 'filter': filter_expr, 'icon': (icon_picker.get_value() or '📁'), 'use_icon': use_icon_cb.checked})
-                set_custom_categories(categories)
                 close_modal()
                 render_custom_categories()
 

--- a/src/pyj/book_list/sidebar.pyj
+++ b/src/pyj/book_list/sidebar.pyj
@@ -3,7 +3,6 @@
 
 from dom import clear, svgicon
 from elementmaker import E
-from modals import create_custom_dialog
 from utils import parse_url_params
 from gettext import gettext as _
 
@@ -11,11 +10,11 @@ from book_list.router import home
 from book_list.globals import get_session_data
 from book_list.ui import show_panel
 from book_list.custom_categories import (
-    add_custom_category, custom_category_item, custom_category_nav_initial,
-    get_custom_categories, remove_custom_category_at, set_custom_category_at
+    add_custom_category, custom_category_nav_initial, get_custom_categories,
+    remove_custom_category_at, set_custom_category_at
 )
-from book_list.custom_category_icon_picker import create_custom_category_icon_picker, normalize_custom_category_icon
-from widgets import create_button
+from book_list.custom_category_dialog import show_custom_category_dialog
+from book_list.custom_category_icon_picker import normalize_custom_category_icon
 
 
 def create_sidebar():
@@ -170,124 +169,36 @@ def create_sidebar():
     def edit_custom_category(index):
         categories = get_custom_categories()
         item = categories[index] or v'{}'
-        initial_name = (item.name or '') + ''
-        initial_filter = (item.filter or '') + ''
 
-        create_custom_dialog(_('Edit custom Category'), def(parent, close_modal):
-            name_input = E.input(type='text', value=initial_name, placeholder=_('Category name'))
-            filter_input = E.input(type='text', value=initial_filter, placeholder=_('Filter condition'))
-            icon_picker = create_custom_category_icon_picker((item.icon or 'folder') + '')
-            use_icon_cb = E.input(type='checkbox')
-            use_icon_cb.checked = item.use_icon is not False
-            icon_section = E.div(class_='cc-icon-section',
-                E.div(class_='cc-row',
-                    E.label(_('Icon'), class_='cc-label'),
-                    icon_picker.root
-                ),
-            )
-            use_icon_help = E.div(_('When disabled, only the first character of the name is shown while the navigation is collapsed.'), class_='help')
+        def save_changes(updated_item):
+            if not set_custom_category_at(index, updated_item):
+                return False
+            render_custom_categories()
+            return True
 
-            def sync_icon_section_visibility(ev=None):
-                on = use_icon_cb.checked
-                icon_section.style.display = 'block' if on else 'none'
-                use_icon_help.style.display = 'none' if on else 'block'
+        def delete_item():
+            if not remove_custom_category_at(index):
+                return False
+            render_custom_categories()
+            return True
 
-            def save_changes(ev=None):
-                item = custom_category_item(name_input.value, filter_input.value, icon_picker.get_value(), use_icon_cb.checked)
-                if not set_custom_category_at(index, item):
-                    return
-                close_modal()
-                render_custom_categories()
-
-            def delete_item(ev=None):
-                if not remove_custom_category_at(index):
-                    return
-                close_modal()
-                render_custom_categories()
-
-            parent.appendChild(E.div(class_='cs-custom-category-dialog',
-                E.div(class_='cc-row',
-                    E.label(_('Category name'), class_='cc-label'),
-                    name_input
-                ),
-                E.div(class_='cc-row',
-                    E.label(_('Filter condition'), class_='cc-label'),
-                    filter_input
-                ),
-                E.div(class_='cc-checkbox-row',
-                    use_icon_cb,
-                    E.span(_('Show icon in sidebar'), style='margin-left:0.45rem'),
-                ),
-                use_icon_help,
-                icon_section,
-                E.div(class_='cc-actions-delete',
-                    create_button(_('Delete'), 'trash', delete_item),
-                ),
-                E.div(class_='cc-actions-save-cancel',
-                    create_button(_('Cancel'), 'close', def(ev=None): close_modal();),
-                    create_button(_('Save'), 'check', save_changes, highlight=True),
-                )
-            ))
-            use_icon_cb.addEventListener('change', sync_icon_section_visibility)
-            sync_icon_section_visibility()
-            setTimeout(def():
-                name_input.focus()
-            , 10)
+        show_custom_category_dialog(
+            _('Edit custom Category'), _('Save'), save_changes,
+            initial_name=(item.name or '') + '',
+            initial_filter=(item.filter or '') + '',
+            initial_icon=(item.icon or 'folder') + '',
+            initial_use_icon=item.use_icon is not False,
+            on_delete=delete_item,
         )
 
     def create_custom_category():
-        create_custom_dialog(_('New Category'), def(parent, close_modal):
-            name_input = E.input(type='text', placeholder=_('Category name'))
-            filter_input = E.input(type='text', placeholder=_('Filter condition'))
-            icon_picker = create_custom_category_icon_picker('folder')
-            use_icon_cb = E.input(type='checkbox')
-            use_icon_cb.checked = True
-            icon_section = E.div(class_='cc-icon-section',
-                E.div(class_='cc-row',
-                    E.label(_('Icon'), class_='cc-label'),
-                    icon_picker.root
-                ),
-            )
-            use_icon_help = E.div(_('When disabled, only the first character of the name is shown while the navigation is collapsed.'), class_='help')
+        def create_item(item):
+            if not add_custom_category(item):
+                return False
+            render_custom_categories()
+            return True
 
-            def sync_icon_section_visibility(ev=None):
-                on = use_icon_cb.checked
-                icon_section.style.display = 'block' if on else 'none'
-                use_icon_help.style.display = 'none' if on else 'block'
-
-            def create_item(ev=None):
-                item = custom_category_item(name_input.value, filter_input.value, icon_picker.get_value(), use_icon_cb.checked)
-                if not add_custom_category(item):
-                    return
-                close_modal()
-                render_custom_categories()
-
-            parent.appendChild(E.div(class_='cs-custom-category-dialog',
-                E.div(class_='cc-row',
-                    E.label(_('Category name'), class_='cc-label'),
-                    name_input
-                ),
-                E.div(class_='cc-row',
-                    E.label(_('Filter condition'), class_='cc-label'),
-                    filter_input
-                ),
-                E.div(class_='cc-checkbox-row',
-                    use_icon_cb,
-                    E.span(_('Show icon in sidebar'), style='margin-left:0.45rem'),
-                ),
-                use_icon_help,
-                icon_section,
-                E.div(class_='cc-actions-save-cancel cc-actions-save-cancel--toprule',
-                    create_button(_('Cancel'), 'close', def(ev=None): close_modal();),
-                    create_button(_('Create'), 'plus', create_item, highlight=True),
-                )
-            ))
-            use_icon_cb.addEventListener('change', sync_icon_section_visibility)
-            sync_icon_section_visibility()
-            setTimeout(def():
-                name_input.focus()
-            , 10)
-        )
+        show_custom_category_dialog(_('New Category'), _('Create'), create_item, save_icon='plus')
 
     def render_custom_categories():
         clear(g_custom)

--- a/src/pyj/book_list/views.pyj
+++ b/src/pyj/book_list/views.pyj
@@ -18,7 +18,8 @@ from book_list.custom_list import (
     custom_list_css, description as CUSTOM_LIST_DESCRIPTION,
     init as init_custom_list
 )
-from book_list.custom_categories import custom_category_item, save_custom_category
+from book_list.custom_categories import save_custom_category
+from book_list.custom_category_dialog import show_custom_category_dialog
 from book_list.details_list import (
     append_item as details_list_append_item, create_item as create_details_list_item,
     description as DETAILS_LIST_DESCRIPTION, details_list_css,
@@ -36,10 +37,9 @@ from book_list.search import (
     init as init_search_panel, set_apply_search, tb_config_panel_handler
 )
 from book_list.top_bar import add_button, create_top_bar, set_title_tooltip
-from book_list.custom_category_icon_picker import create_custom_category_icon_picker
 from book_list.ui import query_as_href, set_panel_handler, show_panel
 from dom import add_extra_css, build_rule, clear, ensure_id, set_css, svgicon
-from modals import create_custom_dialog, error_dialog
+from modals import error_dialog
 from session import get_interface_data
 from utils import conditional_timeout, parse_url_params, safe_set_inner_html
 from widgets import create_button, create_pager_widget, create_spinner, enable_escape_key, create_select
@@ -341,56 +341,20 @@ def fts():
 def save_to_custom_category():
     current_filter = (library_data.search_result?.query or '') + ''
 
-    create_custom_dialog(_('Save to custom Category'), def(parent, close_modal):
-        name_input = E.input(type='text', placeholder=_('Category name'))
-        filter_input = E.input(type='text', placeholder=_('Filter expression'), value=current_filter)
-        icon_picker = create_custom_category_icon_picker('folder')
-        use_icon_cb = E.input(type='checkbox')
-        use_icon_cb.checked = True
-        icon_section = E.div(class_='cc-icon-section',
-            E.div(style='margin:0.8rem 0 0.6rem 0', _('Icon')),
-            icon_picker.root,
-        )
-        use_icon_help = E.div(style='opacity:0.75;font-size:0.9em;margin-bottom:0.6rem', _('When disabled, only the first character of the name is shown while the navigation is collapsed.'))
+    def do_save(item):
+        if not save_custom_category(item):
+            return False
+        try:
+            cb = window.cs_refresh_custom_categories
+        except Exception:
+            cb = None
+        if cb:
+            cb()
+        return True
 
-        def sync_icon_section_visibility(ev=None):
-            on = use_icon_cb.checked
-            icon_section.style.display = 'block' if on else 'none'
-            use_icon_help.style.display = 'none' if on else 'block'
-
-        def do_save(ev=None):
-            item = custom_category_item(name_input.value, filter_input.value, icon_picker.get_value(), use_icon_cb.checked)
-            if not save_custom_category(item):
-                return
-            close_modal()
-            try:
-                cb = window.cs_refresh_custom_categories
-            except Exception:
-                cb = None
-            if cb:
-                cb()
-
-        parent.appendChild(E.div(class_='cs-custom-category-dialog',
-            E.div(style='margin-bottom:0.6rem', _('Category name')),
-            name_input,
-            E.div(style='margin:0.8rem 0 0.6rem 0', _('Filter condition')),
-            filter_input,
-            E.div(style='display:flex;align-items:center;margin:0.8rem 0 0.35rem 0',
-                use_icon_cb,
-                E.span(_('Show icon in sidebar'), style='margin-left:0.45rem'),
-            ),
-            use_icon_help,
-            icon_section,
-            E.div(class_='cc-actions-save-cancel cc-actions-save-cancel--toprule',
-                create_button(_('Cancel'), 'close', def(ev=None): close_modal();),
-                create_button(_('Save'), 'check', do_save, highlight=True),
-            )
-        ))
-        use_icon_cb.addEventListener('change', sync_icon_section_visibility)
-        sync_icon_section_visibility()
-        setTimeout(def():
-            name_input.focus()
-        , 10)
+    show_custom_category_dialog(
+        _('Save to custom Category'), _('Save'), do_save,
+        initial_filter=current_filter,
     )
 
 

--- a/src/pyj/book_list/views.pyj
+++ b/src/pyj/book_list/views.pyj
@@ -18,6 +18,7 @@ from book_list.custom_list import (
     custom_list_css, description as CUSTOM_LIST_DESCRIPTION,
     init as init_custom_list
 )
+from book_list.custom_categories import custom_category_item, save_custom_category
 from book_list.details_list import (
     append_item as details_list_append_item, create_item as create_details_list_item,
     description as DETAILS_LIST_DESCRIPTION, details_list_css,
@@ -338,7 +339,6 @@ def fts():
 
 
 def save_to_custom_category():
-    sd = get_session_data()
     current_filter = (library_data.search_result?.query or '') + ''
 
     create_custom_dialog(_('Save to custom Category'), def(parent, close_modal):
@@ -359,15 +359,9 @@ def save_to_custom_category():
             use_icon_help.style.display = 'none' if on else 'block'
 
         def do_save(ev=None):
-            name = (name_input.value or '').strip()
-            filter_expr = (filter_input.value or '').strip()
-            if not name or not filter_expr:
+            item = custom_category_item(name_input.value, filter_input.value, icon_picker.get_value(), use_icon_cb.checked)
+            if not save_custom_category(item):
                 return
-            items = sd.get('custom_categories', v'[]') or v'[]'
-            # Keep unique names: overwrite existing item with same name.
-            items = [x for x in items if ((x.name or '') + '') is not name]
-            items.unshift({'name': name, 'filter': filter_expr, 'icon': (icon_picker.get_value() or '📁'), 'use_icon': use_icon_cb.checked})
-            sd.set('custom_categories', items)
             close_modal()
             try:
                 cb = window.cs_refresh_custom_categories


### PR DESCRIPTION
Centralizes custom category storage and dialog code.

Keeps the saved search behavior the same while removing duplicated sidebar and search UI code.

Tested with rapydscript --only-module srv, test_rs, and a local server smoke.