### PR TITLE
Refresh saved virtual libraries on library switch

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,7 +1,3 @@
-Switching between libraries does not repopulate the virtual library section of
-the sidebar. A refresh is needed for that. The virtual libraries should be
-repopulated just like the Browse section.
-
 The scrollbars in dark mode have very low contrast
 
 Viewer UI needs to be re styled to match overall server UI

--- a/src/pyj/book_list/library_data.pyj
+++ b/src/pyj/book_list/library_data.pyj
@@ -95,7 +95,7 @@ def update_library_data(data):
     else:
         last_virtual_library_for.library_id = None
         last_virtual_library_for.vl = None
-    refresh_browse_fields()
+    refresh_sidebar_navigation()
     refresh_browse_field_settings()
 
 
@@ -128,12 +128,12 @@ def set_browse_fields(field_keys):
     by_library[current_library_id()] = field_keys
     get_session_data().set(BROWSE_VISIBLE_FIELDS_SETTING, by_library)
     update_visible_browse_fields()
-    refresh_browse_fields()
+    refresh_sidebar_navigation()
 
 
-def refresh_browse_fields():
+def refresh_sidebar_navigation():
     try:
-        refresh = window.cs_refresh_browse_fields
+        refresh = window.cs_refresh_sidebar_navigation
     except Exception:
         refresh = None
     if refresh:

--- a/src/pyj/book_list/sidebar.pyj
+++ b/src/pyj/book_list/sidebar.pyj
@@ -330,15 +330,7 @@ def create_sidebar():
                 continue
             section_elems[key] = nav_section(field.name or key, key, field.description or '', icon=field.icon or 'toc', icon_url=field.custom_icon_url or '')
             g2.appendChild(section_elems[key])
-        try:
-            update_active = window.cs_update_sidebar_active
-        except Exception:
-            update_active = None
-        if update_active:
-            update_active()
 
-    render_browse_fields()
-    window.cs_refresh_browse_fields = render_browse_fields
     left.appendChild(g2)
 
     left.appendChild(E.div(class_='cs-nav-divider'))
@@ -346,6 +338,7 @@ def create_sidebar():
     # Group: virtual libraries
     left.appendChild(E.div(svgicon('star'), E.span(_('Virtual libraries')), class_='cs-nav-group-title'))
     saved_virtual_libraries_group = E.div(class_='cs-nav-group')
+    saved_virtual_libraries_library_id = None
     left.appendChild(saved_virtual_libraries_group)
 
     left.appendChild(E.div(class_='cs-nav-divider'))
@@ -398,8 +391,11 @@ def create_sidebar():
         )
 
     def render_saved_virtual_libraries():
+        nonlocal saved_virtual_libraries_library_id
+        library_id = (current_library_id() or '') + ''
+        saved_virtual_libraries_library_id = library_id
         clear(saved_virtual_libraries_group)
-        for item in get_saved_virtual_libraries(current_library_id()):
+        for item in get_saved_virtual_libraries(library_id):
             name = (item.name or '') + ''
             search_expr = (item.search or '') + ''
             icon_name = (item.icon or DEFAULT_SAVED_VIRTUAL_LIBRARY_ICON) + ''
@@ -427,6 +423,10 @@ def create_sidebar():
         add_link = nav_link(_('New virtual library'), create_saved_virtual_library, _('Create a new virtual library'), icon='plus')
         saved_virtual_libraries_group.appendChild(add_link)
 
+    def sync_saved_virtual_libraries():
+        if saved_virtual_libraries_library_id is not ((current_library_id() or '') + ''):
+            render_saved_virtual_libraries()
+
     def update_sidebar_visibility(current):
         sd = get_session_data()
         show_in_viewer = sd.get('show_sidebar_in_book_viewer', True)
@@ -436,6 +436,7 @@ def create_sidebar():
     def update_sidebar_active():
         current = parse_url_params()
         update_sidebar_visibility(current)
+        sync_saved_virtual_libraries()
         active_panel = current.panel or ''
         active_field = current.field or ''
         clear_active(home_link)
@@ -455,8 +456,12 @@ def create_sidebar():
         elif not active_panel:
             home_link.dataset.active = '1'
 
+    def render_sidebar_navigation():
+        render_browse_fields()
+        render_saved_virtual_libraries()
+        update_sidebar_active()
+
     window.cs_update_sidebar_active = update_sidebar_active
-    window.cs_refresh_saved_virtual_libraries = render_saved_virtual_libraries
-    render_saved_virtual_libraries()
-    update_sidebar_active()
+    window.cs_refresh_sidebar_navigation = render_sidebar_navigation
+    render_sidebar_navigation()
     return root, left

--- a/src/pyj/book_list/views.pyj
+++ b/src/pyj/book_list/views.pyj
@@ -30,7 +30,7 @@ from book_list.item_list import create_item, create_item_list
 from book_list.library_data import (
     add_more_books, all_virtual_libraries, book_metadata, current_book_ids,
     current_library_id, current_sorted_field, ensure_current_library_data, library_data, load_status,
-    loaded_books_query, thumbnail_cache, url_books_query
+    loaded_books_query, refresh_sidebar_navigation, thumbnail_cache, url_books_query
 )
 from book_list.router import back, home, push_state, update_window_title
 from book_list.search import (
@@ -347,12 +347,7 @@ def save_to_saved_virtual_library():
     def do_save(item):
         if not save_saved_virtual_library(item):
             return False
-        try:
-            cb = window.cs_refresh_saved_virtual_libraries
-        except Exception:
-            cb = None
-        if cb:
-            cb()
+        refresh_sidebar_navigation()
         return True
 
     show_saved_virtual_library_dialog(

--- a/src/pyj/test.pyj
+++ b/src/pyj/test.pyj
@@ -11,6 +11,7 @@ import test_item_list  # noqa: unused-import
 import test_local_books  # noqa: unused-import
 import test_nav_list  # noqa: unused-import
 import test_saved_virtual_libraries  # noqa: unused-import
+import test_library_data  # noqa: unused-import
 import read_book.test_cfi  # noqa: unused-import
 import test_annotations  # noqa: unused-import
 

--- a/src/pyj/test_book_list_helpers.pyj
+++ b/src/pyj/test_book_list_helpers.pyj
@@ -1,0 +1,30 @@
+# vim:fileencoding=utf-8
+# License: GPL v3 Copyright: 2026, Kovid Goyal <kovid at kovidgoyal.net>
+from __python__ import hash_literals
+
+from book_list.globals import get_session_data, set_session_data
+
+
+class FakeSessionData:
+
+    def __init__(self):
+        self.data = {}
+
+    def get(self, key, defval=None):
+        if Object.prototype.hasOwnProperty.call(self.data, key):
+            return self.data[key]
+        return defval
+
+    def set(self, key, value):
+        self.data[key] = value
+        return True
+
+
+def with_empty_session(proceed):
+    previous = get_session_data()
+    sd = FakeSessionData()
+    set_session_data(sd)
+    try:
+        return proceed(sd)
+    finally:
+        set_session_data(previous)

--- a/src/pyj/test_library_data.pyj
+++ b/src/pyj/test_library_data.pyj
@@ -1,0 +1,91 @@
+# vim:fileencoding=utf-8
+# License: GPL v3 Copyright: 2026, Kovid Goyal <kovid at kovidgoyal.net>
+from __python__ import hash_literals
+
+from book_list.library_data import refresh_sidebar_navigation, update_library_data
+from book_list.saved_virtual_libraries import save_saved_virtual_library, saved_virtual_library_item
+from book_list.sidebar import create_sidebar
+from test_book_list_helpers import with_empty_session
+from testing import assert_equal, assert_false, assert_true, test
+from utils import parse_url_params
+
+
+def empty_library_data(library_id='lib-a'):
+    return {
+        'search_result': {'library_id': library_id, 'vl': '', 'query': '', 'sort': '', 'sort_order': ''},
+        'sortable_fields': v'[]',
+        'field_metadata': {},
+        'metadata': {},
+        'virtual_libraries': {},
+        'book_display_fields': v'[]',
+        'bools_are_tristate': True,
+        'book_details_vertical_categories': v'[]',
+        'fts_enabled': False,
+        'fields_that_support_notes': v'[]',
+        'categories_using_hierarchy': v'[]',
+        'browse_fields': v'[]',
+    }
+
+
+@test
+def sidebar_navigation_refresh_contract():
+    calls = {'count': 0}
+    previous = window.cs_refresh_sidebar_navigation
+
+    def refresh():
+        calls.count += 1
+
+    try:
+        window.cs_refresh_sidebar_navigation = refresh
+        refresh_sidebar_navigation()
+        assert_equal(calls.count, 1)
+    finally:
+        window.cs_refresh_sidebar_navigation = previous
+
+
+@test
+def update_library_data_refreshes_sidebar_navigation():
+    def run(sd):
+        calls = {'count': 0}
+        previous = window.cs_refresh_sidebar_navigation
+
+        def refresh():
+            calls.count += 1
+
+        try:
+            window.cs_refresh_sidebar_navigation = refresh
+            update_library_data(empty_library_data())
+            assert_equal(calls.count, 1)
+        finally:
+            window.cs_refresh_sidebar_navigation = previous
+
+    with_empty_session(run)
+
+
+@test
+def sidebar_refreshes_saved_virtual_libraries_on_url_library_change():
+    def run(sd):
+        save_saved_virtual_library(saved_virtual_library_item('lib-a', 'Library A', 'tags:a'))
+        save_saved_virtual_library(saved_virtual_library_item('lib-b', 'Library B', 'tags:b'))
+        previous_url = window.location.href
+        previous_update_active = window.cs_update_sidebar_active
+        previous_refresh = window.cs_refresh_sidebar_navigation
+        try:
+            window.history.replaceState(None, '', '#library_id=lib-a')
+            parse_url_params.cache = {}
+            root, left = create_sidebar()
+            assert_true(left.textContent.indexOf('Library A') > -1)
+            assert_false(left.textContent.indexOf('Library B') > -1)
+
+            window.history.replaceState(None, '', '#library_id=lib-b')
+            parse_url_params.cache = {}
+            window.cs_update_sidebar_active()
+            assert_true(left.textContent.indexOf('Library B') > -1)
+            assert_false(left.textContent.indexOf('Library A') > -1)
+        finally:
+            window.history.replaceState(None, '', previous_url)
+            parse_url_params.cache = {}
+            window.cs_update_sidebar_active = previous_update_active
+            window.cs_refresh_sidebar_navigation = previous_refresh
+
+    with_empty_session(run)

--- a/src/pyj/test_saved_virtual_libraries.pyj
+++ b/src/pyj/test_saved_virtual_libraries.pyj
@@ -2,35 +2,14 @@
 # License: GPL v3 Copyright: 2026, Kovid Goyal <kovid at kovidgoyal.net>
 from __python__ import hash_literals
 
-from book_list.globals import set_session_data
 from book_list.saved_virtual_libraries import (
     all_saved_virtual_libraries, get_saved_virtual_libraries,
     remove_saved_virtual_library, replace_saved_virtual_library,
     saved_virtual_library_item, saved_virtual_library_query,
     save_saved_virtual_library
 )
+from test_book_list_helpers import with_empty_session
 from testing import assert_equal, test
-
-
-class FakeSessionData:
-
-    def __init__(self):
-        self.data = {}
-
-    def get(self, key, defval=None):
-        if Object.prototype.hasOwnProperty.call(self.data, key):
-            return self.data[key]
-        return defval
-
-    def set(self, key, value):
-        self.data[key] = value
-        return True
-
-
-def use_empty_session():
-    sd = FakeSessionData()
-    set_session_data(sd)
-    return sd
 
 
 @test
@@ -48,49 +27,55 @@ def saved_virtual_library_item_contract():
 
 @test
 def saved_virtual_library_library_scope_and_upsert():
-    use_empty_session()
-    save_saved_virtual_library(saved_virtual_library_item('lib-a', 'Favorites', 'tags:true'))
-    save_saved_virtual_library(saved_virtual_library_item('lib-b', 'Favorites', 'authors:true'))
-    save_saved_virtual_library(saved_virtual_library_item('lib-a', 'Unread', 'read:false'))
-    save_saved_virtual_library(saved_virtual_library_item('lib-a', 'Favorites', 'rating:>=4'))
+    def run(sd):
+        save_saved_virtual_library(saved_virtual_library_item('lib-a', 'Favorites', 'tags:true'))
+        save_saved_virtual_library(saved_virtual_library_item('lib-b', 'Favorites', 'authors:true'))
+        save_saved_virtual_library(saved_virtual_library_item('lib-a', 'Unread', 'read:false'))
+        save_saved_virtual_library(saved_virtual_library_item('lib-a', 'Favorites', 'rating:>=4'))
 
-    lib_a = get_saved_virtual_libraries('lib-a')
-    lib_b = get_saved_virtual_libraries('lib-b')
-    assert_equal(lib_a.length, 2)
-    assert_equal(lib_a[0].name, 'Favorites')
-    assert_equal(lib_a[0].search, 'rating:>=4')
-    assert_equal(lib_a[1].name, 'Unread')
-    assert_equal(lib_b.length, 1)
-    assert_equal(lib_b[0].search, 'authors:true')
-    assert_equal(all_saved_virtual_libraries().length, 3)
+        lib_a = get_saved_virtual_libraries('lib-a')
+        lib_b = get_saved_virtual_libraries('lib-b')
+        assert_equal(lib_a.length, 2)
+        assert_equal(lib_a[0].name, 'Favorites')
+        assert_equal(lib_a[0].search, 'rating:>=4')
+        assert_equal(lib_a[1].name, 'Unread')
+        assert_equal(lib_b.length, 1)
+        assert_equal(lib_b[0].search, 'authors:true')
+        assert_equal(all_saved_virtual_libraries().length, 3)
+
+    with_empty_session(run)
 
 
 @test
 def saved_virtual_library_edit_removes_duplicate_name():
-    use_empty_session()
-    save_saved_virtual_library(saved_virtual_library_item('lib-a', 'Favorites', 'tags:true'))
-    original = saved_virtual_library_item('lib-a', 'Unread', 'read:false')
-    save_saved_virtual_library(original)
+    def run(sd):
+        save_saved_virtual_library(saved_virtual_library_item('lib-a', 'Favorites', 'tags:true'))
+        original = saved_virtual_library_item('lib-a', 'Unread', 'read:false')
+        save_saved_virtual_library(original)
 
-    replacement = saved_virtual_library_item('lib-a', 'Favorites', 'rating:>=4')
-    assert_equal(replace_saved_virtual_library(original, replacement), True)
+        replacement = saved_virtual_library_item('lib-a', 'Favorites', 'rating:>=4')
+        assert_equal(replace_saved_virtual_library(original, replacement), True)
 
-    entries = get_saved_virtual_libraries('lib-a')
-    assert_equal(entries.length, 1)
-    assert_equal(entries[0].name, 'Favorites')
-    assert_equal(entries[0].search, 'rating:>=4')
+        entries = get_saved_virtual_libraries('lib-a')
+        assert_equal(entries.length, 1)
+        assert_equal(entries[0].name, 'Favorites')
+        assert_equal(entries[0].search, 'rating:>=4')
+
+    with_empty_session(run)
 
 
 @test
 def saved_virtual_library_remove_uses_item_key():
-    use_empty_session()
-    target = saved_virtual_library_item('lib-a', 'Favorites', 'tags:true')
-    save_saved_virtual_library(target)
-    save_saved_virtual_library(saved_virtual_library_item('lib-b', 'Favorites', 'authors:true'))
-    assert_equal(remove_saved_virtual_library(target), True)
-    assert_equal(remove_saved_virtual_library(target), False)
-    assert_equal(get_saved_virtual_libraries('lib-a').length, 0)
-    assert_equal(get_saved_virtual_libraries('lib-b').length, 1)
+    def run(sd):
+        target = saved_virtual_library_item('lib-a', 'Favorites', 'tags:true')
+        save_saved_virtual_library(target)
+        save_saved_virtual_library(saved_virtual_library_item('lib-b', 'Favorites', 'authors:true'))
+        assert_equal(remove_saved_virtual_library(target), True)
+        assert_equal(remove_saved_virtual_library(target), False)
+        assert_equal(get_saved_virtual_libraries('lib-a').length, 0)
+        assert_equal(get_saved_virtual_libraries('lib-b').length, 1)
+
+    with_empty_session(run)
 
 
 @test


### PR DESCRIPTION
Refreshes the sidebar through one navigation seam so saved virtual libraries update when the current library changes.

Also covers the library-switch path and removes the completed TODO.

Tested with:
CALIBRE_HEADLESS_PLATFORM=offscreen .venv/bin/python setup.py rapydscript --only-module srv
CALIBRE_HEADLESS_PLATFORM=offscreen .venv/bin/python setup.py test_rs