### PR TITLE
Make pdf-odd-even-offset not affect the page width

### DIFF
--- a/src/calibre/ebooks/pdf/html_writer.py
+++ b/src/calibre/ebooks/pdf/html_writer.py
@@ -1213,11 +1213,21 @@ def convert(opf_path, opts, metadata=None, output_path=None, log=default_log, co
     if opts.pdf_odd_even_offset:
         for page_num in range(1, pdf_doc.page_count() + 1):
             margins = page_margins_map[page_num - 1]
-            mult = -1 if page_num % 2 else 1
-            val = opts.pdf_odd_even_offset
-            if abs(val) < min(margins.left, margins.right):
+            val = abs(opts.pdf_odd_even_offset)
+            if val < min(margins.left, margins.right):
+                mbox = list(pdf_doc.get_page_box('MediaBox', page_num))
                 box = list(pdf_doc.get_page_box('CropBox', page_num))
-                box[0] += val * mult
+                # Expand MediaBox to the right by val
+                mbox[2] += val
+                pdf_doc.set_page_box('MediaBox', page_num, *mbox)
+                # Odd pages: CropBox at left side of expanded MediaBox
+                # Even pages: CropBox at right side of expanded MediaBox
+                if page_num % 2:  # odd
+                    box[0] = mbox[0]
+                    box[2] = mbox[2] - val
+                else:  # even
+                    box[0] = mbox[0] + val
+                    box[2] = mbox[2]
                 pdf_doc.set_page_box('CropBox', page_num, *box)
 
     if cover_data:

--- a/src/calibre/ebooks/pdf/html_writer.py
+++ b/src/calibre/ebooks/pdf/html_writer.py
@@ -1217,17 +1217,12 @@ def convert(opf_path, opts, metadata=None, output_path=None, log=default_log, co
             if val < min(margins.left, margins.right):
                 mbox = list(pdf_doc.get_page_box('MediaBox', page_num))
                 box = list(pdf_doc.get_page_box('CropBox', page_num))
-                # Expand MediaBox to the right by val
-                mbox[2] += val
+                mbox[2] += val  # always expand MediaBox to the right
+                if page_num % 2 == 0:  # even: shift CropBox right
+                    box[0] += val
+                    box[2] += val
+                # odd: CropBox stays put, content appears shifted left
                 pdf_doc.set_page_box('MediaBox', page_num, *mbox)
-                # Odd pages: CropBox at left side of expanded MediaBox
-                # Even pages: CropBox at right side of expanded MediaBox
-                if page_num % 2:  # odd
-                    box[0] = mbox[0]
-                    box[2] = mbox[2] - val
-                else:  # even
-                    box[0] = mbox[0] + val
-                    box[2] = mbox[2]
                 pdf_doc.set_page_box('CropBox', page_num, *box)
 
     if cover_data:


### PR DESCRIPTION
My issue: I'm using calibre to convert an epub book to a print-ready PDF. I tried to use `--pdf-odd-even-offset 10` with ebook-convert CLI in order to shift my PDF content away from the gutter (common operation in order to make the gutter a bit bigger for both even and odd pages). However, when doing that, the page size became smaller: I used `--custom-size 6x9`, but with the odd-even-offset the width became something like 5.86 inch.

My fix: These changes shift the cropbox and mediabox so that the size stays the same.