### PR TITLE
Add browse field settings

### DIFF
--- a/TODO
+++ b/TODO
@@ -3,10 +3,6 @@ a virtual library used to filter the shown books. Calling it Virtual
 library will mean calibre users will be more likely to understand what
 it is.
 
-There should be a way to select which items appear under browse in the sidebar.
-A tab in settings and maybe long tap/right click (contextmenuevent)
-on the category in the side bar to have an option to hide it.
-
 The scrollbars in dark mode have very low contrast
 
 Viewer UI needs to be re styled to match overall server UI

--- a/src/calibre/srv/code.py
+++ b/src/calibre/srv/code.py
@@ -230,8 +230,6 @@ BROWSE_FIELD_DESCRIPTIONS = {
     'pubdate': _('Browse by published date'),
 }
 BROWSE_IGNORED_CATEGORIES = frozenset({'identifiers', 'news', 'search'})
-
-
 def browse_field_kind(key, metadata):
     if metadata is None or metadata.get('kind') != 'field':
         return ''
@@ -390,7 +388,7 @@ def get_library_init_data(ctx, rd, db, num, sorts, orders, vl):
         ans['virtual_libraries'] = db._pref('virtual_libraries', {})
         ans['bools_are_tristate'] = db._pref('bools_are_tristate', True)
         ans['book_display_fields'] = get_field_list(db)
-        ans['browse_fields'] = get_browse_fields(db)
+        ans['browse_field_options'] = ans['browse_fields'] = get_browse_fields(db)
         ans['fts_enabled'] = db.is_fts_enabled()
         ans['book_details_vertical_categories'] = db._pref('book_details_vertical_categories', ())
         ans['fields_that_support_notes'] = tuple(db._field_supports_notes())

--- a/src/calibre/srv/code.py
+++ b/src/calibre/srv/code.py
@@ -14,6 +14,7 @@ from threading import Lock
 from calibre import as_unicode
 from calibre.constants import in_develop_mode
 from calibre.customize.ui import available_input_formats
+from calibre.db.categories import category_display_order
 from calibre.db.view import sanitize_sort_field_name
 from calibre.ebooks.metadata.book.render import resolve_default_author_link
 from calibre.srv.ajax import search_result
@@ -230,6 +231,8 @@ BROWSE_FIELD_DESCRIPTIONS = {
     'pubdate': _('Browse by published date'),
 }
 BROWSE_IGNORED_CATEGORIES = frozenset({'identifiers', 'news', 'search'})
+
+
 def browse_field_kind(key, metadata):
     if metadata is None or metadata.get('kind') != 'field':
         return ''
@@ -240,7 +243,7 @@ def browse_field_kind(key, metadata):
     return ''
 
 
-def browse_field_entry(key, metadata, kind):
+def browse_field_entry(key, metadata, kind, hidden_categories):
     name = metadata.get('name') or key
     return {
         'key': key,
@@ -250,30 +253,32 @@ def browse_field_entry(key, metadata, kind):
         'icon': BROWSE_FIELD_ICONS.get(key) or ('date' if kind == 'date' else 'tags'),
         'is_custom': bool(metadata.get('is_custom')),
         'datatype': metadata.get('datatype') or '',
+        'default_visible': key not in hidden_categories,
     }
 
 
 def browse_field_map(db):
     fm = db.field_metadata
+    hidden_categories = frozenset(db.pref('tag_browser_hidden_categories', set()))
     ans = {}
     for key in BROWSE_FIELD_ORDER:
         metadata = fm.get(key)
         kind = browse_field_kind(key, metadata)
         if kind:
-            ans[key] = browse_field_entry(key, metadata, kind)
+            ans[key] = browse_field_entry(key, metadata, kind, hidden_categories)
     custom_fields = []
     for key, metadata in fm.custom_field_metadata(include_composites=False).items():
         kind = browse_field_kind(key, metadata)
         if kind and key not in ans:
             custom_fields.append((sort_key(metadata.get('name') or key), key, metadata, kind))
     for unused_sort_key, key, metadata, kind in sorted(custom_fields):
-        ans[key] = browse_field_entry(key, metadata, kind)
+        ans[key] = browse_field_entry(key, metadata, kind, hidden_categories)
     return ans
 
 
 def get_browse_fields(db):
     fields = browse_field_map(db)
-    return tuple(fields[key] for key in fields)
+    return tuple(fields[key] for key in category_display_order(db.pref('tag_browser_category_order', ()), tuple(fields)))
 
 
 def escape_search_value(x):
@@ -388,7 +393,7 @@ def get_library_init_data(ctx, rd, db, num, sorts, orders, vl):
         ans['virtual_libraries'] = db._pref('virtual_libraries', {})
         ans['bools_are_tristate'] = db._pref('bools_are_tristate', True)
         ans['book_display_fields'] = get_field_list(db)
-        ans['browse_field_options'] = ans['browse_fields'] = get_browse_fields(db)
+        ans['browse_fields'] = get_browse_fields(db)
         ans['fts_enabled'] = db.is_fts_enabled()
         ans['book_details_vertical_categories'] = db._pref('book_details_vertical_categories', ())
         ans['fields_that_support_notes'] = tuple(db._field_supports_notes())

--- a/src/calibre/srv/tests/ajax.py
+++ b/src/calibre/srv/tests/ajax.py
@@ -159,24 +159,26 @@ class ContentTest(LibraryBaseTest):
         'Test /interface-data browse field data'
         with self.create_server() as server:
             db = server.handler.router.ctx.library_broker.get(None)
+            db.set_pref('tag_browser_category_order', ['tags', 'authors', '#date', 'series', '#enum'])
+            db.set_pref('tag_browser_hidden_categories', ['authors', '#date'])
             conn = server.connect()
             request = partial(make_request, conn, prefix='')
 
             r, data = request('/interface-data/books-init?num=1')
             self.ae(r.status, OK)
+            self.assertNotIn('browse_field_options', data)
+            self.ae([x['key'] for x in data['browse_fields'][:5]], ['tags', 'authors', '#date', 'series', '#enum'])
             fields = {x['key']: x for x in data['browse_fields']}
             for key in 'series authors publisher tags formats rating pubdate'.split():
                 self.assertIn(key, fields)
-            options = {x['key']: x for x in data['browse_field_options']}
-            self.ae(options['#enum']['name'], 'Enum')
-            self.ae(options['#enum']['kind'], 'category')
             self.ae(fields['#enum']['name'], 'Enum')
             self.ae(fields['#enum']['kind'], 'category')
-            self.ae(options['#date']['name'], 'My Date')
-            self.ae(options['#date']['kind'], 'date')
             self.ae(fields['#date']['name'], 'My Date')
             self.ae(fields['#date']['kind'], 'date')
-            self.ae(fields, options)
+            self.ae(fields['authors']['default_visible'], False)
+            self.ae(fields['#date']['default_visible'], False)
+            self.ae(fields['tags']['default_visible'], True)
+            self.ae(fields['#enum']['default_visible'], True)
 
             r, data = request('/interface-data/browse-field/' + quote('#enum', safe=''))
             self.ae(r.status, OK)

--- a/src/calibre/srv/tests/ajax.py
+++ b/src/calibre/srv/tests/ajax.py
@@ -167,10 +167,16 @@ class ContentTest(LibraryBaseTest):
             fields = {x['key']: x for x in data['browse_fields']}
             for key in 'series authors publisher tags formats rating pubdate'.split():
                 self.assertIn(key, fields)
+            options = {x['key']: x for x in data['browse_field_options']}
+            self.ae(options['#enum']['name'], 'Enum')
+            self.ae(options['#enum']['kind'], 'category')
             self.ae(fields['#enum']['name'], 'Enum')
             self.ae(fields['#enum']['kind'], 'category')
+            self.ae(options['#date']['name'], 'My Date')
+            self.ae(options['#date']['kind'], 'date')
             self.ae(fields['#date']['name'], 'My Date')
             self.ae(fields['#date']['kind'], 'date')
+            self.ae(fields, options)
 
             r, data = request('/interface-data/browse-field/' + quote('#enum', safe=''))
             self.ae(r.status, OK)

--- a/src/pyj/book_list/library_data.pyj
+++ b/src/pyj/book_list/library_data.pyj
@@ -96,6 +96,7 @@ def update_library_data(data):
         last_virtual_library_for.library_id = None
         last_virtual_library_for.vl = None
     refresh_browse_fields()
+    refresh_browse_field_settings()
 
 
 def configured_browse_fields():
@@ -133,6 +134,15 @@ def set_browse_fields(field_keys):
 def refresh_browse_fields():
     try:
         refresh = window.cs_refresh_browse_fields
+    except Exception:
+        refresh = None
+    if refresh:
+        refresh()
+
+
+def refresh_browse_field_settings():
+    try:
+        refresh = window.cs_refresh_browse_field_settings
     except Exception:
         refresh = None
     if refresh:

--- a/src/pyj/book_list/library_data.pyj
+++ b/src/pyj/book_list/library_data.pyj
@@ -11,7 +11,7 @@ from session import get_interface_data
 from utils import parse_url_params
 
 load_status = {'loading':True, 'ok':False, 'error_html':None, 'current_fetch': None, 'http_error_code': 0}
-library_data = {'metadata':{}, 'previous_book_ids': v'[]', 'force_refresh': False, 'bools_are_tristate': True, 'field_names': {}, 'browse_field_options': v'[]', 'browse_fields': v'[]'}
+library_data = {'metadata':{}, 'previous_book_ids': v'[]', 'force_refresh': False, 'bools_are_tristate': True, 'field_names': {}, 'available_browse_fields': v'[]', 'browse_fields': v'[]'}
 BROWSE_VISIBLE_FIELDS_SETTING = 'browse_visible_fields'
 
 
@@ -86,7 +86,7 @@ def update_library_data(data):
     library_data.for_library = current_library_id()
     for key in 'search_result sortable_fields field_metadata metadata virtual_libraries book_display_fields bools_are_tristate book_details_vertical_categories fts_enabled fields_that_support_notes categories_using_hierarchy'.split(' '):
         library_data[key] = data[key]
-    library_data.browse_field_options = data.browse_field_options or data.browse_fields or v'[]'
+    library_data.available_browse_fields = data.browse_fields or v'[]'
     update_visible_browse_fields()
     sr = library_data.search_result
     if sr:
@@ -114,9 +114,12 @@ def configured_browse_field_map():
 
 
 def update_visible_browse_fields():
-    options = library_data.browse_field_options or v'[]'
+    fields = library_data.available_browse_fields or v'[]'
     selected = configured_browse_field_map()
-    library_data.browse_fields = options if selected is None else [field for field in options if selected[field.key]]
+    if selected is None:
+        library_data.browse_fields = [field for field in fields if field.default_visible is not False]
+    else:
+        library_data.browse_fields = [field for field in fields if selected[field.key]]
 
 
 def set_browse_fields(field_keys):
@@ -136,12 +139,12 @@ def refresh_browse_fields():
         refresh()
 
 
-def browse_field_options():
+def browse_field_settings():
     ans = v'[]'
     selected = configured_browse_field_map()
-    for field in library_data.browse_field_options or v'[]':
+    for field in library_data.available_browse_fields or v'[]':
         f = Object.assign({}, field)
-        f.enabled = selected is None or bool(selected[f.key])
+        f.enabled = (field.default_visible is not False) if selected is None else bool(selected[f.key])
         ans.push(f)
     return ans
 

--- a/src/pyj/book_list/library_data.pyj
+++ b/src/pyj/book_list/library_data.pyj
@@ -11,7 +11,8 @@ from session import get_interface_data
 from utils import parse_url_params
 
 load_status = {'loading':True, 'ok':False, 'error_html':None, 'current_fetch': None, 'http_error_code': 0}
-library_data = {'metadata':{}, 'previous_book_ids': v'[]', 'force_refresh': False, 'bools_are_tristate': True, 'field_names': {}, 'browse_fields': v'[]'}
+library_data = {'metadata':{}, 'previous_book_ids': v'[]', 'force_refresh': False, 'bools_are_tristate': True, 'field_names': {}, 'browse_field_options': v'[]', 'browse_fields': v'[]'}
+BROWSE_VISIBLE_FIELDS_SETTING = 'browse_visible_fields'
 
 
 def current_library_id():
@@ -83,8 +84,10 @@ def update_library_data(data):
     if library_data.for_library is not current_library_id():
         library_data.field_names = {}
     library_data.for_library = current_library_id()
-    for key in 'search_result sortable_fields field_metadata metadata virtual_libraries book_display_fields browse_fields bools_are_tristate book_details_vertical_categories fts_enabled fields_that_support_notes categories_using_hierarchy'.split(' '):
+    for key in 'search_result sortable_fields field_metadata metadata virtual_libraries book_display_fields bools_are_tristate book_details_vertical_categories fts_enabled fields_that_support_notes categories_using_hierarchy'.split(' '):
         library_data[key] = data[key]
+    library_data.browse_field_options = data.browse_field_options or data.browse_fields or v'[]'
+    update_visible_browse_fields()
     sr = library_data.search_result
     if sr:
         last_virtual_library_for.library_id = sr.library_id
@@ -92,12 +95,55 @@ def update_library_data(data):
     else:
         last_virtual_library_for.library_id = None
         last_virtual_library_for.vl = None
+    refresh_browse_fields()
+
+
+def configured_browse_fields():
+    by_library = get_session_data().get(BROWSE_VISIBLE_FIELDS_SETTING) or {}
+    return by_library[current_library_id()]
+
+
+def configured_browse_field_map():
+    configured = configured_browse_fields()
+    if not Array.isArray(configured):
+        return None
+    ans = {}
+    for key in configured:
+        ans[key] = True
+    return ans
+
+
+def update_visible_browse_fields():
+    options = library_data.browse_field_options or v'[]'
+    selected = configured_browse_field_map()
+    library_data.browse_fields = options if selected is None else [field for field in options if selected[field.key]]
+
+
+def set_browse_fields(field_keys):
+    by_library = get_session_data().get(BROWSE_VISIBLE_FIELDS_SETTING) or {}
+    by_library[current_library_id()] = field_keys
+    get_session_data().set(BROWSE_VISIBLE_FIELDS_SETTING, by_library)
+    update_visible_browse_fields()
+    refresh_browse_fields()
+
+
+def refresh_browse_fields():
     try:
-        refresh_browse_fields = window.cs_refresh_browse_fields
+        refresh = window.cs_refresh_browse_fields
     except Exception:
-        refresh_browse_fields = None
-    if refresh_browse_fields:
-        refresh_browse_fields()
+        refresh = None
+    if refresh:
+        refresh()
+
+
+def browse_field_options():
+    ans = v'[]'
+    selected = configured_browse_field_map()
+    for field in library_data.browse_field_options or v'[]':
+        f = Object.assign({}, field)
+        f.enabled = selected is None or bool(selected[f.key])
+        ans.push(f)
+    return ans
 
 
 def browse_fields():

--- a/src/pyj/book_list/main.pyj
+++ b/src/pyj/book_list/main.pyj
@@ -101,10 +101,10 @@ def install_data_and_init_ui(raw_data):
     data = JSON.parse(raw_data)
     update_interface_data(data)
     update_recently_read_by_user(data.recently_read_by_user)
-    update_library_data(data)
     interface_data = get_interface_data()
     sd = UserSessionData(interface_data.username, interface_data.user_session_data)
     set_session_data(sd)
+    update_library_data(data)
     if data.translations?:
         get_translations(data.translations)
     init_ui()

--- a/src/pyj/book_list/ui_settings.pyj
+++ b/src/pyj/book_list/ui_settings.pyj
@@ -65,6 +65,11 @@ add_extra_css(def():
     # Prefer shared cs-prefs spacing; keep help a little softer.
     style += build_rule(sel + '.help', opacity='0.75')
     style += build_rule('.cs-ui-settings.cs-prefs .help', display='block')
+    style += build_rule(sel + '.browse-intro',
+        margin='0 0 0.85rem 0',
+        opacity='0.8',
+        overflow_wrap='anywhere',
+    )
     # Tabs widget
     style += build_rule(sel + '.cs-tabs',
         width='100%',
@@ -226,11 +231,19 @@ def save_browse_fields(container, ev):
 
 
 def create_browse_fields_widget(container):
+    def refresh():
+        if container.isConnected:
+            create_browse_fields_widget(container)
+        else:
+            window.cs_refresh_browse_field_settings = None
+
+    window.cs_refresh_browse_field_settings = refresh
     clear(container)
     try:
         container.classList.add('cs-prefs')
     except Exception:
         pass
+    container.appendChild(E.div(_('Control which categories are visible in the sidebar.'), class_='browse-intro'))
     outer = E.div(class_='list')
     container.appendChild(outer)
 
@@ -238,10 +251,8 @@ def create_browse_fields_widget(container):
     for field in browse_field_settings():
         found = True
         div = E.div(
-            title=field.description,
             class_='item',
             E.div(class_='item-main'),
-            E.div(field.description or '', class_='help')
         )
         control = E.label(
             style='cursor: pointer',

--- a/src/pyj/book_list/ui_settings.pyj
+++ b/src/pyj/book_list/ui_settings.pyj
@@ -2,10 +2,11 @@
 # License: GPL v3 Copyright: 2026
 from __python__ import hash_literals, bound_methods
 
+from dom import add_extra_css, build_rule, clear
 from elementmaker import E
 from gettext import gettext as _
-from dom import add_extra_css, build_rule
 
+from book_list.library_data import browse_field_options, set_browse_fields
 from book_list.prefs import create_prefs_widget
 from book_list.search import get_prefs as get_tb_prefs
 from book_list.theme import apply_book_list_theme
@@ -76,6 +77,8 @@ add_extra_css(def():
         gap='0',
         border_bottom='var(--calibre-border-style)',
         margin_bottom='1rem',
+        max_width='100%',
+        overflow_x='auto',
     )
     style += build_rule(sel + '[role="tab"]',
         background='none',
@@ -94,6 +97,14 @@ add_extra_css(def():
         user_select='none',
         white_space='nowrap',
     )
+    style += r'''
+@media (max-width: 520px) {
+  .cs-ui-settings [role="tab"] {
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
+  }
+}
+'''
     style += build_rule(sel + '[role="tabpanel"]',
         min_width='0',
         width='100%',
@@ -109,6 +120,7 @@ add_extra_css(def():
 def create_tabs_widget(root):
     # --- Tabs widget ---
     tab_interface_id = 'cs-ui-tab-panel-interface'
+    tab_browse_id = 'cs-ui-tab-panel-browse'
     tab_tagbrowser_id = 'cs-ui-tab-panel-tagbrowser'
 
     tab_interface_btn = E.button(
@@ -127,24 +139,39 @@ def create_tabs_widget(root):
         tabindex='-1',
         title=_('Customise how the Tag browser (accessible via the search button) behaves'),
     )
+    tab_browse_btn = E.button(
+        _('Browse'),
+        role='tab',
+        aria_selected='false',
+        aria_controls=tab_browse_id,
+        tabindex='-1',
+        title=_('Choose fields to show in the Browse section'),
+    )
 
     tablist = E.div(role='tablist', aria_label=_('Settings sections'))
     tablist.appendChild(tab_interface_btn)
+    tablist.appendChild(tab_browse_btn)
     tablist.appendChild(tab_tagbrowser_btn)
 
     panel_interface = E.div(
         id=tab_interface_id,
         role='tabpanel',
     )
+    panel_browse = E.div(
+        id=tab_browse_id,
+        role='tabpanel',
+    )
     panel_tagbrowser = E.div(
         id=tab_tagbrowser_id,
         role='tabpanel',
     )
+    panel_browse.setAttribute('hidden', '')
     panel_tagbrowser.setAttribute('hidden', '')
 
     tabs_widget = E.div(class_='cs-tabs')
     tabs_widget.appendChild(tablist)
     tabs_widget.appendChild(panel_interface)
+    tabs_widget.appendChild(panel_browse)
     tabs_widget.appendChild(panel_tagbrowser)
     root.appendChild(tabs_widget)
 
@@ -159,6 +186,7 @@ def create_tabs_widget(root):
         panel.removeAttribute('hidden')
 
     tab_interface_btn.addEventListener('click', def(ev): select_tab(tab_interface_btn, panel_interface);)
+    tab_browse_btn.addEventListener('click', def(ev): select_tab(tab_browse_btn, panel_browse);)
     tab_tagbrowser_btn.addEventListener('click', def(ev): select_tab(tab_tagbrowser_btn, panel_tagbrowser);)
 
     def on_tablist_keydown(ev):
@@ -182,7 +210,59 @@ def create_tabs_widget(root):
             tabs[next_idx].click()
 
     tablist.addEventListener('keydown', on_tablist_keydown)
-    return panel_interface, panel_tagbrowser
+    return panel_interface, panel_browse, panel_tagbrowser
+
+
+def selected_browse_fields(container):
+    ans = v'[]'
+    for checkbox in container.querySelectorAll('input[data-field-key]'):
+        if checkbox.checked:
+            ans.push(checkbox.getAttribute('data-field-key'))
+    return ans
+
+
+def save_browse_fields(container, ev):
+    set_browse_fields(selected_browse_fields(container))
+
+
+def create_browse_fields_widget(container):
+    clear(container)
+    try:
+        container.classList.add('cs-prefs')
+    except Exception:
+        pass
+    outer = E.div(class_='list')
+    container.appendChild(outer)
+
+    found = False
+    for field in browse_field_options():
+        found = True
+        div = E.div(
+            title=field.description,
+            class_='item',
+            E.div(class_='item-main'),
+            E.div(field.description or '', class_='help')
+        )
+        control = E.label(
+            style='cursor: pointer',
+            E.input(type='checkbox', data_field_key=field.key),
+            E.span(field.name or field.key, class_='label'),
+        )
+        control.classList.add('control')
+        div.firstChild.appendChild(control)
+        checkbox = control.firstChild
+        checkbox.checked = bool(field.enabled)
+        checkbox.addEventListener('change', save_browse_fields.bind(None, container))
+        outer.appendChild(div)
+
+    if not found:
+        outer.appendChild(E.div(
+            class_='item',
+            E.div(
+                class_='item-main',
+                E.div(class_='control', E.span(_('No browse fields available'), class_='label'))
+            )
+        ))
 
 
 def get_ui_prefs():
@@ -220,9 +300,11 @@ def init(container_id):
     container.appendChild(E.div(class_='cs-prefs ' + CLASS_NAME))
     root = container.lastChild
     create_top_bar(container, title=_('Settings'), icon='close')
-    panel_interface, panel_tagbrowser = create_tabs_widget(root)
+    panel_interface, panel_browse, panel_tagbrowser = create_tabs_widget(root)
     # --- Interface tab content ---
     create_prefs_widget(panel_interface, get_ui_prefs())
+    # --- Browse tab content ---
+    create_browse_fields_widget(panel_browse)
     # --- Tag browser tab content ---
     create_prefs_widget(panel_tagbrowser, get_tb_prefs())
 

--- a/src/pyj/book_list/ui_settings.pyj
+++ b/src/pyj/book_list/ui_settings.pyj
@@ -6,7 +6,7 @@ from dom import add_extra_css, build_rule, clear
 from elementmaker import E
 from gettext import gettext as _
 
-from book_list.library_data import browse_field_options, set_browse_fields
+from book_list.library_data import browse_field_settings, set_browse_fields
 from book_list.prefs import create_prefs_widget
 from book_list.search import get_prefs as get_tb_prefs
 from book_list.theme import apply_book_list_theme
@@ -235,7 +235,7 @@ def create_browse_fields_widget(container):
     container.appendChild(outer)
 
     found = False
-    for field in browse_field_options():
+    for field in browse_field_settings():
         found = True
         div = E.div(
             title=field.description,

--- a/src/pyj/session.pyj
+++ b/src/pyj/session.pyj
@@ -19,6 +19,7 @@ all_settings = {
     'show_sidebar_in_viewer': {'default': False, 'category': 'book_list'},
     'series_nav_display_mode': {'default': 'stack', 'category': 'book_list', 'is_local': False},
     'custom_categories': {'default': v'[]', 'category': 'book_list', 'is_local': False},
+    'browse_visible_fields': {'default': {}, 'category': 'book_list', 'is_local': False},
     'sort': {'default': 'timestamp.desc', 'category': 'book_list'},  # comma separated list of items of the form: field.order
     'view_mode': {'default': 'cover_grid', 'category': 'book_list'},
     # Cover grid tile width as % of viewport axis (portrait: vw, landscape: vh), integer ~8–45.


### PR DESCRIPTION
Adds a Browse tab to settings so users can choose which browse sections appear in the sidebar.

Visibility is stored in user settings per library. The server still owns the list of valid browse fields.