### PR TITLE
Show custom icons for browse categories

### DIFF
--- a/TODO
+++ b/TODO
@@ -3,9 +3,6 @@ a virtual library used to filter the shown books. Calling it Virtual
 library will mean calibre users will be more likely to understand what
 it is.
 
-The sidebar custom category items should display the custom icon for that
-category if the user has set an icon for the category.
-
 The scrollbars in dark mode have very low contrast
 
 Viewer UI needs to be re styled to match overall server UI

--- a/resources/content-server/base.css
+++ b/resources/content-server/base.css
@@ -290,6 +290,12 @@ progress::-moz-progress-bar { background-color: var(--primary-color); }
     text-align: center;
 }
 
+.cs-left-nav a .cs-nav-icon-image {
+    height: 1.35rem;
+    max-width: 1.6rem;
+    object-fit: contain;
+}
+
 .cs-left-nav a .cs-nav-collapsed-initial {
     display: none !important;
     font-size: 1.15rem;

--- a/src/calibre/srv/code.py
+++ b/src/calibre/srv/code.py
@@ -243,7 +243,15 @@ def browse_field_kind(key, metadata):
     return ''
 
 
-def browse_field_entry(key, metadata, kind, hidden_categories):
+def browse_field_custom_icon_url(ctx, key):
+    icon = icon_map().get(key)
+    if icon and icon.startswith('_'):
+        # icon_map() returns custom icon names with the leading _ already URL quoted.
+        return ctx.url_for('/icon', which='') + '/' + icon
+    return ''
+
+
+def browse_field_entry(ctx, key, metadata, kind, hidden_categories):
     name = metadata.get('name') or key
     return {
         'key': key,
@@ -251,13 +259,14 @@ def browse_field_entry(key, metadata, kind, hidden_categories):
         'description': BROWSE_FIELD_DESCRIPTIONS.get(key) or _('Browse {0}').format(name),
         'kind': kind,
         'icon': BROWSE_FIELD_ICONS.get(key) or ('date' if kind == 'date' else 'tags'),
+        'custom_icon_url': browse_field_custom_icon_url(ctx, key),
         'is_custom': bool(metadata.get('is_custom')),
         'datatype': metadata.get('datatype') or '',
         'default_visible': key not in hidden_categories,
     }
 
 
-def browse_field_map(db):
+def browse_field_map(ctx, db):
     fm = db.field_metadata
     hidden_categories = frozenset(db.pref('tag_browser_hidden_categories', set()))
     ans = {}
@@ -265,19 +274,19 @@ def browse_field_map(db):
         metadata = fm.get(key)
         kind = browse_field_kind(key, metadata)
         if kind:
-            ans[key] = browse_field_entry(key, metadata, kind, hidden_categories)
+            ans[key] = browse_field_entry(ctx, key, metadata, kind, hidden_categories)
     custom_fields = []
     for key, metadata in fm.custom_field_metadata(include_composites=False).items():
         kind = browse_field_kind(key, metadata)
         if kind and key not in ans:
             custom_fields.append((sort_key(metadata.get('name') or key), key, metadata, kind))
     for unused_sort_key, key, metadata, kind in sorted(custom_fields):
-        ans[key] = browse_field_entry(key, metadata, kind, hidden_categories)
+        ans[key] = browse_field_entry(ctx, key, metadata, kind, hidden_categories)
     return ans
 
 
-def get_browse_fields(db):
-    fields = browse_field_map(db)
+def get_browse_fields(ctx, db):
+    fields = browse_field_map(ctx, db)
     return tuple(fields[key] for key in category_display_order(db.pref('tag_browser_category_order', ()), tuple(fields)))
 
 
@@ -393,7 +402,7 @@ def get_library_init_data(ctx, rd, db, num, sorts, orders, vl):
         ans['virtual_libraries'] = db._pref('virtual_libraries', {})
         ans['bools_are_tristate'] = db._pref('bools_are_tristate', True)
         ans['book_display_fields'] = get_field_list(db)
-        ans['browse_fields'] = get_browse_fields(db)
+        ans['browse_fields'] = get_browse_fields(ctx, db)
         ans['fts_enabled'] = db.is_fts_enabled()
         ans['book_details_vertical_categories'] = db._pref('book_details_vertical_categories', ())
         ans['fields_that_support_notes'] = tuple(db._field_supports_notes())
@@ -635,7 +644,7 @@ def browse_field(ctx, rd, field):
     Optional: ?library_id=<default library>&vl=&date_group=y
     '''
     db = get_library_data(ctx, rd)[0]
-    fields = browse_field_map(db)
+    fields = browse_field_map(ctx, db)
     field_data = fields.get(field)
     if field_data is None:
         raise HTTPNotFound(f'{field} is not a browse field')

--- a/src/calibre/srv/tests/ajax.py
+++ b/src/calibre/srv/tests/ajax.py
@@ -13,9 +13,11 @@ from http.client import FORBIDDEN, NOT_FOUND, OK
 from io import BytesIO
 from urllib.parse import quote, urlencode
 
+from calibre.constants import config_dir
 from calibre.ebooks.metadata.meta import get_metadata
 from calibre.srv.tests.base import LibraryBaseTest
 from calibre.utils.localization import _
+from calibre.utils.resources import get_image_path as I
 from polyglot.binary import as_base64_bytes
 
 
@@ -158,58 +160,83 @@ class ContentTest(LibraryBaseTest):
     def test_interface_data_browse_fields(self):  # {{{
         'Test /interface-data browse field data'
         with self.create_server() as server:
+            from calibre.gui2 import gprefs
+            from calibre.srv import metadata as srv_metadata
             db = server.handler.router.ctx.library_broker.get(None)
             db.set_pref('tag_browser_category_order', ['tags', 'authors', '#date', 'series', '#enum'])
             db.set_pref('tag_browser_hidden_categories', ['authors', '#date'])
-            conn = server.connect()
-            request = partial(make_request, conn, prefix='')
+            icon_name = 'webui browse field test icon.png'
+            icon_dir = os.path.join(config_dir, 'tb_icons')
+            icon_path = os.path.join(icon_dir, icon_name)
+            old_category_icons = dict(gprefs.get('tags_browser_category_icons', {}))
+            try:
+                os.makedirs(icon_dir, exist_ok=True)
+                with open(I('lt.png'), 'rb') as src, open(icon_path, 'wb') as f:
+                    f.write(src.read())
+                category_icons = dict(old_category_icons)
+                category_icons['#enum'] = icon_name
+                gprefs['tags_browser_category_icons'] = category_icons
+                srv_metadata._icon_map = None
+                conn = server.connect()
+                request = partial(make_request, conn, prefix='')
+                r, data = request('/interface-data/books-init?num=1')
+                self.ae(r.status, OK)
+                self.assertNotIn('browse_field_options', data)
+                self.ae([x['key'] for x in data['browse_fields'][:5]], ['tags', 'authors', '#date', 'series', '#enum'])
+                fields = {x['key']: x for x in data['browse_fields']}
+                for key in 'series authors publisher tags formats rating pubdate'.split():
+                    self.assertIn(key, fields)
+                self.ae(fields['#enum']['name'], 'Enum')
+                self.ae(fields['#enum']['kind'], 'category')
+                self.ae(fields['#enum']['custom_icon_url'], f'/icon/_{quote(icon_name)}')
+                r, icon_data = request(fields['#enum']['custom_icon_url'])
+                self.ae(r.status, OK)
+                self.assertTrue(icon_data)
+                self.ae(fields['#date']['name'], 'My Date')
+                self.ae(fields['#date']['kind'], 'date')
+                self.ae(fields['#date']['custom_icon_url'], '')
+                self.ae(fields['authors']['default_visible'], False)
+                self.ae(fields['#date']['default_visible'], False)
+                self.ae(fields['tags']['default_visible'], True)
+                self.ae(fields['#enum']['default_visible'], True)
 
-            r, data = request('/interface-data/books-init?num=1')
-            self.ae(r.status, OK)
-            self.assertNotIn('browse_field_options', data)
-            self.ae([x['key'] for x in data['browse_fields'][:5]], ['tags', 'authors', '#date', 'series', '#enum'])
-            fields = {x['key']: x for x in data['browse_fields']}
-            for key in 'series authors publisher tags formats rating pubdate'.split():
-                self.assertIn(key, fields)
-            self.ae(fields['#enum']['name'], 'Enum')
-            self.ae(fields['#enum']['kind'], 'category')
-            self.ae(fields['#date']['name'], 'My Date')
-            self.ae(fields['#date']['kind'], 'date')
-            self.ae(fields['authors']['default_visible'], False)
-            self.ae(fields['#date']['default_visible'], False)
-            self.ae(fields['tags']['default_visible'], True)
-            self.ae(fields['#enum']['default_visible'], True)
+                r, data = request('/interface-data/browse-field/' + quote('#enum', safe=''))
+                self.ae(r.status, OK)
+                enum_items = {x['name']: x for x in data['items']}
+                self.ae(set(enum_items), {'One', 'Two'})
+                self.ae(enum_items['One']['search'], '#enum:"One"')
+                r, data = request('/interface-data/browse-field/_enum')
+                self.ae(r.status, NOT_FOUND)
 
-            r, data = request('/interface-data/browse-field/' + quote('#enum', safe=''))
-            self.ae(r.status, OK)
-            enum_items = {x['name']: x for x in data['items']}
-            self.ae(set(enum_items), {'One', 'Two'})
-            self.ae(enum_items['One']['search'], '#enum:"One"')
-            r, data = request('/interface-data/browse-field/_enum')
-            self.ae(r.status, NOT_FOUND)
+                r, data = request('/interface-data/browse-field/rating')
+                self.ae(r.status, OK)
+                rating_items = {x['name']: x for x in data['items']}
+                self.ae(rating_items['★★']['search'], 'rating:2')
 
-            r, data = request('/interface-data/browse-field/rating')
-            self.ae(r.status, OK)
-            rating_items = {x['name']: x for x in data['items']}
-            self.ae(rating_items['★★']['search'], 'rating:2')
+                r, data = request('/interface-data/browse-field/' + quote('#date', safe='') + '?date_group=ym')
+                self.ae(r.status, OK)
+                self.ae(data['items'], [{
+                    'name': '2011-09',
+                    'count': 2,
+                    'avg_rating': None,
+                    'search': '#date:>=2011-09-01 and #date:<2011-10-01',
+                }])
 
-            r, data = request('/interface-data/browse-field/' + quote('#date', safe='') + '?date_group=ym')
-            self.ae(r.status, OK)
-            self.ae(data['items'], [{
-                'name': '2011-09',
-                'count': 2,
-                'avg_rating': None,
-                'search': '#date:>=2011-09-01 and #date:<2011-10-01',
-            }])
-
-            db.set_pref('categories_using_hierarchy', ['tags'])
-            db.set_field('tags', {1: ['Fiction.Mystery'], 2: ['Fiction.Romance']})
-            r, data = request('/interface-data/browse-field/tags?partition_method=disable')
-            self.ae(r.status, OK)
-            tag_items = {x['name']: x for x in data['items']}
-            self.ae(set(tag_items), {'Fiction', 'Mystery', 'Romance'})
-            self.ae(tag_items['Mystery']['search_name'], 'Fiction.Mystery')
-            self.ae(tag_items['Mystery']['search'], 'tags:"Fiction.Mystery"')
+                db.set_pref('categories_using_hierarchy', ['tags'])
+                db.set_field('tags', {1: ['Fiction.Mystery'], 2: ['Fiction.Romance']})
+                r, data = request('/interface-data/browse-field/tags?partition_method=disable')
+                self.ae(r.status, OK)
+                tag_items = {x['name']: x for x in data['items']}
+                self.ae(set(tag_items), {'Fiction', 'Mystery', 'Romance'})
+                self.ae(tag_items['Mystery']['search_name'], 'Fiction.Mystery')
+                self.ae(tag_items['Mystery']['search'], 'tags:"Fiction.Mystery"')
+            finally:
+                gprefs['tags_browser_category_icons'] = old_category_icons
+                srv_metadata._icon_map = None
+                try:
+                    os.remove(icon_path)
+                except OSError:
+                    pass
     # }}}
 
     def test_srv_restrictions(self):  # {{{

--- a/src/pyj/book_list/sidebar.pyj
+++ b/src/pyj/book_list/sidebar.pyj
@@ -23,16 +23,29 @@ def create_sidebar():
     sidebar_width = '240px'
     document.documentElement.style.setProperty('--cs-sidebar-width', sidebar_width)
 
-    def nav_link(label, action, title='', icon=None, icon_emoji=None, chevron=False, collapsed_initial=None):
+    def nav_svg_icon(icon):
+        if icon:
+            return E.span(svgicon(icon), class_='cs-nav-icon')
+        return E.span('', class_='cs-nav-icon')
+
+    def nav_image_icon(icon_url, fallback_icon):
+        img = E.img(src=icon_url, alt='', class_='cs-nav-icon cs-nav-icon-image')
+        img.onerror = def():
+            img.onerror = None
+            if img.parentNode:
+                img.parentNode.replaceChild(nav_svg_icon(fallback_icon), img)
+        return img
+
+    def nav_link(label, action, title='', icon=None, icon_url=None, icon_emoji=None, chevron=False, collapsed_initial=None):
         left = E.span(class_='cs-nav-left')
-        if icon_emoji is not None and (icon_emoji + ''):
+        if icon_url is not None and (icon_url + ''):
+            left.appendChild(nav_image_icon(icon_url, icon))
+        elif icon_emoji is not None and (icon_emoji + ''):
             left.appendChild(E.span(icon_emoji + '', class_='cs-nav-icon cs-nav-icon-emoji'))
         elif collapsed_initial is not None and (collapsed_initial + ''):
             left.appendChild(E.span(collapsed_initial + '', class_='cs-nav-icon cs-nav-collapsed-initial'))
-        elif icon:
-            left.appendChild(E.span(svgicon(icon), class_='cs-nav-icon'))
         else:
-            left.appendChild(E.span('', class_='cs-nav-icon'))
+            left.appendChild(nav_svg_icon(icon))
         left.appendChild(E.span(label, class_='cs-nav-label'))
         a = E.a(left, href='#', title=title)
         if chevron:
@@ -110,10 +123,10 @@ def create_sidebar():
     left.appendChild(E.div(svgicon('toc'), E.span(_('Browse')), class_='cs-nav-group-title'))
     g2 = E.div(class_='cs-nav-group')
 
-    def nav_section(label, field, tooltip='', icon='toc'):
+    def nav_section(label, field, tooltip='', icon='toc', icon_url=''):
         action = def():
             show_panel('nav_list', {'field': field})
-        t = nav_link(label, action, tooltip, icon=icon, chevron=True)
+        t = nav_link(label, action, tooltip, icon=icon, icon_url=icon_url, chevron=True)
         return t
 
     section_elems = {}
@@ -126,7 +139,7 @@ def create_sidebar():
             key = (field.key or '') + ''
             if not key:
                 continue
-            section_elems[key] = nav_section(field.name or key, key, field.description or '', icon=field.icon or 'toc')
+            section_elems[key] = nav_section(field.name or key, key, field.description or '', icon=field.icon or 'toc', icon_url=field.custom_icon_url or '')
             g2.appendChild(section_elems[key])
         try:
             update_active = window.cs_update_sidebar_active


### PR DESCRIPTION
Shows configured tag browser category icons in the WebUI browse sidebar.

The server exposes custom icon URLs as part of browse field data, and the sidebar renders them with the existing fallback icon if image loading fails.

Tested with the focused browse field server test, RapydScript build, and test_rs.
