### PR TITLE
Centralize viewer chrome styling

### DIFF
--- a/src/pyj/read_book/chrome.pyj
+++ b/src/pyj/read_book/chrome.pyj
@@ -1,0 +1,18 @@
+# vim:fileencoding=utf-8
+# License: GPL v3 Copyright: 2026, Kovid Goyal <kovid at kovidgoyal.net>
+from __python__ import hash_literals
+
+from book_list.theme import get_color
+from dom import set_css
+
+
+def viewer_chrome_colors():
+    return {
+        'background': get_color('window-background'),
+        'foreground': get_color('window-foreground'),
+    }
+
+
+def apply_viewer_chrome_colors(elem):
+    colors = viewer_chrome_colors()
+    set_css(elem, background_color=colors.background, color=colors.foreground)

--- a/src/pyj/read_book/main_overlay_style.pyj
+++ b/src/pyj/read_book/main_overlay_style.pyj
@@ -1,0 +1,87 @@
+# vim:fileencoding=utf-8
+# License: GPL v3 Copyright: 2026, Kovid Goyal <kovid at kovidgoyal.net>
+from __python__ import hash_literals
+
+from book_list.theme import get_color
+from dom import add_extra_css, build_rule, unique_id
+from read_book.chrome import viewer_chrome_colors
+
+MAIN_OVERLAY_TS_CLASS = 'read-book-main-overlay-top-section'
+MAIN_OVERLAY_ACTIONS_CLASS = 'read-book-main-overlay-actions'
+MAIN_OVERLAY_ACTION_CONTROL_CLASS = 'read-book-main-overlay-action-control'
+MAIN_OVERLAY_ACTION_ICON_CLASS = 'read-book-main-overlay-action-icon'
+MAIN_OVERLAY_TEXT_ICON_CLASS = 'read-book-main-overlay-text-icon'
+MAIN_OVERLAY_TOP_ROW_CLASS = 'read-book-main-overlay-top-row'
+MAIN_OVERLAY_TITLE_CLASS = 'read-book-main-overlay-title'
+MAIN_OVERLAY_TIMER_CLASS = 'read-book-main-overlay-timer'
+MAIN_OVERLAY_FOOTER_ACTION_CLASS = 'read-book-main-overlay-footer-action'
+MAIN_OVERLAY_FOOTER_CLASS = 'read-book-main-overlay-footer'
+MAIN_OVERLAY_FOOTER_ACTIONS_CLASS = 'read-book-main-overlay-footer-actions'
+MAIN_OVERLAY_FOOTER_SLOT_CLASS = 'read-book-main-overlay-footer-slot'
+MAIN_OVERLAY_FOOTER_MIDDLE_SLOT_CLASS = 'read-book-main-overlay-footer-middle-slot'
+MAIN_OVERLAY_FOOTER_RIGHT_SLOT_CLASS = 'read-book-main-overlay-footer-right-slot'
+MAIN_OVERLAY_ICON_SIZE = '3.5ex'
+
+
+def timer_id():
+    if not timer_id.ans:
+        timer_id.ans = unique_id()
+    return timer_id.ans
+
+
+def main_overlay_css():
+    style = ''
+    colors = viewer_chrome_colors()
+    border = 'var(--calibre-border-style-subtle)'
+    hover_background = 'var(--cs-accent-weak)'
+    active_background = 'var(--cs-accent-weak-2)'
+    focus_outline = '1px solid ' + get_color('input-focus-outline-color')
+    style += build_rule('.' + MAIN_OVERLAY_TS_CLASS,
+                        user_select='none', background_color=colors.background, color=colors.foreground)
+    style += build_rule('.' + MAIN_OVERLAY_TOP_ROW_CLASS,
+                        display='flex', justify_content='space-between', align_items='baseline',
+                        font_size='smaller', padding='0.5ex 1ex', border_bottom=border)
+    style += build_rule('.' + MAIN_OVERLAY_TITLE_CLASS,
+                        max_width='90%', text_overflow='ellipsis', font_weight='bold',
+                        white_space='nowrap', overflow='hidden')
+    style += build_rule('.' + MAIN_OVERLAY_TIMER_CLASS,
+                        max_width='9%', white_space='nowrap', overflow='hidden')
+    style += build_rule('.' + MAIN_OVERLAY_FOOTER_CLASS,
+                        position='fixed', width='100%', bottom='0', display='flex',
+                        justify_content='space-between', align_items='center',
+                        user_select='none', background_color=colors.background, color=colors.foreground)
+    style += build_rule('.' + MAIN_OVERLAY_FOOTER_ACTIONS_CLASS,
+                        display='flex', justify_content='space-between', align_items='center')
+    style += build_rule('.' + MAIN_OVERLAY_FOOTER_ACTION_CLASS,
+                        display='flex', align_items='center', cursor='pointer', padding='0.5ex 1rem',
+                        appearance='none', margin='0', border='0', color='inherit',
+                        background='transparent', font='inherit')
+    style += build_rule('.' + MAIN_OVERLAY_FOOTER_ACTION_CLASS + ':focus',
+                        outline=focus_outline)
+    style += build_rule('.' + MAIN_OVERLAY_FOOTER_ACTION_CLASS + ' > svg:first-child', margin_right='0.5ex')
+    style += build_rule('.' + MAIN_OVERLAY_FOOTER_SLOT_CLASS, padding='0.5ex 1rem')
+    sel = '.' + MAIN_OVERLAY_TS_CLASS + ' > .' + MAIN_OVERLAY_ACTIONS_CLASS + ' '
+    style += build_rule(sel, overflow='hidden')
+    sel += '> ul '
+    style += build_rule(sel, display='flex', list_style='none', margin='0', padding='0', border_bottom=border)
+    sel += '> li'
+    style += build_rule(sel, border_right=border, display='flex')
+    style += build_rule(sel + ':last-child', border_right_style='none')
+    action_sel = sel + ' > .' + MAIN_OVERLAY_ACTION_CONTROL_CLASS
+    style += build_rule(action_sel,
+                        display='flex', flex_wrap='wrap', align_items='center', cursor='pointer',
+                        appearance='none', margin='0', padding='0.5em 1ex', border='0',
+                        color='inherit', background='transparent', font='inherit', text_align='left')
+    style += build_rule(action_sel + ':focus',
+                        outline=focus_outline)
+    style += build_rule(action_sel + ' > .' + MAIN_OVERLAY_ACTION_ICON_CLASS + ':first-child', margin_right='0.5ex')
+    style += build_rule('.' + MAIN_OVERLAY_TEXT_ICON_CLASS, font_size='175%', font_weight='bold')
+    style += build_rule(action_sel + ':hover, .' + MAIN_OVERLAY_FOOTER_ACTION_CLASS + ':hover',
+                        background_color=hover_background)
+    style += build_rule(action_sel + ':active, .' + MAIN_OVERLAY_FOOTER_ACTION_CLASS + ':active',
+                        background_color=active_background)
+    style += f'@media screen and (max-width: 350px) {{ #{timer_id()} {{ display: none; }} }}'
+    return style
+
+
+add_extra_css(main_overlay_css)

--- a/src/pyj/read_book/overlay.pyj
+++ b/src/pyj/read_book/overlay.pyj
@@ -13,9 +13,7 @@ from book_list.router import home
 from book_list.theme import get_color
 from book_list.top_bar import create_top_bar
 from book_list.ui import query_as_href, show_panel
-from dom import (
-    add_extra_css, build_rule, clear, ensure_id, set_css, svgicon, unique_id
-)
+from dom import clear, ensure_id, set_css, svgicon
 from gettext import gettext as _
 from modals import error_dialog, question_dialog
 from read_book.bookmarks import create_bookmarks_panel
@@ -23,6 +21,15 @@ from read_book.chrome import apply_viewer_chrome_colors, viewer_chrome_colors
 from read_book.globals import is_dark_theme, runtime, ui_operations
 from read_book.goto import create_goto_panel, create_location_overlay, create_page_list_overlay
 from read_book.highlights import builtin_color, create_highlights_panel
+from read_book.main_overlay_style import (
+    MAIN_OVERLAY_ACTION_CONTROL_CLASS, MAIN_OVERLAY_ACTION_ICON_CLASS,
+    MAIN_OVERLAY_ACTIONS_CLASS, MAIN_OVERLAY_FOOTER_ACTION_CLASS,
+    MAIN_OVERLAY_FOOTER_ACTIONS_CLASS, MAIN_OVERLAY_FOOTER_CLASS,
+    MAIN_OVERLAY_FOOTER_MIDDLE_SLOT_CLASS, MAIN_OVERLAY_FOOTER_RIGHT_SLOT_CLASS,
+    MAIN_OVERLAY_FOOTER_SLOT_CLASS, MAIN_OVERLAY_ICON_SIZE, MAIN_OVERLAY_TEXT_ICON_CLASS,
+    MAIN_OVERLAY_TIMER_CLASS, MAIN_OVERLAY_TITLE_CLASS, MAIN_OVERLAY_TOP_ROW_CLASS,
+    MAIN_OVERLAY_TS_CLASS, timer_id
+)
 from read_book.profiles import create_profiles_panel
 from read_book.open_book import create_open_book
 from read_book.prefs.font_size import create_font_size_panel
@@ -217,84 +224,6 @@ class SyncBook:  # {{{
             self.overlay.view.sync_data_received(cfi, new_annotations_map)
 
 
-# }}}
-
-# CSS {{{
-MAIN_OVERLAY_TS_CLASS = 'read-book-main-overlay-top-section'
-MAIN_OVERLAY_ACTIONS_CLASS = 'read-book-main-overlay-actions'
-MAIN_OVERLAY_ACTION_CONTROL_CLASS = 'read-book-main-overlay-action-control'
-MAIN_OVERLAY_ACTION_ICON_CLASS = 'read-book-main-overlay-action-icon'
-MAIN_OVERLAY_TEXT_ICON_CLASS = 'read-book-main-overlay-text-icon'
-MAIN_OVERLAY_TOP_ROW_CLASS = 'read-book-main-overlay-top-row'
-MAIN_OVERLAY_TITLE_CLASS = 'read-book-main-overlay-title'
-MAIN_OVERLAY_TIMER_CLASS = 'read-book-main-overlay-timer'
-MAIN_OVERLAY_FOOTER_ACTION_CLASS = 'read-book-main-overlay-footer-action'
-MAIN_OVERLAY_FOOTER_CLASS = 'read-book-main-overlay-footer'
-MAIN_OVERLAY_FOOTER_ACTIONS_CLASS = 'read-book-main-overlay-footer-actions'
-MAIN_OVERLAY_FOOTER_SLOT_CLASS = 'read-book-main-overlay-footer-slot'
-MAIN_OVERLAY_FOOTER_MIDDLE_SLOT_CLASS = 'read-book-main-overlay-footer-middle-slot'
-MAIN_OVERLAY_FOOTER_RIGHT_SLOT_CLASS = 'read-book-main-overlay-footer-right-slot'
-MAIN_OVERLAY_ICON_SIZE = '3.5ex'
-
-
-def timer_id():
-    if not timer_id.ans:
-        timer_id.ans = unique_id()
-    return timer_id.ans
-
-
-add_extra_css(def():
-    style = ''
-    border_style = 'var(--calibre-border-style-subtle)'
-    hover_bg = 'var(--cs-accent-weak)'
-    active_bg = 'var(--cs-accent-weak-2)'
-    style += build_rule('.' + MAIN_OVERLAY_TS_CLASS,
-                        user_select='none', background_color=get_color('window-background'))
-    style += build_rule('.' + MAIN_OVERLAY_TOP_ROW_CLASS,
-                        display='flex', justify_content='space-between', align_items='baseline',
-                        font_size='smaller', padding='0.5ex 1ex', border_bottom=border_style)
-    style += build_rule('.' + MAIN_OVERLAY_TITLE_CLASS,
-                        max_width='90%', text_overflow='ellipsis', font_weight='bold',
-                        white_space='nowrap', overflow='hidden')
-    style += build_rule('.' + MAIN_OVERLAY_TIMER_CLASS,
-                        max_width='9%', white_space='nowrap', overflow='hidden')
-    style += build_rule('.' + MAIN_OVERLAY_FOOTER_CLASS,
-                        position='fixed', width='100%', bottom='0', display='flex',
-                        justify_content='space-between', align_items='center',
-                        user_select='none', background_color=get_color('window-background'))
-    style += build_rule('.' + MAIN_OVERLAY_FOOTER_ACTIONS_CLASS,
-                        display='flex', justify_content='space-between', align_items='center')
-    style += build_rule('.' + MAIN_OVERLAY_FOOTER_ACTION_CLASS,
-                        display='flex', align_items='center', cursor='pointer', padding='0.5ex 1rem',
-                        appearance='none', margin='0', border='0', color='inherit',
-                        background='transparent', font='inherit')
-    style += build_rule('.' + MAIN_OVERLAY_FOOTER_ACTION_CLASS + ':focus',
-                        outline='1px solid ' + get_color('input-focus-outline-color'))
-    style += build_rule('.' + MAIN_OVERLAY_FOOTER_ACTION_CLASS + ' > svg:first-child', margin_right='0.5ex')
-    style += build_rule('.' + MAIN_OVERLAY_FOOTER_SLOT_CLASS, padding='0.5ex 1rem')
-    sel = '.' + MAIN_OVERLAY_TS_CLASS + ' > .' + MAIN_OVERLAY_ACTIONS_CLASS + ' '
-    style += build_rule(sel, overflow='hidden')
-    sel += '> ul '
-    style += build_rule(sel, display='flex', list_style='none', margin='0', padding='0', border_bottom=border_style)
-    sel += '> li'
-    style += build_rule(sel, border_right=border_style, display='flex')
-    style += build_rule(sel + ':last-child', border_right_style='none')
-    action_sel = sel + ' > .' + MAIN_OVERLAY_ACTION_CONTROL_CLASS
-    style += build_rule(action_sel,
-                        display='flex', flex_wrap='wrap', align_items='center', cursor='pointer',
-                        appearance='none', margin='0', padding='0.5em 1ex', border='0',
-                        color='inherit', background='transparent', font='inherit', text_align='left')
-    style += build_rule(action_sel + ':focus',
-                        outline='1px solid ' + get_color('input-focus-outline-color'))
-    style += build_rule(action_sel + ' > .' + MAIN_OVERLAY_ACTION_ICON_CLASS + ':first-child', margin_right='0.5ex')
-    style += build_rule('.' + MAIN_OVERLAY_TEXT_ICON_CLASS, font_size='175%', font_weight='bold')
-    style += build_rule(action_sel + ':hover, .' + MAIN_OVERLAY_FOOTER_ACTION_CLASS + ':hover',
-                        background_color=hover_bg)
-    style += build_rule(action_sel + ':active, .' + MAIN_OVERLAY_FOOTER_ACTION_CLASS + ':active',
-                        background_color=active_bg)
-    style += f'@media screen and (max-width: 350px) {{ #{timer_id()} {{ display: none; }} }}'
-    return style
-)
 # }}}
 
 def create_main_overlay_action_with_icon(text, tooltip, action, icon_elem, icon_color=None):

--- a/src/pyj/read_book/overlay.pyj
+++ b/src/pyj/read_book/overlay.pyj
@@ -19,6 +19,7 @@ from dom import (
 from gettext import gettext as _
 from modals import error_dialog, question_dialog
 from read_book.bookmarks import create_bookmarks_panel
+from read_book.chrome import apply_viewer_chrome_colors, viewer_chrome_colors
 from read_book.globals import is_dark_theme, runtime, ui_operations
 from read_book.goto import create_goto_panel, create_location_overlay, create_page_list_overlay
 from read_book.highlights import builtin_color, create_highlights_panel
@@ -79,7 +80,7 @@ class DeleteBook:  # {{{
 
     def show(self, container):
         self.container_id = container.getAttribute('id')
-        set_css(container, background_color=get_color('window-background'))
+        apply_viewer_chrome_colors(container)
         container.appendChild(E.div(
             style='display: flex; flex-direction: column; justify-content: center; align-items: center; height: 100%',
             tabindex='0',
@@ -148,7 +149,7 @@ class SyncBook:  # {{{
 
     def show(self, container):
         self.container_id = container.getAttribute('id')
-        set_css(container, background_color=get_color('window-background'))
+        apply_viewer_chrome_colors(container)
         book = self.overlay.view.book
         to_sync = v'[[book.key, new Date(0)]]'
         view = self.overlay.view
@@ -345,7 +346,7 @@ def render_main_overlay_footer_templates(footer_parts, renderer):
 
 
 def simple_overlay_title(title, overlay, container, close_action):
-    container.style.backgroundColor = get_color('window-background')
+    apply_viewer_chrome_colors(container)
     def action():
         event = this
         event.stopPropagation()
@@ -651,7 +652,7 @@ class PrefsOverlay: # {{{
 
     def show(self, container):
         self.changes_occurred = False
-        container.style.backgroundColor = get_color('window-background')
+        apply_viewer_chrome_colors(container)
         self.prefs = self.create_panel_impl(container)
 
     def on_change(self):
@@ -936,9 +937,10 @@ class Overlay:
 
     def clear_container(self):
         c = self.container
+        colors = viewer_chrome_colors()
         clear(c)
         c.style.backgroundColor = 'transparent'
-        c.style.color = get_color('window-foreground')
+        c.style.color = colors.foreground
         if c.style.display is not 'block':
             c.style.display = 'block'
         return c

--- a/src/pyj/test.pyj
+++ b/src/pyj/test.pyj
@@ -13,6 +13,7 @@ import test_nav_list  # noqa: unused-import
 import test_saved_virtual_libraries  # noqa: unused-import
 import test_library_data  # noqa: unused-import
 import test_sidebar  # noqa: unused-import
+import test_viewer_appearance  # noqa: unused-import
 import read_book.test_cfi  # noqa: unused-import
 import test_annotations  # noqa: unused-import
 

--- a/src/pyj/test_viewer_appearance.pyj
+++ b/src/pyj/test_viewer_appearance.pyj
@@ -1,0 +1,29 @@
+# vim:fileencoding=utf-8
+# License: GPL v3 Copyright: 2026, Kovid Goyal <kovid at kovidgoyal.net>
+from __python__ import hash_literals
+
+from dom import get_widget_css
+from read_book.chrome import apply_viewer_chrome_colors
+from read_book.main_overlay_style import MAIN_OVERLAY_TS_CLASS, main_overlay_css
+from testing import assert_equal, assert_true, test
+
+
+@test
+def viewer_chrome_colors_apply_to_element():
+    elem = document.createElement('div')
+    apply_viewer_chrome_colors(elem)
+    assert_equal(elem.style.backgroundColor, 'var(--calibre-color-window-background)')
+    assert_equal(elem.style.color, 'var(--calibre-color-window-foreground)')
+
+
+@test
+def main_overlay_style_uses_viewer_chrome():
+    css = main_overlay_css()
+    assert_true(css.indexOf('.' + MAIN_OVERLAY_TS_CLASS) > -1)
+    assert_true(css.indexOf('background-color:var(--calibre-color-window-background);') > -1)
+    assert_true(css.indexOf('color:var(--calibre-color-window-foreground);') > -1)
+    assert_true(css.indexOf('border-bottom:var(--calibre-border-style-subtle);') > -1)
+    assert_true(css.indexOf('outline:1px solid var(--calibre-color-input-focus-outline-color);') > -1)
+    assert_true(css.indexOf('background-color:var(--cs-accent-weak);') > -1)
+    assert_true(css.indexOf('background-color:var(--cs-accent-weak-2);') > -1)
+    assert_true(get_widget_css().indexOf('.' + MAIN_OVERLAY_TS_CLASS) > -1)


### PR DESCRIPTION
Move shared viewer chrome colors into a small helper.
Move main overlay CSS and class names into a dedicated style module.
Add RapydScript coverage for the shared styling contract.