### PR TITLE
Unify viewer sidebar setting

### DIFF
--- a/src/pyj/book_list/sidebar.pyj
+++ b/src/pyj/book_list/sidebar.pyj
@@ -429,7 +429,7 @@ def create_sidebar():
 
     def update_sidebar_visibility(current):
         sd = get_session_data()
-        show_in_viewer = sd.get('show_sidebar_in_book_viewer', True)
+        show_in_viewer = sd.get('show_sidebar_in_book_viewer')
         mode = (current.mode or 'book_list') if current else 'book_list'
         left.style.display = 'flex' if (mode is not 'read_book' or show_in_viewer) else 'none'
 

--- a/src/pyj/book_list/ui_settings.pyj
+++ b/src/pyj/book_list/ui_settings.pyj
@@ -293,7 +293,7 @@ def get_ui_prefs():
             'onchange': apply_book_list_theme,
         },
         {
-            'name': 'show_sidebar_in_viewer',
+            'name': 'show_sidebar_in_book_viewer',
             'text': _('Show sidebar when reading'),
             'tooltip': _('Show the left navigation sidebar when reading books'),
         },

--- a/src/pyj/session.pyj
+++ b/src/pyj/session.pyj
@@ -16,7 +16,6 @@ all_settings = {
     # auto = follow OS; dark/light = force content-server chrome (book list, sidebar, modals).
     'book_list_color_scheme': {'default': 'auto', 'category': 'book_list', 'is_local': False},
     'ui_highlight_color': {'default': '#437000', 'category': 'book_list', 'is_local': False},
-    'show_sidebar_in_viewer': {'default': False, 'category': 'book_list'},
     'series_nav_display_mode': {'default': 'stack', 'category': 'book_list', 'is_local': False},
     'saved_virtual_libraries': {'default': v'[]', 'category': 'book_list', 'is_local': False},
     'browse_visible_fields': {'default': {}, 'category': 'book_list', 'is_local': False},

--- a/src/pyj/test.pyj
+++ b/src/pyj/test.pyj
@@ -12,6 +12,7 @@ import test_local_books  # noqa: unused-import
 import test_nav_list  # noqa: unused-import
 import test_saved_virtual_libraries  # noqa: unused-import
 import test_library_data  # noqa: unused-import
+import test_sidebar  # noqa: unused-import
 import read_book.test_cfi  # noqa: unused-import
 import test_annotations  # noqa: unused-import
 

--- a/src/pyj/test_library_data.pyj
+++ b/src/pyj/test_library_data.pyj
@@ -5,6 +5,8 @@ from __python__ import hash_literals
 from book_list.library_data import refresh_sidebar_navigation, update_library_data
 from book_list.saved_virtual_libraries import save_saved_virtual_library, saved_virtual_library_item
 from book_list.sidebar import create_sidebar
+from book_list.ui_settings import get_ui_prefs
+from session import session_defaults
 from test_book_list_helpers import with_empty_session
 from testing import assert_equal, assert_false, assert_true, test
 from utils import parse_url_params
@@ -58,6 +60,46 @@ def update_library_data_refreshes_sidebar_navigation():
             assert_equal(calls.count, 1)
         finally:
             window.cs_refresh_sidebar_navigation = previous
+
+    with_empty_session(run)
+
+
+@test
+def viewer_sidebar_setting_contract():
+    names = [x.name for x in get_ui_prefs()]
+    assert_true(names.indexOf('show_sidebar_in_book_viewer') > -1)
+    assert_equal(names.indexOf('show_sidebar_in_viewer'), -1)
+    assert_equal(session_defaults().show_sidebar_in_book_viewer, False)
+    assert_false(Object.prototype.hasOwnProperty.call(session_defaults(), 'show_sidebar_in_viewer'))
+
+
+@test
+def viewer_sidebar_setting_controls_reader_visibility():
+    def run(sd):
+        previous_url = window.location.href
+        previous_update_active = window.cs_update_sidebar_active
+        previous_refresh = window.cs_refresh_sidebar_navigation
+        try:
+            sd.set('show_sidebar_in_book_viewer', False)
+            window.history.replaceState(None, '', '#mode=read_book')
+            parse_url_params.cache = {}
+            root, left = create_sidebar()
+            assert_equal(left.style.display, 'none')
+
+            sd.set('show_sidebar_in_book_viewer', True)
+            window.cs_update_sidebar_active()
+            assert_equal(left.style.display, 'flex')
+
+            sd.set('show_sidebar_in_book_viewer', False)
+            window.history.replaceState(None, '', '#mode=book_list')
+            parse_url_params.cache = {}
+            window.cs_update_sidebar_active()
+            assert_equal(left.style.display, 'flex')
+        finally:
+            window.history.replaceState(None, '', previous_url)
+            parse_url_params.cache = {}
+            window.cs_update_sidebar_active = previous_update_active
+            window.cs_refresh_sidebar_navigation = previous_refresh
 
     with_empty_session(run)
 

--- a/src/pyj/test_library_data.pyj
+++ b/src/pyj/test_library_data.pyj
@@ -5,8 +5,6 @@ from __python__ import hash_literals
 from book_list.library_data import refresh_sidebar_navigation, update_library_data
 from book_list.saved_virtual_libraries import save_saved_virtual_library, saved_virtual_library_item
 from book_list.sidebar import create_sidebar
-from book_list.ui_settings import get_ui_prefs
-from session import session_defaults
 from test_book_list_helpers import with_empty_session
 from testing import assert_equal, assert_false, assert_true, test
 from utils import parse_url_params
@@ -60,46 +58,6 @@ def update_library_data_refreshes_sidebar_navigation():
             assert_equal(calls.count, 1)
         finally:
             window.cs_refresh_sidebar_navigation = previous
-
-    with_empty_session(run)
-
-
-@test
-def viewer_sidebar_setting_contract():
-    names = [x.name for x in get_ui_prefs()]
-    assert_true(names.indexOf('show_sidebar_in_book_viewer') > -1)
-    assert_equal(names.indexOf('show_sidebar_in_viewer'), -1)
-    assert_equal(session_defaults().show_sidebar_in_book_viewer, False)
-    assert_false(Object.prototype.hasOwnProperty.call(session_defaults(), 'show_sidebar_in_viewer'))
-
-
-@test
-def viewer_sidebar_setting_controls_reader_visibility():
-    def run(sd):
-        previous_url = window.location.href
-        previous_update_active = window.cs_update_sidebar_active
-        previous_refresh = window.cs_refresh_sidebar_navigation
-        try:
-            sd.set('show_sidebar_in_book_viewer', False)
-            window.history.replaceState(None, '', '#mode=read_book')
-            parse_url_params.cache = {}
-            root, left = create_sidebar()
-            assert_equal(left.style.display, 'none')
-
-            sd.set('show_sidebar_in_book_viewer', True)
-            window.cs_update_sidebar_active()
-            assert_equal(left.style.display, 'flex')
-
-            sd.set('show_sidebar_in_book_viewer', False)
-            window.history.replaceState(None, '', '#mode=book_list')
-            parse_url_params.cache = {}
-            window.cs_update_sidebar_active()
-            assert_equal(left.style.display, 'flex')
-        finally:
-            window.history.replaceState(None, '', previous_url)
-            parse_url_params.cache = {}
-            window.cs_update_sidebar_active = previous_update_active
-            window.cs_refresh_sidebar_navigation = previous_refresh
 
     with_empty_session(run)
 

--- a/src/pyj/test_sidebar.pyj
+++ b/src/pyj/test_sidebar.pyj
@@ -1,0 +1,50 @@
+# vim:fileencoding=utf-8
+# License: GPL v3 Copyright: 2026, Kovid Goyal <kovid at kovidgoyal.net>
+from __python__ import hash_literals
+
+from book_list.sidebar import create_sidebar
+from book_list.ui_settings import get_ui_prefs
+from session import session_defaults
+from test_book_list_helpers import with_empty_session
+from testing import assert_equal, assert_false, assert_true, test
+from utils import parse_url_params
+
+
+@test
+def viewer_sidebar_setting_contract():
+    names = [x.name for x in get_ui_prefs()]
+    assert_true(names.indexOf('show_sidebar_in_book_viewer') > -1)
+    assert_equal(names.indexOf('show_sidebar_in_viewer'), -1)
+    assert_equal(session_defaults().show_sidebar_in_book_viewer, False)
+    assert_false(Object.prototype.hasOwnProperty.call(session_defaults(), 'show_sidebar_in_viewer'))
+
+
+@test
+def viewer_sidebar_setting_controls_reader_visibility():
+    def run(sd):
+        previous_url = window.location.href
+        previous_update_active = window.cs_update_sidebar_active
+        previous_refresh = window.cs_refresh_sidebar_navigation
+        try:
+            sd.set('show_sidebar_in_book_viewer', False)
+            window.history.replaceState(None, '', '#mode=read_book')
+            parse_url_params.cache = {}
+            root, left = create_sidebar()
+            assert_equal(left.style.display, 'none')
+
+            sd.set('show_sidebar_in_book_viewer', True)
+            window.cs_update_sidebar_active()
+            assert_equal(left.style.display, 'flex')
+
+            sd.set('show_sidebar_in_book_viewer', False)
+            window.history.replaceState(None, '', '#mode=book_list')
+            parse_url_params.cache = {}
+            window.cs_update_sidebar_active()
+            assert_equal(left.style.display, 'flex')
+        finally:
+            window.history.replaceState(None, '', previous_url)
+            parse_url_params.cache = {}
+            window.cs_update_sidebar_active = previous_update_active
+            window.cs_refresh_sidebar_navigation = previous_refresh
+
+    with_empty_session(run)


### PR DESCRIPTION
Removes the duplicate viewer sidebar setting name in the webui branch.

The settings panel now writes the same show_sidebar_in_book_viewer key that the sidebar reads, and the unused show_sidebar_in_viewer key is gone. The sidebar now uses the session setting default instead of carrying a second fallback.

Tests cover the canonical setting name and reader-mode sidebar visibility.

Validation:
CALIBRE_HEADLESS_PLATFORM=offscreen .venv/bin/python setup.py rapydscript --only-module srv
CALIBRE_HEADLESS_PLATFORM=offscreen .venv/bin/python setup.py test_rs