### PR TITLE
Add custom columns to webui browse

### DIFF
--- a/src/calibre/srv/code.py
+++ b/src/calibre/srv/code.py
@@ -19,7 +19,10 @@ from calibre.ebooks.metadata.book.render import resolve_default_author_link
 from calibre.srv.ajax import search_result
 from calibre.srv.errors import BookNotFound, HTTPBadRequest, HTTPForbidden, HTTPNotFound, HTTPRedirect, HTTPTempRedirect
 from calibre.srv.last_read import last_read_cache
-from calibre.srv.metadata import book_as_json, categories_as_json, categories_settings, get_gpref, icon_map, web_search_link
+from calibre.srv.metadata import (
+    book_as_json, categories_as_json, categories_settings, category_item_as_json,
+    get_gpref, icon_map, web_search_link
+)
 from calibre.srv.routes import endpoint, json
 from calibre.srv.utils import get_library_data, get_use_roman
 from calibre.utils.config import prefs, tweaks
@@ -210,6 +213,132 @@ def get_field_list(db):
     return [f for f, d in fieldlist if d and f in available]
 
 
+BROWSE_FIELD_ORDER = ('series', 'authors', 'publisher', 'tags', 'formats', 'rating', 'pubdate')
+BROWSE_FIELD_ICONS = {
+    'series': 'book',
+    'authors': 'user',
+    'publisher': 'library',
+    'tags': 'tags',
+    'formats': 'convert',
+    'rating': 'star',
+    'pubdate': 'date',
+}
+BROWSE_FIELD_DESCRIPTIONS = {
+    'series': _('Browse all series'),
+    'authors': _('Browse all authors'),
+    'publisher': _('Browse all publishers'),
+    'tags': _('Browse all tags'),
+    'formats': _('Browse all formats'),
+    'rating': _('Browse by rating'),
+    'pubdate': _('Browse by published date'),
+}
+BROWSE_IGNORED_CATEGORIES = frozenset({'identifiers', 'news', 'search'})
+
+
+def browse_field_kind(key, metadata):
+    if metadata is None or metadata.get('kind') != 'field':
+        return ''
+    if key == 'pubdate' or (metadata.get('is_custom') and metadata.get('datatype') == 'datetime'):
+        return 'date'
+    if metadata.get('is_category') and key not in BROWSE_IGNORED_CATEGORIES:
+        return 'category'
+    return ''
+
+
+def browse_field_entry(key, metadata, kind):
+    name = metadata.get('name') or key
+    return {
+        'key': key,
+        'name': name,
+        'description': BROWSE_FIELD_DESCRIPTIONS.get(key) or _('Browse {0}').format(name),
+        'kind': kind,
+        'icon': BROWSE_FIELD_ICONS.get(key) or ('date' if kind == 'date' else 'tags'),
+        'is_custom': bool(metadata.get('is_custom')),
+        'datatype': metadata.get('datatype') or '',
+    }
+
+
+def browse_field_map(db):
+    fm = db.field_metadata
+    ans = {}
+    for key in BROWSE_FIELD_ORDER:
+        metadata = fm.get(key)
+        kind = browse_field_kind(key, metadata)
+        if kind:
+            ans[key] = browse_field_entry(key, metadata, kind)
+    custom_fields = []
+    for key, metadata in fm.custom_field_metadata(include_composites=False).items():
+        kind = browse_field_kind(key, metadata)
+        if kind and key not in ans:
+            custom_fields.append((sort_key(metadata.get('name') or key), key, metadata, kind))
+    for unused_sort_key, key, metadata, kind in sorted(custom_fields):
+        ans[key] = browse_field_entry(key, metadata, kind)
+    return ans
+
+
+def get_browse_fields(db):
+    fields = browse_field_map(db)
+    return tuple(fields[key] for key in fields)
+
+
+def escape_search_value(x):
+    return str(x or '').replace('\\', '\\\\').replace('"', '\\"')
+
+
+def category_browse_search_expression(field, item):
+    return item.search_expression or f'{field}:"{escape_search_value(item.original_name)}"'
+
+
+def category_browse_items(ctx, rd, db, field, vl):
+    opts = categories_settings(rd.query, db, gst_container=tuple)
+    categories = ctx.get_categories(
+        rd, db, sort=opts.sort_by, first_letter_sort=opts.collapse_model == 'first letter', vl=vl)
+    ans = []
+    for item in categories.get(field, ()):
+        data = category_item_as_json(item)
+        data['search'] = category_browse_search_expression(field, item)
+        data['search_name'] = item.original_name
+        ans.append(data)
+    return tuple(ans)
+
+
+def next_month(year, month):
+    month += 1
+    if month > 12:
+        return year + 1, 1
+    return year, month
+
+
+def date_browse_items(ctx, rd, db, field, vl):
+    from calibre.db.search import TemplatesNotAllowed
+
+    try:
+        book_ids, parse_error = ctx.search(
+            rd, db, rd.query.get('search') or '', vl=vl, report_restriction_errors=True)
+    except TemplatesNotAllowed:
+        raise HTTPBadRequest(_('templates are not allowed in search expressions'))
+    if parse_error is not None:
+        raise HTTPBadRequest(str(parse_error))
+    group = rd.query.get('date_group') or 'y'
+    if group == 'ym':
+        groups = db.books_by_month(field=field, restrict_to_books=book_ids)
+        items = sorted(groups, reverse=True)
+        return tuple({
+            'name': f'{year:04d}-{month:02d}',
+            'count': len(groups[year, month]),
+            'avg_rating': None,
+            'search': '{}:>={:04d}-{:02d}-01 and {}:<{:04d}-{:02d}-01'.format(
+                field, year, month, field, *next_month(year, month)),
+        } for year, month in items if groups[year, month])
+    groups = db.books_by_year(field=field, restrict_to_books=book_ids)
+    return tuple({
+        'name': f'{year:04d}',
+        'count': len(groups[year]),
+        'avg_rating': None,
+        'search': f'{field}:>={year:04d}-01-01 and {field}:<{year + 1:04d}-01-01',
+    } for year in sorted(groups, reverse=True) if groups[year])
+
+
 def get_library_init_data(ctx, rd, db, num, sorts, orders, vl):
     ans = {}
     with db.safe_read_lock:
@@ -234,6 +363,7 @@ def get_library_init_data(ctx, rd, db, num, sorts, orders, vl):
         ans['virtual_libraries'] = db._pref('virtual_libraries', {})
         ans['bools_are_tristate'] = db._pref('bools_are_tristate', True)
         ans['book_display_fields'] = get_field_list(db)
+        ans['browse_fields'] = get_browse_fields(db)
         ans['fts_enabled'] = db.is_fts_enabled()
         ans['book_details_vertical_categories'] = db._pref('book_details_vertical_categories', ())
         ans['fields_that_support_notes'] = tuple(db._field_supports_notes())
@@ -466,6 +596,30 @@ def tag_browser(ctx, rd):
         return json(ctx, rd, tag_browser, categories_as_json(ctx, rd, db, opts, vl))
 
     return rd.etagged_dynamic_response(etag, generate)
+
+
+@endpoint('/interface-data/browse-field/{field}', postprocess=json)
+def browse_field(ctx, rd, field):
+    '''
+    Get browse-list items for the specified metadata field.
+    Optional: ?library_id=<default library>&vl=&date_group=y
+    '''
+    db = get_library_data(ctx, rd)[0]
+    if field.startswith('_'):
+        try:
+            field = db.field_metadata.label_to_key(field[1:], prefer_custom=True)
+        except ValueError:
+            raise HTTPNotFound(f'{field} is not a browse field')
+    fields = browse_field_map(db)
+    field_data = fields.get(field)
+    if field_data is None:
+        raise HTTPNotFound(f'{field} is not a browse field')
+    vl = rd.query.get('vl') or ''
+    if field_data['kind'] == 'date':
+        items = date_browse_items(ctx, rd, db, field, vl)
+    else:
+        items = category_browse_items(ctx, rd, db, field, vl)
+    return {'field': field, 'items': items}
 
 
 def all_lang_names():

--- a/src/calibre/srv/code.py
+++ b/src/calibre/srv/code.py
@@ -634,11 +634,6 @@ def browse_field(ctx, rd, field):
     Optional: ?library_id=<default library>&vl=&date_group=y
     '''
     db = get_library_data(ctx, rd)[0]
-    if field.startswith('_'):
-        try:
-            field = db.field_metadata.label_to_key(field[1:], prefer_custom=True)
-        except ValueError:
-            raise HTTPNotFound(f'{field} is not a browse field')
     fields = browse_field_map(db)
     field_data = fields.get(field)
     if field_data is None:

--- a/src/calibre/srv/code.py
+++ b/src/calibre/srv/code.py
@@ -20,8 +20,7 @@ from calibre.srv.ajax import search_result
 from calibre.srv.errors import BookNotFound, HTTPBadRequest, HTTPForbidden, HTTPNotFound, HTTPRedirect, HTTPTempRedirect
 from calibre.srv.last_read import last_read_cache
 from calibre.srv.metadata import (
-    book_as_json, categories_as_json, categories_settings, category_item_as_json,
-    get_gpref, icon_map, web_search_link
+    book_as_json, categories_as_json, categories_settings, get_gpref, icon_map, web_search_link
 )
 from calibre.srv.routes import endpoint, json
 from calibre.srv.utils import get_library_data, get_use_roman
@@ -286,19 +285,49 @@ def escape_search_value(x):
 
 
 def category_browse_search_expression(field, item):
-    return item.search_expression or f'{field}:"{escape_search_value(item.original_name)}"'
+    search = item.get('search_expression')
+    if search:
+        return search
+    search_name = item.get('original_name') or item.get('name') or ''
+    if field == 'rating':
+        stars = str(search_name).count('★')
+        if 1 <= stars <= 5:
+            return f'rating:{stars}'
+    return f'{field}:"{escape_search_value(search_name)}"'
 
 
 def category_browse_items(ctx, rd, db, field, vl):
     opts = categories_settings(rd.query, db, gst_container=tuple)
-    categories = ctx.get_categories(
-        rd, db, sort=opts.sort_by, first_letter_sort=opts.collapse_model == 'first letter', vl=vl)
-    ans = []
-    for item in categories.get(field, ()):
-        data = category_item_as_json(item)
-        data['search'] = category_browse_search_expression(field, item)
-        data['search_name'] = item.original_name
-        ans.append(data)
+    categories = json_loads(categories_as_json(ctx, rd, db, opts, vl))
+    root = categories.get('root') or {}
+    item_map = categories.get('item_map') or {}
+    category_node = None
+    for child in root.get('children', ()):
+        item = item_map.get(child.get('id')) or {}
+        if item.get('is_category') and item.get('category') == field:
+            category_node = child
+            break
+    if category_node is None:
+        return ()
+    ans, seen = [], set()
+
+    def walk(node):
+        for child in node.get('children', ()):
+            item = item_map.get(child.get('id')) or {}
+            name = item.get('name') or ''
+            if name and not item.get('is_category') and name not in seen:
+                seen.add(name)
+                search_name = item.get('original_name') or name
+                ans.append({
+                    'name': name,
+                    'count': item.get('count'),
+                    'avg_rating': item.get('avg_rating'),
+                    'search_name': search_name,
+                    'search': category_browse_search_expression(field, item),
+                })
+            walk(child)
+
+    walk(category_node)
     return tuple(ans)
 
 

--- a/src/calibre/srv/metadata.py
+++ b/src/calibre/srv/metadata.py
@@ -188,7 +188,7 @@ def get_icon_for_node(node, parent, node_to_tag_map, tag_map, eval_formatter, db
     def name_for_icon(node):
         return node.get('original_name', node.get('name'))
 
-    value_icons = get_gpref('tags_browser_value_icons')
+    value_icons = get_gpref('tags_browser_value_icons') or {}
     val_icon, for_children = value_icons.get(category, {}).get(name_for_icon(node), (None, False))
     if val_icon is None:
         # No specific icon. Walk up the hierarchy checking parents.

--- a/src/calibre/srv/tests/ajax.py
+++ b/src/calibre/srv/tests/ajax.py
@@ -155,6 +155,38 @@ class ContentTest(LibraryBaseTest):
             self.ae(r.status, 400)
     # }}}
 
+    def test_interface_data_browse_fields(self):  # {{{
+        'Test /interface-data browse field data'
+        with self.create_server() as server:
+            conn = server.connect()
+            request = partial(make_request, conn, prefix='')
+
+            r, data = request('/interface-data/books-init?num=1')
+            self.ae(r.status, OK)
+            fields = {x['key']: x for x in data['browse_fields']}
+            for key in 'series authors publisher tags formats rating pubdate'.split():
+                self.assertIn(key, fields)
+            self.ae(fields['#enum']['name'], 'Enum')
+            self.ae(fields['#enum']['kind'], 'category')
+            self.ae(fields['#date']['name'], 'My Date')
+            self.ae(fields['#date']['kind'], 'date')
+
+            r, data = request('/interface-data/browse-field/' + quote('#enum', safe=''))
+            self.ae(r.status, OK)
+            enum_items = {x['name']: x for x in data['items']}
+            self.ae(set(enum_items), {'One', 'Two'})
+            self.ae(enum_items['One']['search'], '#enum:"One"')
+
+            r, data = request('/interface-data/browse-field/' + quote('#date', safe='') + '?date_group=ym')
+            self.ae(r.status, OK)
+            self.ae(data['items'], [{
+                'name': '2011-09',
+                'count': 2,
+                'avg_rating': None,
+                'search': '#date:>=2011-09-01 and #date:<2011-10-01',
+            }])
+    # }}}
+
     def test_srv_restrictions(self):  # {{{
         ' Test that virtual lib. + search restriction works on all end points'
         with self.create_server(auth=True, auth_mode='basic') as server:

--- a/src/calibre/srv/tests/ajax.py
+++ b/src/calibre/srv/tests/ajax.py
@@ -177,6 +177,8 @@ class ContentTest(LibraryBaseTest):
             enum_items = {x['name']: x for x in data['items']}
             self.ae(set(enum_items), {'One', 'Two'})
             self.ae(enum_items['One']['search'], '#enum:"One"')
+            r, data = request('/interface-data/browse-field/_enum')
+            self.ae(r.status, NOT_FOUND)
 
             r, data = request('/interface-data/browse-field/rating')
             self.ae(r.status, OK)

--- a/src/calibre/srv/tests/ajax.py
+++ b/src/calibre/srv/tests/ajax.py
@@ -158,6 +158,7 @@ class ContentTest(LibraryBaseTest):
     def test_interface_data_browse_fields(self):  # {{{
         'Test /interface-data browse field data'
         with self.create_server() as server:
+            db = server.handler.router.ctx.library_broker.get(None)
             conn = server.connect()
             request = partial(make_request, conn, prefix='')
 
@@ -177,6 +178,11 @@ class ContentTest(LibraryBaseTest):
             self.ae(set(enum_items), {'One', 'Two'})
             self.ae(enum_items['One']['search'], '#enum:"One"')
 
+            r, data = request('/interface-data/browse-field/rating')
+            self.ae(r.status, OK)
+            rating_items = {x['name']: x for x in data['items']}
+            self.ae(rating_items['★★']['search'], 'rating:2')
+
             r, data = request('/interface-data/browse-field/' + quote('#date', safe='') + '?date_group=ym')
             self.ae(r.status, OK)
             self.ae(data['items'], [{
@@ -185,6 +191,15 @@ class ContentTest(LibraryBaseTest):
                 'avg_rating': None,
                 'search': '#date:>=2011-09-01 and #date:<2011-10-01',
             }])
+
+            db.set_pref('categories_using_hierarchy', ['tags'])
+            db.set_field('tags', {1: ['Fiction.Mystery'], 2: ['Fiction.Romance']})
+            r, data = request('/interface-data/browse-field/tags?partition_method=disable')
+            self.ae(r.status, OK)
+            tag_items = {x['name']: x for x in data['items']}
+            self.ae(set(tag_items), {'Fiction', 'Mystery', 'Romance'})
+            self.ae(tag_items['Mystery']['search_name'], 'Fiction.Mystery')
+            self.ae(tag_items['Mystery']['search'], 'tags:"Fiction.Mystery"')
     # }}}
 
     def test_srv_restrictions(self):  # {{{

--- a/src/pyj/book_list/library_data.pyj
+++ b/src/pyj/book_list/library_data.pyj
@@ -11,7 +11,7 @@ from session import get_interface_data
 from utils import parse_url_params
 
 load_status = {'loading':True, 'ok':False, 'error_html':None, 'current_fetch': None, 'http_error_code': 0}
-library_data = {'metadata':{}, 'previous_book_ids': v'[]', 'force_refresh': False, 'bools_are_tristate': True, 'field_names': {}}
+library_data = {'metadata':{}, 'previous_book_ids': v'[]', 'force_refresh': False, 'bools_are_tristate': True, 'field_names': {}, 'browse_fields': v'[]'}
 
 
 def current_library_id():
@@ -83,7 +83,7 @@ def update_library_data(data):
     if library_data.for_library is not current_library_id():
         library_data.field_names = {}
     library_data.for_library = current_library_id()
-    for key in 'search_result sortable_fields field_metadata metadata virtual_libraries book_display_fields bools_are_tristate book_details_vertical_categories fts_enabled fields_that_support_notes categories_using_hierarchy'.split(' '):
+    for key in 'search_result sortable_fields field_metadata metadata virtual_libraries book_display_fields browse_fields bools_are_tristate book_details_vertical_categories fts_enabled fields_that_support_notes categories_using_hierarchy'.split(' '):
         library_data[key] = data[key]
     sr = library_data.search_result
     if sr:
@@ -92,6 +92,22 @@ def update_library_data(data):
     else:
         last_virtual_library_for.library_id = None
         last_virtual_library_for.vl = None
+    try:
+        refresh_browse_fields = window.cs_refresh_browse_fields
+    except Exception:
+        refresh_browse_fields = None
+    if refresh_browse_fields:
+        refresh_browse_fields()
+
+
+def browse_fields():
+    return library_data.browse_fields or v'[]'
+
+
+def browse_field_for(field):
+    for f in browse_fields():
+        if f.key is field:
+            return f
 
 
 def add_more_books(data):

--- a/src/pyj/book_list/nav_list.pyj
+++ b/src/pyj/book_list/nav_list.pyj
@@ -7,14 +7,14 @@ from gettext import gettext as _
 
 from book_list.globals import get_session_data
 from book_list.item_list import create_item, create_item_list
-from book_list.library_data import field_names_for
+from book_list.library_data import browse_field_for
 from book_list.library_data import cover_url, current_library_id
 from book_list.router import back
 from book_list.top_bar import create_top_bar
 from book_list.ui import set_panel_handler, show_panel
 from book_list.theme import get_color
 from dom import add_extra_css, build_rule, clear, svgicon
-from ajax import ajax, ajax_send
+from ajax import ajax
 from utils import parse_url_params
 from widgets import create_pager_widget, create_button
 
@@ -57,43 +57,12 @@ def sync_cs_list_row_heights(list_root):
 
 
 def title_for_field(field):
-    field = field or ''
-    # Reuse existing msgids so labels are localized across calibre translations
-    def label_prefix(x):
-        x = (x or '').toString()
-        if '：' in x:
-            return x.partition('：')[0]
-        if ':' in x:
-            return x.partition(':')[0]
-        return x
-    publisher_label = label_prefix(_('Publisher: {publisher}') or 'Publisher')
-    pubdate_label = label_prefix(_('Published: {pubdate}') or 'Published')
-    tags_label = (_('Tags') or 'Tags')
-    tag_label = 'Tag' if tags_label is 'Tags' else tags_label
-    m = {
-        'series': _('Series'),
-        'authors': _('Authors'),
-        'publisher': publisher_label,
-        'tags': tag_label,
-        'formats': _('Formats'),
-        'rating': _('Rating'),
-        'pubdate': pubdate_label,
-    }
-    return m[field] or field
+    info = browse_field_for(field)
+    return info?.name or field or ''
 
 
 def subtitle_for_field(field):
-    field = field or ''
-    m = {
-        'series': _('Browse all series'),
-        'authors': _('Browse all authors'),
-        'publisher': _('Browse all publishers'),
-        'tags': _('Browse all tags'),
-        'formats': _('Browse all formats'),
-        'rating': _('Browse by rating'),
-        'pubdate': _('Browse by published date'),
-    }
-    return m[field] or ''
+    return browse_field_for(field)?.description or ''
 
 
 def rating_search_query_from_display_name(label):
@@ -168,6 +137,7 @@ def tags_cache_key():
     return '|'.join([
         current_library_id() or '',
         q.vl or '',
+        q.search or '',
         sd.get('sort_tags_by') + '',
         sd.get('partition_method') + '',
         sd.get('collapse_at') + '',
@@ -179,8 +149,6 @@ def tags_cache_key():
 cached_names = {}
 series_cover_cache = {}
 series_cover_inflight = {}
-pubdate_group_cache = {}
-tag_browser_cache = {}
 
 add_extra_css(def():
     sel = '.cs-nav-list '
@@ -577,10 +545,9 @@ def update_nav_list_url(field, offset, num, query_text=None, replace=True, g=Non
     q = {'field': field, 'offset': str(offset), 'num': str(num)}
     if query_text:
         q.q = query_text
-    if field is 'pubdate':
-        g = g or parse_url_params().g
-        if g:
-            q.g = g
+    g = g or parse_url_params().g
+    if g:
+        q.g = g
     show_panel('nav_list', q, replace=replace)
 
 
@@ -589,11 +556,12 @@ def create_nav_list_panel(container_id):
     clear(container)
     q = parse_url_params()
     field = q.field or ''
+    field_info = browse_field_for(field) or {'kind': 'category'}
     num = clamp(parse_int(q.num, 15), 5, 100)
     offset = max(0, parse_int(q.offset, 0))
     query_text = (q.q or '').toString()
-    group_mode = (q.g or 'y').toString()  # for pubdate: 'y' (year) or 'ym' (year-month)
-    if field is 'pubdate':
+    group_mode = (q.g or 'y').toString()
+    if field_info.kind is 'date':
         query_text = ''
     # Tags panel: render all tags progressively on one page (no paging)
     visible_tags = 50
@@ -614,7 +582,7 @@ def create_nav_list_panel(container_id):
     )
     body.appendChild(E.div(top_pager_widget.container, style='margin: 0 0.75rem'))
     status = top_pager_widget.count_msg
-    if field is not 'pubdate':
+    if field_info.kind is not 'date':
         search_inp = E.input(
             type='search',
             placeholder=_('Filter…'),
@@ -635,8 +603,7 @@ def create_nav_list_panel(container_id):
         top_pager_widget.middle_row.appendChild(apply_btn)
 
 
-    if field is 'pubdate':
-        # Grouping toggle for Published date panel
+    if field_info.kind is 'date':
         group_toggle = E.div(style='display:flex; gap:0.5rem; align-items:center; flex-wrap:wrap')
         group_toggle.appendChild(E.span(_('Group:'), style='opacity:0.75'))
         seg = E.div(class_='cs-toggle')
@@ -699,127 +666,7 @@ def create_nav_list_panel(container_id):
                 ans.push(x)
         return ans
 
-    def to_ymd(val):
-        # Accept ISO-ish strings, return 'YYYY-MM-DD' or ''
-        if not val:
-            return ''
-        s = (val + '').strip()
-        if s.length >= 10 and s[4] is '-' and s[7] is '-':
-            return s.slice(0, 10)
-        # Some values might be 'YYYY-MM' or 'YYYY'
-        if s.length >= 7 and s[4] is '-' and s.length == 7:
-            return s + '-01'
-        if s.length == 4:
-            return s + '-01-01'
-        return ''
-
-    def aggregate_pubdate_groups_from_metadata(meta_map, counts_y, counts_ym):
-        # meta_map: {book_id: metadata}
-        if not meta_map:
-            return
-        for bid in Object.keys(meta_map):
-            mi = meta_map[bid]
-            if not mi:
-                continue
-            ymd = to_ymd(mi.pubdate)
-            if not ymd:
-                continue
-            y = ymd.slice(0, 4)
-            ym = ymd.slice(0, 7)
-            counts_y[y] = (counts_y[y] or 0) + 1
-            counts_ym[ym] = (counts_ym[ym] or 0) + 1
-
-
-    def fetch_pubdate_groups(proceed):
-        # Use interface-data/more-books to iterate through all matching books and
-        # aggregate pubdate groups client-side. Works with the shipped Calibre.app backend.
-        ck = (current_library_id() or '') + '|' + (parse_url_params().vl or '') + '|' + (parse_url_params().search or '')
-        cached = pubdate_group_cache[ck]
-        if cached:
-            proceed(True, cached)
-            return
-
-        counts_y = {}
-        counts_ym = {}
-        offset0 = 0
-        page_size = 200
-        total = None
-
-        # Build a query payload similar to book list pagination
-        q = parse_url_params()
-        searchq = q.search or ''
-        vlq = q.vl or ''
-        # We don't care about sort for aggregation, but backend expects it
-        sort_field = 'timestamp'
-        sort_order = 'desc'
-
-        def step():
-            nonlocal offset0, total
-            payload = {
-                'query': searchq,
-                'sort': sort_field,
-                'sort_order': sort_order,
-                'vl': vlq,
-                'offset': offset0,
-            }
-            def done(end_type, xhr, ev):
-                nonlocal offset0, total
-                if end_type is not 'load':
-                    if end_type is not 'abort':
-                        proceed(False, xhr.error_html)
-                    return
-                try:
-                    data = JSON.parse(xhr.responseText)
-                except Exception:
-                    proceed(False, 'Invalid JSON from server')
-                    return
-                sr = data.search_result or v'{}'
-                if total is None:
-                    total = sr.total_num or 0
-                aggregate_pubdate_groups_from_metadata(data.metadata, counts_y, counts_ym)
-                got = (sr.book_ids.length or 0) if sr.book_ids else 0
-                offset0 += got
-                if got <= 0 or offset0 >= total:
-                    labels_y = Object.keys(counts_y).sort().reverse()
-                    labels_ym = Object.keys(counts_ym).sort().reverse()
-                    res = {'y': {'labels': labels_y, 'counts': counts_y}, 'ym': {'labels': labels_ym, 'counts': counts_ym}}
-                    pubdate_group_cache[ck] = res
-                    proceed(True, res)
-                else:
-                    step()
-
-            ajax_send('interface-data/more-books', payload, done,
-                      query={'library_id': current_library_id(), 'num': str(page_size)} )
-        step()
-
-    def next_month(y, m):
-        y = int(y); m = int(m)
-        m += 1
-        if m > 12:
-            m = 1
-            y += 1
-        mm = ('0' + str(m)) if m < 10 else str(m)
-        return str(y), mm
-
-    def pubdate_query_for(label):
-        # label is either 'YYYY' or 'YYYY-MM'
-        s = label or ''
-        if s.length == 4:
-            y = int(s)
-            start = s + '-01-01'
-            end = str(y + 1) + '-01-01'
-        else:
-            y = s.slice(0, 4)
-            m = s.slice(5, 7)
-            start = y + '-' + m + '-01'
-            ny, nm = next_month(y, m)
-            end = ny + '-' + nm + '-01'
-        # Use a range query so it works even if stored as full dates
-        return {'search': f'pubdate:>={start} and pubdate:<{end}'}
-
     series_cover_targets = {}
-
-    TAG_BROWSER_FIELDS = v"['tags', 'series', 'authors', 'publisher', 'formats', 'rating']"
 
     def nav_list_rating_count_parts(count, avg_rating):
         sd = get_session_data()
@@ -851,15 +698,15 @@ def create_nav_list_panel(container_id):
                 parts.push(info.text )
         return ' · '.join(parts)
 
-    def fetch_from_tag_browser(field, proceed):
-        ck = tags_cache_key() + '|' + field
-        cached = tag_browser_cache[ck]
-        if cached:
-            proceed(True, cached)
-            return
+    def browse_cache_key():
+        return tags_cache_key() + '|' + field + '|' + group_mode
+
+    def fetch_browse_items(proceed):
         q = parse_url_params()
         sd = get_session_data()
-        query = {'library_id': current_library_id(), 'vl': q.vl or ''}
+        query = {'library_id': current_library_id(), 'vl': q.vl or '', 'date_group': group_mode}
+        if q.search:
+            query.search = q.search
         for k in 'sort_tags_by partition_method collapse_at dont_collapse hide_empty_categories'.split(' '):
             query[k] = sd.get(k) + ''
 
@@ -872,38 +719,9 @@ def create_nav_list_panel(container_id):
             except Exception:
                 proceed(False, 'Invalid JSON from server')
                 return
-            root = data.root or v'{}'
-            item_map = data.item_map or v'{}'
-            category_node = None
-            for child in (root.children or v'[]'):
-                item = item_map[child.id] or v'{}'
-                if item.is_category and item.category is field:
-                    category_node = child
-                    break
-            if not category_node:
-                tag_browser_cache[ck] = v'[]'
-                proceed(True, v'[]')
-                return
+            proceed(True, data.items or v'[]')
 
-            items = []
-            seen = {}
-
-            def walk(node):
-                for ch in (node.children or v'[]'):
-                    item = item_map[ch.id] or v'{}'
-                    name = (item.name or '') + ''
-                    if (not item.is_category) and name and (not seen[name]):
-                        seen[name] = True
-                        search_name = (item.original_name or name) + ''
-                        items.push({'name': name, 'count': item.count, 'avg_rating': item.avg_rating, 'search_name': search_name})
-                    if ch.children and ch.children.length:
-                        walk(ch)
-
-            walk(category_node)
-            tag_browser_cache[ck] = items
-            proceed(True, items)
-
-        ajax('interface-data/tag-browser', done, query=query, bypass_cache=False).send()
+        ajax(f'interface-data/browse-field/{encodeURIComponent(field)}', done, query=query, bypass_cache=False).send()
 
     def ensure_series_covers(series_name, target_div):
         if not series_name:
@@ -974,22 +792,6 @@ def create_nav_list_panel(container_id):
     def render_page(data):
         set_loading(False)
         raw = data or v'[]'
-        # Special handling for Published date: derive group labels from raw date values
-        if field is 'pubdate':
-            yset = {}
-            ymset = {}
-            for v in raw:
-                ymd = to_ymd(v)
-                if not ymd:
-                    continue
-                y = ymd.slice(0, 4)
-                ym = ymd.slice(0, 7)
-                yset[y] = True
-                ymset[ym] = True
-            labels = Object.keys(ymset) if group_mode is 'ym' else Object.keys(yset)
-            # Sort descending so newest first
-            labels.sort().reverse()
-            raw = labels
         items = [to_item(x) for x in raw]
         items = filtered(items)
         total = items.length or 0
@@ -1020,10 +822,11 @@ def create_nav_list_panel(container_id):
                 inner = E.span(label)
                 if meta:
                     inner = E.span(E.span(label), E.span(' ' + meta, class_='cs-tag-meta'))
+                search_query = {'search': it.search or make_search(field, it.search_name or label).search}
                 bubbles.appendChild(E.a(
                     href='#',
                     class_='cs-tag-bubble',
-                    onclick=make_action(make_search(field, it.search_name or label)),
+                    onclick=make_action(search_query),
                     title=label,
                     inner
                 ))
@@ -1066,32 +869,26 @@ def create_nav_list_panel(container_id):
                 continue
             label = it.name + ''
             search_val = it.search_name or label
+            search_query = {'search': it.search or make_search(field, search_val).search}
             meta = nav_list_rating_count_parts(it.count, it.avg_rating)
             if field is 'series':
                 series_mode = body.dataset.seriesDisplay or 'stack'
                 if series_mode is 'list':
-                    list_items.push(create_item(label, action=make_action(make_search(field, search_val)), nav_list_meta=meta))
+                    list_items.push(create_item(label, action=make_action(search_query), nav_list_meta=meta))
                 else:
                     covers = E.div(class_='cs-series-stack-covers')
                     row = E.div(class_='cs-series-stack-row', E.div(covers), E.div(label, class_='cs-series-stack-name'))
                     row.dataset.seriesName = label
-                    list_items.push(create_item(row, action=make_action(make_search(field, search_val)), nav_list_meta=meta))
+                    list_items.push(create_item(row, action=make_action(search_query), nav_list_meta=meta))
             elif field is 'rating':
                 # Use server-provided display name (tag-browser item.name); do not parse as int — names are localized.
-                list_items.push(create_item(label, action=make_action(make_search(field, search_val)), nav_list_meta=meta))
-            elif field is 'pubdate':
-                # label is 'YYYY' or 'YYYY-MM'
-                list_items.push(create_item(label, action=make_action(pubdate_query_for(label))))
+                list_items.push(create_item(label, action=make_action(search_query), nav_list_meta=meta))
             else:
-                list_items.push(create_item(label, action=make_action(make_search(field, search_val)), nav_list_meta=meta))
+                list_items.push(create_item(label, action=make_action(search_query), nav_list_meta=meta))
         subtitle = subtitle_for_field(field)
-        if field is 'authors' or field is 'publisher' or field is 'series' or field is 'formats' or field is 'rating' or field is 'pubdate':
-            nav_subtitle.textContent = subtitle or ''
-            nav_subtitle.style.display = 'block' if subtitle else 'none'
-            create_item_list(list_container, list_items)
-        else:
-            nav_subtitle.style.display = 'none'
-            create_item_list(list_container, list_items, subtitle)
+        nav_subtitle.textContent = subtitle or ''
+        nav_subtitle.style.display = 'block' if subtitle else 'none'
+        create_item_list(list_container, list_items)
 
         def flush_row_heights():
             sync_cs_list_row_heights(list_container)
@@ -1122,7 +919,7 @@ def create_nav_list_panel(container_id):
         bottom_pager.appendChild(bot_widget.container)
         bottom_pager.style.display = ''
 
-    def render(ok, fieldname, payload):
+    def render(ok, payload):
         set_loading(False)
         if not ok:
             clear(list_container)
@@ -1131,31 +928,14 @@ def create_nav_list_panel(container_id):
             return
         # Update without flashing: create_item_list will clear content itself
         names = payload or v'[]'
-        cached_names[field] = names
+        cached_names[browse_cache_key()] = names
         render_page(names)
 
-    if field is 'pubdate':
-        set_loading(True)
-        fetch_pubdate_groups(def(ok, data):
-            if not ok:
-                render(False, field, data)
-                return
-            grp = data[group_mode] or v'{}'
-            render_page(grp.labels or v'[]')
-        )
+    cached = cached_names[browse_cache_key()]
+    if cached:
+        render_page(cached)
     else:
-        if field in TAG_BROWSER_FIELDS:
-            if cached_names[field]:
-                render_page(cached_names[field])
-            else:
-                set_loading(True)
-                fetch_from_tag_browser(field, def(ok, payload):
-                    render(ok, field, payload)
-                )
-        elif cached_names[field]:
-            render_page(cached_names[field])
-        else:
-            set_loading(True)
-            field_names_for(field, render)
+        set_loading(True)
+        fetch_browse_items(render)
 
 set_panel_handler('nav_list', create_nav_list_panel)

--- a/src/pyj/book_list/sidebar.pyj
+++ b/src/pyj/book_list/sidebar.pyj
@@ -8,6 +8,7 @@ from gettext import gettext as _
 
 from book_list.router import home
 from book_list.globals import get_session_data
+from book_list.library_data import browse_fields
 from book_list.ui import show_panel
 from book_list.custom_categories import (
     add_custom_category, custom_category_nav_initial, get_custom_categories,
@@ -116,36 +117,26 @@ def create_sidebar():
         return t
 
     section_elems = {}
-    section_elems.series = nav_section(_('Series'), 'series', _('Browse all series'), icon='book')
-    section_elems.authors = nav_section(_('Authors'), 'authors', _('Browse all authors'), icon='user')
-    # Reuse existing msgids so labels are localized across calibre translations.
-    # Some translations use full-width colon '：' and include placeholders, so
-    # we take only the prefix before the colon.
-    def label_prefix(x):
-        x = (x or '').toString()
-        if '：' in x:
-            return x.partition('：')[0]
-        if ':' in x:
-            return x.partition(':')[0]
-        return x
 
-    publisher_label = label_prefix(_('Publisher: {publisher}') or 'Publisher')
-    pubdate_label = label_prefix(_('Published: {pubdate}') or 'Published')
-    tags_label = (_('Tags') or 'Tags')
-    tag_label = 'Tag' if tags_label is 'Tags' else tags_label
+    def render_browse_fields():
+        clear(g2)
+        for k in Object.keys(section_elems):
+            v'delete section_elems[k]'
+        for field in browse_fields():
+            key = (field.key or '') + ''
+            if not key:
+                continue
+            section_elems[key] = nav_section(field.name or key, key, field.description or '', icon=field.icon or 'toc')
+            g2.appendChild(section_elems[key])
+        try:
+            update_active = window.cs_update_sidebar_active
+        except Exception:
+            update_active = None
+        if update_active:
+            update_active()
 
-    section_elems.publisher = nav_section(publisher_label, 'publisher', _('Browse all publishers'), icon='library')
-    section_elems.tags = nav_section(tag_label, 'tags', _('Browse all tags'), icon='tags')
-    section_elems.formats = nav_section(_('Formats'), 'formats', _('Browse all formats'), icon='convert')
-    section_elems.rating = nav_section(_('Rating'), 'rating', _('Browse by rating'), icon='star')
-    section_elems.pubdate = nav_section(pubdate_label, 'pubdate', _('Browse by published date'), icon='date')
-    g2.appendChild(section_elems.series)
-    g2.appendChild(section_elems.authors)
-    g2.appendChild(section_elems.publisher)
-    g2.appendChild(section_elems.tags)
-    g2.appendChild(section_elems.formats)
-    g2.appendChild(section_elems.rating)
-    g2.appendChild(section_elems.pubdate)
+    render_browse_fields()
+    window.cs_refresh_browse_fields = render_browse_fields
     left.appendChild(g2)
 
     left.appendChild(E.div(class_='cs-nav-divider'))
@@ -245,7 +236,7 @@ def create_sidebar():
         clear_active(search_link)
         clear_active(reader_link)
         clear_active(settings_link)
-        for k in ('series', 'authors', 'publisher', 'tags', 'formats', 'rating', 'pubdate'):
+        for k in Object.keys(section_elems):
             clear_active(section_elems[k])
         if active_panel is 'book_list^search':
             search_link.dataset.active = '1'


### PR DESCRIPTION
Adds server-owned browse field data and uses it for the WebUI Browse section.

Custom category and date columns now show up alongside the built-in browse fields.

Tested with rapydscript --only-module srv, test_rs, a focused server test, and local browser smoke.