### PR TITLE
Annotations browser: include custom highlight styles in Restrict to dropdown

### DIFF
--- a/src/calibre/db/backend.py
+++ b/src/calibre/db/backend.py
@@ -2638,10 +2638,30 @@ class DB:
     def all_annotation_styles(self):
         all_styles = [{'kind': 'color', 'which': style} for style in builtin_colors_light.keys()] + \
             [{'kind': 'decoration', 'which': style} for style in builtin_decorations.keys()]
-        # In the future, we could merge in custom styles from the DB.
-        # Under the current schema, this would require scanning all annotations,
-        # so it's excluded for performance at this time.
-        return {style['which']: style for style in all_styles}
+        ans = {style['which']: style for style in all_styles}
+        # Merge in custom highlight styles found in the database.  Custom
+        # styles are stored as JSON inside the annot_data column with
+        # 'type': 'custom' and a 'friendly_name' key.  We scan the DB to
+        # discover them, since they are not part of the built-in set.
+        try:
+            for (raw_annot_data,) in self.execute(
+                "SELECT annot_data FROM annotations"
+                " WHERE json_extract(annot_data, '$.style.type') = 'custom'"
+                " AND json_extract(annot_data, '$.removed') IS NULL"
+            ):
+                try:
+                    style = json.loads(raw_annot_data).get('style')
+                except Exception:
+                    continue
+                if style is not None and isinstance(style, dict):
+                    name = style.get('friendly_name') or style.get('which')
+                    if name and name not in ans:
+                        ans[name] = style
+        except Exception:
+            # Best-effort: if the query fails (e.g. schema mismatch) just
+            # return the built-in styles.
+            pass
+        return ans
 
     def set_annotations_for_book(self, book_id, fmt, annots_list, user_type='local', user='viewer'):
         try:

--- a/src/calibre/gui2/library/annotations.py
+++ b/src/calibre/gui2/library/annotations.py
@@ -870,7 +870,13 @@ class Restrictions(QWidget):
             all_styles = db.all_annotation_styles()
             translate = _
             for style_name, style in all_styles.items():
-                item = QStandardItem(translate(annotation_title(style_name)))
+                # Custom styles store their display name in friendly_name;
+                # built-in styles use annotation_title on the style name.
+                if style.get('type') == 'custom':
+                    label = style.get('friendly_name', style_name)
+                else:
+                    label = annotation_title(style_name)
+                item = QStandardItem(translate(label))
                 item.setData({'type': 'highlight', 'style': style}, Qt.ItemDataRole.UserRole)
                 dec = decoration_for_style(self.palette(), style, self.icon_size, dpr, is_dark)
                 if dec:


### PR DESCRIPTION
The 'Restrict to' dropdown in the Annotations browser only lists built-in highlight presets (Yellow, Green, Blue, Red, Purple, Wavy, Strikeout). Custom highlight presets created by the user are not shown.

## Changes

### 1. `src/calibre/db/backend.py` — `all_annotation_styles()`

Scan the database for annotations whose style has `type='custom'` and merge those style definitions into the returned dictionary alongside the built-in styles. The scan is wrapped in try/except so any DB error falls back gracefully to just built-in styles.

### 2. `src/calibre/gui2/library/annotations.py` — `Restrictions.re_initialize()`

Use `friendly_name` from the style dict as the display label for custom styles, instead of passing the style name through `annotation_title()` which is designed for annotation types, not style names.

## Testing

- Verified that custom highlight styles (e.g. 'orange', 'fuchsia', 'grey') now appear in the 'Restrict to' dropdown alongside the built-in presets.
- Built-in styles continue to work as before.
- Selecting a custom style from the dropdown correctly filters annotations to only those using that style.