### PR TITLE
Clean up viewer overlay controls

### DIFF
--- a/src/pyj/read_book/overlay.pyj
+++ b/src/pyj/read_book/overlay.pyj
@@ -367,9 +367,7 @@ class MainOverlay:  # {{{
                 return '{}:{}'.format(date.getHours(), date.getMinutes())
             }
 
-    def show(self, container):
-        self.container_id = container.getAttribute('id')
-        sd = get_session_data()
+    def create_actions(self, sd):
         ac = create_main_overlay_action
         text_ac = create_main_overlay_text_action
 
@@ -532,17 +530,21 @@ class MainOverlay:  # {{{
             if copy_actions.childNodes.length:
                 actions_div.appendChild(copy_actions)
 
-        container.appendChild(E.div(class_=MAIN_OVERLAY_TS_CLASS,  # top section
+        return actions_div
+
+    def create_top_section(self, actions_div):
+        return E.div(class_=MAIN_OVERLAY_TS_CLASS,
             onclick=def (evt):evt.stopPropagation();,
 
-            E.div(  # top row
+            E.div(
                 E.div(self.overlay.view.book?.metadata?.title or _('Unknown'), class_=MAIN_OVERLAY_TITLE_CLASS),
                 E.div(time_formatter.format(Date()), id=timer_id(), class_=MAIN_OVERLAY_TIMER_CLASS),
                 class_=MAIN_OVERLAY_TOP_ROW_CLASS,
             ),
             actions_div,
-        ))
+        )
 
+    def create_footer(self):
         def close_viewer_controls(ev):
             ev.stopPropagation()
             self.overlay.hide_current_panel(ev)
@@ -553,8 +555,14 @@ class MainOverlay:  # {{{
             self.overlay.hide_current_panel(ev)
 
         footer_parts = create_main_overlay_footer(close_viewer_controls, show_viewer_help)
-        container.appendChild(footer_parts.footer)
         render_main_overlay_footer_templates(footer_parts, self.overlay.view.create_template_renderer())
+        return footer_parts.footer
+
+    def show(self, container):
+        self.container_id = container.getAttribute('id')
+        sd = get_session_data()
+        container.appendChild(self.create_top_section(self.create_actions(sd)))
+        container.appendChild(self.create_footer())
 
         self.on_hide()
         self.timer = setInterval(self.update_time, 1000)

--- a/src/pyj/read_book/overlay.pyj
+++ b/src/pyj/read_book/overlay.pyj
@@ -221,6 +221,16 @@ class SyncBook:  # {{{
 # CSS {{{
 MAIN_OVERLAY_TS_CLASS = 'read-book-main-overlay-top-section'
 MAIN_OVERLAY_ACTIONS_CLASS = 'read-book-main-overlay-actions'
+MAIN_OVERLAY_ACTION_ICON_CLASS = 'read-book-main-overlay-action-icon'
+MAIN_OVERLAY_TEXT_ICON_CLASS = 'read-book-main-overlay-text-icon'
+MAIN_OVERLAY_TOP_ROW_CLASS = 'read-book-main-overlay-top-row'
+MAIN_OVERLAY_TITLE_CLASS = 'read-book-main-overlay-title'
+MAIN_OVERLAY_TIMER_CLASS = 'read-book-main-overlay-timer'
+MAIN_OVERLAY_BUTTON_CLASS = 'main-overlay-button'
+MAIN_OVERLAY_FOOTER_CLASS = 'read-book-main-overlay-footer'
+MAIN_OVERLAY_FOOTER_ACTIONS_CLASS = 'read-book-main-overlay-footer-actions'
+MAIN_OVERLAY_FOOTER_SLOT_CLASS = 'read-book-main-overlay-footer-slot'
+MAIN_OVERLAY_ICON_SIZE = '3.5ex'
 
 
 def timer_id():
@@ -231,6 +241,26 @@ def timer_id():
 
 add_extra_css(def():
     style = ''
+    style += build_rule('.' + MAIN_OVERLAY_TS_CLASS,
+                        user_select='none', background_color=get_color('window-background'))
+    style += build_rule('.' + MAIN_OVERLAY_TOP_ROW_CLASS,
+                        display='flex', justify_content='space-between', align_items='baseline',
+                        font_size='smaller', padding='0.5ex 1ex', border_bottom='solid 1px currentColor')
+    style += build_rule('.' + MAIN_OVERLAY_TITLE_CLASS,
+                        max_width='90%', text_overflow='ellipsis', font_weight='bold',
+                        white_space='nowrap', overflow='hidden')
+    style += build_rule('.' + MAIN_OVERLAY_TIMER_CLASS,
+                        max_width='9%', white_space='nowrap', overflow='hidden')
+    style += build_rule('.' + MAIN_OVERLAY_FOOTER_CLASS,
+                        position='fixed', width='100%', bottom='0', display='flex',
+                        justify_content='space-between', align_items='center',
+                        user_select='none', background_color=get_color('window-background'))
+    style += build_rule('.' + MAIN_OVERLAY_FOOTER_ACTIONS_CLASS,
+                        display='flex', justify_content='space-between', align_items='center')
+    style += build_rule('.' + MAIN_OVERLAY_BUTTON_CLASS,
+                        display='flex', align_items='center', cursor='pointer', padding='0.5ex 1rem')
+    style += build_rule('.' + MAIN_OVERLAY_BUTTON_CLASS + ' > svg:first-child', margin_right='0.5ex')
+    style += build_rule('.' + MAIN_OVERLAY_FOOTER_SLOT_CLASS, padding='0.5ex 1rem')
     sel = '.' + MAIN_OVERLAY_TS_CLASS + ' > .' + MAIN_OVERLAY_ACTIONS_CLASS + ' '
     style += build_rule(sel, overflow='hidden')
     sel += '> ul '
@@ -238,13 +268,24 @@ add_extra_css(def():
     sel += '> li'
     style += build_rule(sel, border_right='1px solid currentColor', padding='0.5em 1ex', display='flex', flex_wrap='wrap', align_items='center', cursor='pointer')
     style += build_rule(sel + ':last-child', border_right_style='none')
-    style += build_rule(sel + ':hover > *:first-child, .main-overlay-button:hover > *:first-child',
+    style += build_rule(sel + ' > .' + MAIN_OVERLAY_ACTION_ICON_CLASS + ':first-child', margin_right='0.5ex')
+    style += build_rule('.' + MAIN_OVERLAY_TEXT_ICON_CLASS, font_size='175%', font_weight='bold')
+    style += build_rule(sel + ':hover > *:first-child, .' + MAIN_OVERLAY_BUTTON_CLASS + ':hover > *:first-child',
                         color=get_color('window-hover-foreground'))
-    style += build_rule(sel + ':active > *:first-child, .main-overlay-button:active > *:first-child', transform='scale(1.8)')
+    style += build_rule(sel + ':active > *:first-child, .' + MAIN_OVERLAY_BUTTON_CLASS + ':active > *:first-child', transform='scale(1.8)')
     style += f'@media screen and (max-width: 350px) {{ #{timer_id()} {{ display: none; }} }}'
     return style
 )
 # }}}
+
+def create_main_overlay_action(text, tooltip, action, icon, is_text_button=False):
+    if is_text_button:
+        icon_elem = E.span(icon, class_=MAIN_OVERLAY_TEXT_ICON_CLASS)
+    else:
+        icon_elem = svgicon(icon, MAIN_OVERLAY_ICON_SIZE, MAIN_OVERLAY_ICON_SIZE)
+    icon_elem.classList.add(MAIN_OVERLAY_ACTION_ICON_CLASS)
+    return E.li(icon_elem, text, onclick=action, title=tooltip)
+
 
 def simple_overlay_title(title, overlay, container, close_action):
     container.style.backgroundColor = get_color('window-background')
@@ -271,17 +312,8 @@ class MainOverlay:  # {{{
 
     def show(self, container):
         self.container_id = container.getAttribute('id')
-        icon_size = '3.5ex'
         sd = get_session_data()
-
-        def ac(text, tooltip, action, icon, is_text_button):
-            if is_text_button:
-                icon = E.span(icon, style='font-size: 175%; font-weight: bold')
-            else:
-                icon = svgicon(icon, icon_size, icon_size) if icon else ''
-            icon.style.marginRight = '0.5ex'
-
-            return E.li(icon, text, onclick=action, title=tooltip)
+        ac = create_main_overlay_action
 
         sync_action = ac(_('Sync'), _('Get last read position and annotations from the server'), self.overlay.sync_book, 'cloud-download')
         if ui_operations.has_unsynced_changes and ui_operations.has_unsynced_changes():
@@ -441,36 +473,35 @@ class MainOverlay:  # {{{
             if copy_actions.childNodes.length:
                 actions_div.appendChild(copy_actions)
 
-        container.appendChild(set_css(E.div(class_=MAIN_OVERLAY_TS_CLASS,  # top section
+        container.appendChild(E.div(class_=MAIN_OVERLAY_TS_CLASS,  # top section
             onclick=def (evt):evt.stopPropagation();,
 
-            set_css(E.div(  # top row
-                E.div(self.overlay.view.book?.metadata?.title or _('Unknown'), style='max-width: 90%; text-overflow: ellipsis; font-weight: bold; white-space: nowrap; overflow: hidden'),
-                E.div(time_formatter.format(Date()), id=timer_id(), style='max-width: 9%; white-space: nowrap; overflow: hidden'),
-                ),
-                display='flex', justify_content='space-between', align_items='baseline', font_size='smaller', padding='0.5ex 1ex', border_bottom='solid 1px currentColor'
+            E.div(  # top row
+                E.div(self.overlay.view.book?.metadata?.title or _('Unknown'), class_=MAIN_OVERLAY_TITLE_CLASS),
+                E.div(time_formatter.format(Date()), id=timer_id(), class_=MAIN_OVERLAY_TIMER_CLASS),
+                class_=MAIN_OVERLAY_TOP_ROW_CLASS,
             ),
             actions_div,
-        ), user_select='none', background_color=get_color('window-background')))
+        ))
 
         container.appendChild(
             E.div( # bottom bar
-                  style='position: fixed; width: 100%; bottom: 0; display: flex; justify-content: space-between; align-items: center;'
-                        'user-select: none; background-color: {}'.format(get_color('window-background')),
+                class_=MAIN_OVERLAY_FOOTER_CLASS,
                 E.div(
-                    style='display: flex; justify-content: space-between; align-items: center;',
+                    class_=MAIN_OVERLAY_FOOTER_ACTIONS_CLASS,
                     E.div(
-                        style='display: flex; align-items: center; cursor: pointer; padding: 0.5ex 1rem', class_='main-overlay-button',
+                        class_=MAIN_OVERLAY_BUTTON_CLASS,
                         title=_('Close the viewer controls'),
-                        svgicon('close', icon_size, icon_size), '\xa0', _('Close')
+                        svgicon('close', MAIN_OVERLAY_ICON_SIZE, MAIN_OVERLAY_ICON_SIZE), _('Close')
                     ),
                     E.div(
-                        style='display: flex; align-items: center; cursor: pointer; padding: 0.5ex 1rem', class_='main-overlay-button',
-                        svgicon('help', icon_size, icon_size), '\xa0', _('Help'), onclick=def(ev):
+                        class_=MAIN_OVERLAY_BUTTON_CLASS,
+                        svgicon('help', MAIN_OVERLAY_ICON_SIZE, MAIN_OVERLAY_ICON_SIZE), _('Help'), onclick=def(ev):
                             ui_operations.show_help('viewer')
                     )
                 ),
-                E.div(style='padding: 0.5ex 1rem', '\xa0'), E.div(style='padding: 0.5ex 1rem', '\xa0'),
+                E.div(class_=MAIN_OVERLAY_FOOTER_SLOT_CLASS, '\xa0'),
+                E.div(class_=MAIN_OVERLAY_FOOTER_SLOT_CLASS, '\xa0'),
             ),
         )
         renderer = self.overlay.view.create_template_renderer()

--- a/src/pyj/read_book/overlay.pyj
+++ b/src/pyj/read_book/overlay.pyj
@@ -226,10 +226,12 @@ MAIN_OVERLAY_TEXT_ICON_CLASS = 'read-book-main-overlay-text-icon'
 MAIN_OVERLAY_TOP_ROW_CLASS = 'read-book-main-overlay-top-row'
 MAIN_OVERLAY_TITLE_CLASS = 'read-book-main-overlay-title'
 MAIN_OVERLAY_TIMER_CLASS = 'read-book-main-overlay-timer'
-MAIN_OVERLAY_BUTTON_CLASS = 'main-overlay-button'
+MAIN_OVERLAY_FOOTER_ACTION_CLASS = 'read-book-main-overlay-footer-action'
 MAIN_OVERLAY_FOOTER_CLASS = 'read-book-main-overlay-footer'
 MAIN_OVERLAY_FOOTER_ACTIONS_CLASS = 'read-book-main-overlay-footer-actions'
 MAIN_OVERLAY_FOOTER_SLOT_CLASS = 'read-book-main-overlay-footer-slot'
+MAIN_OVERLAY_FOOTER_MIDDLE_SLOT_CLASS = 'read-book-main-overlay-footer-middle-slot'
+MAIN_OVERLAY_FOOTER_RIGHT_SLOT_CLASS = 'read-book-main-overlay-footer-right-slot'
 MAIN_OVERLAY_ICON_SIZE = '3.5ex'
 
 
@@ -257,9 +259,10 @@ add_extra_css(def():
                         user_select='none', background_color=get_color('window-background'))
     style += build_rule('.' + MAIN_OVERLAY_FOOTER_ACTIONS_CLASS,
                         display='flex', justify_content='space-between', align_items='center')
-    style += build_rule('.' + MAIN_OVERLAY_BUTTON_CLASS,
-                        display='flex', align_items='center', cursor='pointer', padding='0.5ex 1rem')
-    style += build_rule('.' + MAIN_OVERLAY_BUTTON_CLASS + ' > svg:first-child', margin_right='0.5ex')
+    style += build_rule('.' + MAIN_OVERLAY_FOOTER_ACTION_CLASS,
+                        display='flex', align_items='center', cursor='pointer', padding='0.5ex 1rem',
+                        border='0', color='inherit', background='transparent', font='inherit')
+    style += build_rule('.' + MAIN_OVERLAY_FOOTER_ACTION_CLASS + ' > svg:first-child', margin_right='0.5ex')
     style += build_rule('.' + MAIN_OVERLAY_FOOTER_SLOT_CLASS, padding='0.5ex 1rem')
     sel = '.' + MAIN_OVERLAY_TS_CLASS + ' > .' + MAIN_OVERLAY_ACTIONS_CLASS + ' '
     style += build_rule(sel, overflow='hidden')
@@ -270,21 +273,55 @@ add_extra_css(def():
     style += build_rule(sel + ':last-child', border_right_style='none')
     style += build_rule(sel + ' > .' + MAIN_OVERLAY_ACTION_ICON_CLASS + ':first-child', margin_right='0.5ex')
     style += build_rule('.' + MAIN_OVERLAY_TEXT_ICON_CLASS, font_size='175%', font_weight='bold')
-    style += build_rule(sel + ':hover > *:first-child, .' + MAIN_OVERLAY_BUTTON_CLASS + ':hover > *:first-child',
+    style += build_rule(sel + ':hover > *:first-child, .' + MAIN_OVERLAY_FOOTER_ACTION_CLASS + ':hover > *:first-child',
                         color=get_color('window-hover-foreground'))
-    style += build_rule(sel + ':active > *:first-child, .' + MAIN_OVERLAY_BUTTON_CLASS + ':active > *:first-child', transform='scale(1.8)')
+    style += build_rule(sel + ':active > *:first-child, .' + MAIN_OVERLAY_FOOTER_ACTION_CLASS + ':active > *:first-child', transform='scale(1.8)')
     style += f'@media screen and (max-width: 350px) {{ #{timer_id()} {{ display: none; }} }}'
     return style
 )
 # }}}
 
-def create_main_overlay_action(text, tooltip, action, icon, is_text_button=False):
-    if is_text_button:
-        icon_elem = E.span(icon, class_=MAIN_OVERLAY_TEXT_ICON_CLASS)
-    else:
-        icon_elem = svgicon(icon, MAIN_OVERLAY_ICON_SIZE, MAIN_OVERLAY_ICON_SIZE)
+def create_main_overlay_action_with_icon(text, tooltip, action, icon_elem):
     icon_elem.classList.add(MAIN_OVERLAY_ACTION_ICON_CLASS)
     return E.li(icon_elem, text, onclick=action, title=tooltip)
+
+
+def create_main_overlay_action(text, tooltip, action, icon):
+    return create_main_overlay_action_with_icon(text, tooltip, action, svgicon(icon, MAIN_OVERLAY_ICON_SIZE, MAIN_OVERLAY_ICON_SIZE))
+
+
+def create_main_overlay_text_action(text, tooltip, action, icon_text):
+    return create_main_overlay_action_with_icon(text, tooltip, action, E.span(icon_text, class_=MAIN_OVERLAY_TEXT_ICON_CLASS))
+
+
+def create_main_overlay_footer_action(icon, text, tooltip, action):
+    return E.button(
+        class_=MAIN_OVERLAY_FOOTER_ACTION_CLASS, title=tooltip, type='button', onclick=action,
+        svgicon(icon, MAIN_OVERLAY_ICON_SIZE, MAIN_OVERLAY_ICON_SIZE), text
+    )
+
+
+def create_main_overlay_footer(close_action, help_action):
+    middle = E.div(class_=' '.join([MAIN_OVERLAY_FOOTER_SLOT_CLASS, MAIN_OVERLAY_FOOTER_MIDDLE_SLOT_CLASS]), '\xa0')
+    right = E.div(class_=' '.join([MAIN_OVERLAY_FOOTER_SLOT_CLASS, MAIN_OVERLAY_FOOTER_RIGHT_SLOT_CLASS]), '\xa0')
+    footer = E.div(
+        class_=MAIN_OVERLAY_FOOTER_CLASS,
+        E.div(
+            class_=MAIN_OVERLAY_FOOTER_ACTIONS_CLASS,
+            create_main_overlay_footer_action('close', _('Close'), _('Close the viewer controls'), close_action),
+            create_main_overlay_footer_action('help', _('Help'), _('Show viewer help'), help_action)
+        ),
+        middle,
+        right,
+    )
+    return {'footer': footer, 'middle_slot': middle, 'right_slot': right}
+
+
+def render_main_overlay_footer_templates(footer_parts, renderer):
+    if not renderer:
+        return
+    renderer(footer_parts.middle_slot, 'controls_footer', 'middle', '')
+    renderer(footer_parts.right_slot, 'controls_footer', 'right', '')
 
 
 def simple_overlay_title(title, overlay, container, close_action):
@@ -314,6 +351,7 @@ class MainOverlay:  # {{{
         self.container_id = container.getAttribute('id')
         sd = get_session_data()
         ac = create_main_overlay_action
+        text_ac = create_main_overlay_text_action
 
         sync_action = ac(_('Sync'), _('Get last read position and annotations from the server'), self.overlay.sync_book, 'cloud-download')
         if ui_operations.has_unsynced_changes and ui_operations.has_unsynced_changes():
@@ -362,7 +400,7 @@ class MainOverlay:  # {{{
             E.ul(highlights_action, bookmarks_action, reading_stats_action),
 
             E.ul(
-                ac(_('Font size'), _('Change text size'), self.overlay.show_font_size_chooser, 'Aa', True),
+                text_ac(_('Font size'), _('Change text size'), self.overlay.show_font_size_chooser, 'Aa'),
                 ac(_('Preferences'), _('Configure the E-book viewer'), self.overlay.show_prefs, 'cogs'),
             ),
 
@@ -484,32 +522,18 @@ class MainOverlay:  # {{{
             actions_div,
         ))
 
-        container.appendChild(
-            E.div( # bottom bar
-                class_=MAIN_OVERLAY_FOOTER_CLASS,
-                E.div(
-                    class_=MAIN_OVERLAY_FOOTER_ACTIONS_CLASS,
-                    E.div(
-                        class_=MAIN_OVERLAY_BUTTON_CLASS,
-                        title=_('Close the viewer controls'),
-                        svgicon('close', MAIN_OVERLAY_ICON_SIZE, MAIN_OVERLAY_ICON_SIZE), _('Close')
-                    ),
-                    E.div(
-                        class_=MAIN_OVERLAY_BUTTON_CLASS,
-                        svgicon('help', MAIN_OVERLAY_ICON_SIZE, MAIN_OVERLAY_ICON_SIZE), _('Help'), onclick=def(ev):
-                            ui_operations.show_help('viewer')
-                    )
-                ),
-                E.div(class_=MAIN_OVERLAY_FOOTER_SLOT_CLASS, '\xa0'),
-                E.div(class_=MAIN_OVERLAY_FOOTER_SLOT_CLASS, '\xa0'),
-            ),
-        )
-        renderer = self.overlay.view.create_template_renderer()
-        if renderer:
-            c = container.lastChild.lastChild
-            b = c.previousSibling
-            renderer(b, 'controls_footer', 'middle', '')
-            renderer(c, 'controls_footer', 'right', '')
+        def close_viewer_controls(ev):
+            ev.stopPropagation()
+            self.overlay.hide_current_panel(ev)
+
+        def show_viewer_help(ev):
+            ev.stopPropagation()
+            ui_operations.show_help('viewer')
+            self.overlay.hide_current_panel(ev)
+
+        footer_parts = create_main_overlay_footer(close_viewer_controls, show_viewer_help)
+        container.appendChild(footer_parts.footer)
+        render_main_overlay_footer_templates(footer_parts, self.overlay.view.create_template_renderer())
 
         self.on_hide()
         self.timer = setInterval(self.update_time, 1000)

--- a/src/pyj/read_book/overlay.pyj
+++ b/src/pyj/read_book/overlay.pyj
@@ -221,6 +221,7 @@ class SyncBook:  # {{{
 # CSS {{{
 MAIN_OVERLAY_TS_CLASS = 'read-book-main-overlay-top-section'
 MAIN_OVERLAY_ACTIONS_CLASS = 'read-book-main-overlay-actions'
+MAIN_OVERLAY_ACTION_CONTROL_CLASS = 'read-book-main-overlay-action-control'
 MAIN_OVERLAY_ACTION_ICON_CLASS = 'read-book-main-overlay-action-icon'
 MAIN_OVERLAY_TEXT_ICON_CLASS = 'read-book-main-overlay-text-icon'
 MAIN_OVERLAY_TOP_ROW_CLASS = 'read-book-main-overlay-top-row'
@@ -243,11 +244,14 @@ def timer_id():
 
 add_extra_css(def():
     style = ''
+    border_style = 'var(--calibre-border-style-subtle, 1px solid ' + get_color('border-subtle') + ')'
+    hover_bg = 'var(--cs-accent-weak, ' + get_color('list-hover-background') + ')'
+    active_bg = 'var(--cs-accent-weak-2, ' + get_color('window-background2') + ')'
     style += build_rule('.' + MAIN_OVERLAY_TS_CLASS,
                         user_select='none', background_color=get_color('window-background'))
     style += build_rule('.' + MAIN_OVERLAY_TOP_ROW_CLASS,
                         display='flex', justify_content='space-between', align_items='baseline',
-                        font_size='smaller', padding='0.5ex 1ex', border_bottom='solid 1px currentColor')
+                        font_size='smaller', padding='0.5ex 1ex', border_bottom=border_style)
     style += build_rule('.' + MAIN_OVERLAY_TITLE_CLASS,
                         max_width='90%', text_overflow='ellipsis', font_weight='bold',
                         white_space='nowrap', overflow='hidden')
@@ -261,33 +265,49 @@ add_extra_css(def():
                         display='flex', justify_content='space-between', align_items='center')
     style += build_rule('.' + MAIN_OVERLAY_FOOTER_ACTION_CLASS,
                         display='flex', align_items='center', cursor='pointer', padding='0.5ex 1rem',
-                        border='0', color='inherit', background='transparent', font='inherit')
+                        appearance='none', margin='0', border='0', color='inherit',
+                        background='transparent', font='inherit')
+    style += build_rule('.' + MAIN_OVERLAY_FOOTER_ACTION_CLASS + ':focus',
+                        outline='1px solid ' + get_color('input-focus-outline-color'))
     style += build_rule('.' + MAIN_OVERLAY_FOOTER_ACTION_CLASS + ' > svg:first-child', margin_right='0.5ex')
     style += build_rule('.' + MAIN_OVERLAY_FOOTER_SLOT_CLASS, padding='0.5ex 1rem')
     sel = '.' + MAIN_OVERLAY_TS_CLASS + ' > .' + MAIN_OVERLAY_ACTIONS_CLASS + ' '
     style += build_rule(sel, overflow='hidden')
     sel += '> ul '
-    style += build_rule(sel, display='flex', list_style='none', border_bottom='1px solid currentColor')
+    style += build_rule(sel, display='flex', list_style='none', border_bottom=border_style)
     sel += '> li'
-    style += build_rule(sel, border_right='1px solid currentColor', padding='0.5em 1ex', display='flex', flex_wrap='wrap', align_items='center', cursor='pointer')
+    style += build_rule(sel, border_right=border_style, display='flex')
     style += build_rule(sel + ':last-child', border_right_style='none')
-    style += build_rule(sel + ' > .' + MAIN_OVERLAY_ACTION_ICON_CLASS + ':first-child', margin_right='0.5ex')
+    action_sel = sel + ' > .' + MAIN_OVERLAY_ACTION_CONTROL_CLASS
+    style += build_rule(action_sel,
+                        display='flex', flex_wrap='wrap', align_items='center', cursor='pointer',
+                        appearance='none', margin='0', padding='0.5em 1ex', border='0',
+                        color='inherit', background='transparent', font='inherit', text_align='left')
+    style += build_rule(action_sel + ':focus',
+                        outline='1px solid ' + get_color('input-focus-outline-color'))
+    style += build_rule(action_sel + ' > .' + MAIN_OVERLAY_ACTION_ICON_CLASS + ':first-child', margin_right='0.5ex')
     style += build_rule('.' + MAIN_OVERLAY_TEXT_ICON_CLASS, font_size='175%', font_weight='bold')
-    style += build_rule(sel + ':hover > *:first-child, .' + MAIN_OVERLAY_FOOTER_ACTION_CLASS + ':hover > *:first-child',
-                        color=get_color('window-hover-foreground'))
-    style += build_rule(sel + ':active > *:first-child, .' + MAIN_OVERLAY_FOOTER_ACTION_CLASS + ':active > *:first-child', transform='scale(1.8)')
+    style += build_rule(action_sel + ':hover, .' + MAIN_OVERLAY_FOOTER_ACTION_CLASS + ':hover',
+                        background_color=hover_bg)
+    style += build_rule(action_sel + ':active, .' + MAIN_OVERLAY_FOOTER_ACTION_CLASS + ':active',
+                        background_color=active_bg)
     style += f'@media screen and (max-width: 350px) {{ #{timer_id()} {{ display: none; }} }}'
     return style
 )
 # }}}
 
-def create_main_overlay_action_with_icon(text, tooltip, action, icon_elem):
+def create_main_overlay_action_with_icon(text, tooltip, action, icon_elem, icon_color=None):
+    if icon_color:
+        icon_elem.style.color = icon_color
     icon_elem.classList.add(MAIN_OVERLAY_ACTION_ICON_CLASS)
-    return E.li(icon_elem, text, onclick=action, title=tooltip)
+    return E.li(E.button(
+        class_=MAIN_OVERLAY_ACTION_CONTROL_CLASS, title=tooltip, type='button', onclick=action,
+        icon_elem, text
+    ))
 
 
-def create_main_overlay_action(text, tooltip, action, icon):
-    return create_main_overlay_action_with_icon(text, tooltip, action, svgicon(icon, MAIN_OVERLAY_ICON_SIZE, MAIN_OVERLAY_ICON_SIZE))
+def create_main_overlay_action(text, tooltip, action, icon, icon_color=None):
+    return create_main_overlay_action_with_icon(text, tooltip, action, svgicon(icon, MAIN_OVERLAY_ICON_SIZE, MAIN_OVERLAY_ICON_SIZE), icon_color)
 
 
 def create_main_overlay_text_action(text, tooltip, action, icon_text):
@@ -353,9 +373,10 @@ class MainOverlay:  # {{{
         ac = create_main_overlay_action
         text_ac = create_main_overlay_text_action
 
-        sync_action = ac(_('Sync'), _('Get last read position and annotations from the server'), self.overlay.sync_book, 'cloud-download')
+        sync_icon_color = None
         if ui_operations.has_unsynced_changes and ui_operations.has_unsynced_changes():
-            sync_action.firstChild.style.color = builtin_color('yellow', is_dark_theme())
+            sync_icon_color = builtin_color('yellow', is_dark_theme())
+        sync_action = ac(_('Sync'), _('Get last read position and annotations from the server'), self.overlay.sync_book, 'cloud-download', sync_icon_color)
         delete_action = ac(_('Delete'), _('Delete this book from local storage'), self.overlay.delete_book, 'trash')
         reload_action = ac(_('Reload'), _('Reload this book from the {}').format( _('computer') if runtime.is_standalone_viewer else _('server')), self.overlay.reload_book, 'refresh')
         back_action = ac(_('Back'), _('Go back'), self.back, 'arrow-left')


### PR DESCRIPTION
Moves viewer overlay action and footer markup behind small helpers, replaces clickable list and footer divs with real buttons, and renders footer templates through explicit slots.

Validated with rapydscript and test_rs.