### PR TITLE
Share webui theme variable contract

### DIFF
--- a/src/pyj/book_list/theme.pyj
+++ b/src/pyj/book_list/theme.pyj
@@ -51,14 +51,6 @@ def hex_as_rgba(s, opacity='1'):
     return f'rgba({v[0]},{v[1]},{v[2]},{opacity})'
 
 
-def get_theme_primary_rgb():
-    de = document.documentElement
-    raw = (de.style.getPropertyValue('--calibre-color-primary') or '').strip()
-    if not raw:
-        raw = (window.getComputedStyle(de).getPropertyValue('--calibre-color-primary') or '').strip()
-    return parse_hex_color(raw)
-
-
 def mix_rgb_channel(a, b, t):
     return _byte(Math.round(a * (1 - t) + b * t))
 
@@ -84,33 +76,39 @@ def rgb_to_hex(rgb):
     return '#' + h(r) + h(g) + h(b)
 
 
-def apply_light_mode_primary_tinted_backgrounds():
-    P = get_theme_primary_rgb()
+def light_mode_primary_tints(primary_rgb):
     W = [255, 255, 255]
-    s = document.documentElement.style
-    wb = rgb_to_hex(mix_rgb(W, P, 0.055))
-    wb2 = rgb_to_hex(mix_rgb(W, P, 0.115))
-    tree = rgb_to_hex(mix_rgb(W, P, 0.095))
+    wb = rgb_to_hex(mix_rgb(W, primary_rgb, 0.055))
+    wb2 = rgb_to_hex(mix_rgb(W, primary_rgb, 0.115))
+    tree = rgb_to_hex(mix_rgb(W, primary_rgb, 0.095))
     dlg = wb
-    lh_bg = rgb_to_hex(mix_rgb(W, P, 0.168))
-    inp = rgb_to_hex(mix_rgb(W, P, 0.068))
-    bar_bg = rgb_to_hex(mix_rgb(W, P, 0.052))
+    lh_bg = rgb_to_hex(mix_rgb(W, primary_rgb, 0.168))
+    inp = rgb_to_hex(mix_rgb(W, primary_rgb, 0.068))
+    bar_bg = rgb_to_hex(mix_rgb(W, primary_rgb, 0.052))
     # Controls: keep contrast but hue-lock to primary.
     btn_base = [36, 38, 40]
     btn_base2 = [52, 54, 58]
-    btn_s = rgb_to_hex(mix_rgb(btn_base, P, 0.4))
-    btn_e = rgb_to_hex(mix_rgb(btn_base2, P, 0.36))
-    s.setProperty('--calibre-color-window-background', wb)
-    s.setProperty('--calibre-color-window-background2', wb2)
-    s.setProperty('--calibre-color-tree-highlight-item', tree)
-    s.setProperty('--calibre-color-dialog-background', dlg)
-    s.setProperty('--calibre-color-list-hover-background', lh_bg)
-    s.setProperty('--calibre-color-list-hover-foreground', DARK)
-    s.setProperty('--calibre-color-input-background', inp)
-    s.setProperty('--calibre-color-bar-background', bar_bg)
-    s.setProperty('--calibre-color-bar-foreground', DARK)
-    s.setProperty('--calibre-color-button-start', btn_s)
-    s.setProperty('--calibre-color-button-end', btn_e)
+    btn_s = rgb_to_hex(mix_rgb(btn_base, primary_rgb, 0.4))
+    btn_e = rgb_to_hex(mix_rgb(btn_base2, primary_rgb, 0.36))
+    return {
+        '--calibre-color-window-background': wb,
+        '--calibre-color-window-background2': wb2,
+        '--calibre-color-tree-highlight-item': tree,
+        '--calibre-color-dialog-background': dlg,
+        '--calibre-color-list-hover-background': lh_bg,
+        '--calibre-color-list-hover-foreground': DARK,
+        '--calibre-color-input-background': inp,
+        '--calibre-color-bar-background': bar_bg,
+        '--calibre-color-bar-foreground': DARK,
+        '--calibre-color-button-start': btn_s,
+        '--calibre-color-button-end': btn_e,
+    }
+
+
+def apply_theme_variables(variables):
+    s = document.documentElement.style
+    for k in Object.keys(variables):
+        s.setProperty(k, variables[k])
     get_color_as_rgba.cache = {}
     cached_color_to_rgba.cache = {}
 
@@ -172,32 +170,37 @@ DEFAULT_FONTS = {
 }
 
 
-def get_primary_colors(hexval):
-    rgb = parse_hex_color(hexval)
-    r, g, b = rgb
-    v = hexval or ''
+def normalized_primary_color(hexval):
+    v = ((hexval or DEFAULT_PRIMARY_HEX) + '').strip()
+    rgb = parse_hex_color(v)
+    if not rgb:
+        v = DEFAULT_PRIMARY_HEX
+        rgb = parse_hex_color(v)
     if not (v + '').startswith('#'):
         v = '#' + v
-    return v, f'rgba({r},{g},{b},0.18)', f'rgba({r},{g},{b},0.28)'
+    return v, rgb
 
 
-def apply_primary_color(hexval):
-    p, l, l2 = get_primary_colors(hexval)
-    s = document.documentElement.style
-    s.setProperty('--calibre-color-primary', p)
-    s.setProperty('--calibre-color-primary-light', l)
-    s.setProperty('--calibre-color-primary-light-2', l2)
+def theme_variables(is_dark_theme, primary_color):
+    attr = 'dark' if is_dark_theme else 'light'
+    p, rgb = normalized_primary_color(primary_color)
+    r, g, b = rgb
+    ans = {
+        '--calibre-color-primary': p,
+        '--calibre-color-primary-light': f'rgba({r},{g},{b},0.18)',
+        '--calibre-color-primary-light-2': f'rgba({r},{g},{b},0.28)',
+    }
+    for k in DEFAULT_COLORS:
+        ans['--calibre-color-' + k] = DEFAULT_COLORS[k][attr]
+    if not is_dark_theme:
+        tints = light_mode_primary_tints(rgb)
+        for k in Object.keys(tints):
+            ans[k] = tints[k]
+    return ans
 
 
 def set_ui_colors(is_dark_theme, primary_color):
-    attr = 'dark' if is_dark_theme else 'light'
-    s = document.documentElement.style
-    apply_primary_color(primary_color)
-    for k in DEFAULT_COLORS:
-        val = DEFAULT_COLORS[k][attr]
-        s.setProperty('--calibre-color-' + k, val)
-    get_color_as_rgba.cache = {}
-    cached_color_to_rgba.cache = {}
+    apply_theme_variables(theme_variables(is_dark_theme, primary_color))
     document.documentElement.style.colorScheme = 'dark' if is_dark_theme else 'light'
 
 
@@ -237,8 +240,6 @@ def get_saved_color_settings():
 def apply_book_list_theme():
     s = get_saved_color_settings()
     set_ui_colors(s.is_dark, s.primary_color)
-    if not s.is_dark:
-        apply_light_mode_primary_tinted_backgrounds()
     try:
         set_css(document.body, background_color=get_color('window-background'), color=get_color('window-foreground'))
     except Exception:
@@ -276,13 +277,9 @@ def css_for_variables():
     s = get_saved_color_settings()
     attr = 'dark' if s.is_dark else 'light'
     ans = v'[]'
-    for k in DEFAULT_COLORS:
-        val = DEFAULT_COLORS[k][attr]
-        ans.push(f'--calibre-color-{k}: {val};')
-    p, l, l2 = get_primary_colors(s.primary_color)
-    ans.push(f'--calibre-color-primary: {p};')
-    ans.push(f'--calibre-color-primary-light: {l};')
-    ans.push(f'--calibre-color-primary-light-2: {l2};')
+    variables = theme_variables(s.is_dark, s.primary_color)
+    for k in Object.keys(variables):
+        ans.push(f'{k}: {variables[k]};')
     return f':root {{ color-scheme: {attr}; ' + ans.join('\n') + '}\n\n'
 
 

--- a/src/pyj/test.pyj
+++ b/src/pyj/test.pyj
@@ -13,6 +13,7 @@ import test_nav_list  # noqa: unused-import
 import test_saved_virtual_libraries  # noqa: unused-import
 import test_library_data  # noqa: unused-import
 import test_sidebar  # noqa: unused-import
+import test_theme  # noqa: unused-import
 import test_viewer_appearance  # noqa: unused-import
 import read_book.test_cfi  # noqa: unused-import
 import test_annotations  # noqa: unused-import

--- a/src/pyj/test_theme.pyj
+++ b/src/pyj/test_theme.pyj
@@ -1,0 +1,27 @@
+# vim:fileencoding=utf-8
+# License: GPL v3 Copyright: 2026, Kovid Goyal <kovid at kovidgoyal.net>
+from __python__ import hash_literals
+
+from book_list.theme import css_for_variables, set_ui_colors, theme_variables
+from test_book_list_helpers import with_empty_session
+from testing import assert_equal, assert_true, test
+
+
+def assert_css_and_dom_use_variables(variables, css, style):
+    for name in Object.keys(variables):
+        assert_true(css.indexOf(name + ': ' + variables[name] + ';') > -1)
+        assert_equal(style.getPropertyValue(name), variables[name])
+
+
+@test
+def light_theme_css_uses_shared_variables():
+    def run(sd):
+        sd.set('book_list_color_scheme', 'light')
+        sd.set('ui_highlight_color', '#437000')
+        variables = theme_variables(False, '#437000')
+        css = css_for_variables()
+        set_ui_colors(False, '#437000')
+        style = document.documentElement.style
+        assert_css_and_dom_use_variables(variables, css, style)
+        assert_equal(style.colorScheme, 'light')
+    with_empty_session(run)

--- a/src/pyj/test_theme.pyj
+++ b/src/pyj/test_theme.pyj
@@ -2,7 +2,7 @@
 # License: GPL v3 Copyright: 2026, Kovid Goyal <kovid at kovidgoyal.net>
 from __python__ import hash_literals
 
-from book_list.theme import css_for_variables, set_ui_colors, theme_variables
+from book_list.theme import DEFAULT_PRIMARY_HEX, css_for_variables, set_ui_colors, theme_variables
 from test_book_list_helpers import with_empty_session
 from testing import assert_equal, assert_true, test
 
@@ -11,6 +11,27 @@ def assert_css_and_dom_use_variables(variables, css, style):
     for name in Object.keys(variables):
         assert_true(css.indexOf(name + ': ' + variables[name] + ';') > -1)
         assert_equal(style.getPropertyValue(name), variables[name])
+
+
+def assert_variables_have_values(variables, expected):
+    for name in Object.keys(expected):
+        assert_equal(variables[name], expected[name])
+
+
+@test
+def invalid_primary_color_uses_default_theme_contract():
+    def run(sd):
+        sd.set('book_list_color_scheme', 'light')
+        sd.set('ui_highlight_color', 'not-a-color')
+        variables = theme_variables(False, 'not-a-color')
+        default_variables = theme_variables(False, DEFAULT_PRIMARY_HEX)
+        assert_equal(Object.keys(variables).length, Object.keys(default_variables).length)
+        for name in Object.keys(default_variables):
+            assert_equal(variables[name], default_variables[name])
+        css = css_for_variables()
+        set_ui_colors(False, 'not-a-color')
+        assert_css_and_dom_use_variables(default_variables, css, document.documentElement.style)
+    with_empty_session(run)
 
 
 @test
@@ -22,6 +43,52 @@ def light_theme_css_uses_shared_variables():
         css = css_for_variables()
         set_ui_colors(False, '#437000')
         style = document.documentElement.style
+        assert_variables_have_values(variables, {
+            '--calibre-color-primary': '#437000',
+            '--calibre-color-primary-light': 'rgba(67,112,0,0.18)',
+            '--calibre-color-primary-light-2': 'rgba(67,112,0,0.28)',
+            '--calibre-color-window-background': '#f5f7f1',
+            '--calibre-color-window-background2': '#e9efe2',
+            '--calibre-color-tree-highlight-item': '#edf1e7',
+            '--calibre-color-dialog-background': '#f5f7f1',
+            '--calibre-color-list-hover-background': '#dfe7d4',
+            '--calibre-color-list-hover-foreground': '#39322B',
+            '--calibre-color-input-background': '#f2f5ee',
+            '--calibre-color-bar-background': '#f5f8f2',
+            '--calibre-color-bar-foreground': '#39322B',
+            '--calibre-color-button-start': '#304418',
+            '--calibre-color-button-end': '#394b25',
+        })
         assert_css_and_dom_use_variables(variables, css, style)
         assert_equal(style.colorScheme, 'light')
+    with_empty_session(run)
+
+
+@test
+def dark_theme_css_uses_shared_variables():
+    def run(sd):
+        sd.set('book_list_color_scheme', 'dark')
+        sd.set('ui_highlight_color', '#437000')
+        variables = theme_variables(True, '#437000')
+        css = css_for_variables()
+        set_ui_colors(True, '#437000')
+        style = document.documentElement.style
+        assert_variables_have_values(variables, {
+            '--calibre-color-primary': '#437000',
+            '--calibre-color-primary-light': 'rgba(67,112,0,0.18)',
+            '--calibre-color-primary-light-2': 'rgba(67,112,0,0.28)',
+            '--calibre-color-window-background': '#2d2d2d',
+            '--calibre-color-window-background2': '#777',
+            '--calibre-color-tree-highlight-item': '#777',
+            '--calibre-color-dialog-background': '#2d2d2d',
+            '--calibre-color-list-hover-background': '#777',
+            '--calibre-color-list-hover-foreground': '#1d1d1d',
+            '--calibre-color-input-background': 'black',
+            '--calibre-color-bar-background': '#777',
+            '--calibre-color-bar-foreground': '#1d1d1d',
+            '--calibre-color-button-start': '#ddd',
+            '--calibre-color-button-end': '#666',
+        })
+        assert_css_and_dom_use_variables(variables, css, style)
+        assert_equal(style.colorScheme, 'dark')
     with_empty_session(run)


### PR DESCRIPTION
Unifies webui theme variable generation so the book list and standalone viewer use the same CSS variable contract.

Light-mode primary tints now come from the saved primary color instead of reading from the DOM, and invalid primary colors fall back to the default.

Adds RapydScript tests for generated CSS, DOM-applied variables, invalid color fallback, exact light tint values, and dark mode.

Validation: git diff --check upstream/webui...HEAD; RapydScript compile for test.pyj, viewer-main.pyj, and srv.pyj.