### PR TITLE
Support HTML Export of Book Highlights and Annotations

### DIFF
--- a/src/calibre/gui2/library/annotations.py
+++ b/src/calibre/gui2/library/annotations.py
@@ -6,7 +6,7 @@ import json
 import os
 import re
 from functools import lru_cache, partial
-from urllib.parse import quote
+from urllib.parse import quote, unquote
 
 from qt.core import (
     QAbstractItemView,
@@ -88,6 +88,14 @@ def render_highlight_as_text(hl, lines, as_markdown=False, link_prefix=None):
 
 
 def render_bookmark_as_text(b, lines, as_markdown=False, link_prefix=None):
+    """Render a bookmark as text.
+
+    Args:
+        b (dict): The bookmark data.
+        lines (list): The list to which the text lines will be appended.
+        as_markdown (bool): Whether to render as markdown.
+        link_prefix (str): The prefix for location links.
+    """
     lines.append(b['title'])
     date = render_timestamp(b['timestamp'])
     if as_markdown and link_prefix and b['pos_type'] == 'epubcfi':
@@ -100,6 +108,34 @@ def render_bookmark_as_text(b, lines, as_markdown=False, link_prefix=None):
     else:
         lines.append('───')
     lines.append('')
+
+
+def sanitize_color(color):
+    """
+    Extract the hex code from a hexadecimal color
+    Args:
+        color: A hexadecimal color string (e.g., "#rrggbb").
+
+    Returns:
+        The hexadecimal color string with the #.
+    """
+    return re.sub(r'[^a-zA-Z0-9-]', '', color)
+
+
+def color_contrasting(hex_color):
+    """
+    Generates a contrasting hexadecimal color.
+
+    Args:
+        hex_color: A hexadecimal color string (e.g., "#rrggbb").
+
+    Returns:
+        A contrasting hexadecimal color string.
+    """
+    hex_color = hex_color.lstrip("#")
+    rgb = tuple(int(hex_color[i:i+2], 16) for i in (0, 2, 4))
+    contrasting_rgb = tuple(255 - c for c in rgb)
+    return "#{:02x}{:02x}{:02x}".format(*contrasting_rgb)
 
 
 class ChapterGroup:
@@ -194,6 +230,498 @@ def render_notes(notes, tag='p'):
             current_lines = []
     if current_lines:
         yield '<{0}>{1}</{0}>'.format(tag, '\n'.join(current_lines))
+
+
+def slugify(text: str, max_length: int = 60) -> str:
+    """
+    Convert header text into a URL-safe slug suitable for element IDs.
+    - Lowercase
+    - Replace non-alphanumeric runs with hyphens
+    - Trim leading/trailing hyphens
+    - Truncate to `max_length`
+    """
+    if not text:
+        return "untitled"
+    s = text.strip().lower()
+    # replace HTML tags if present
+    s = re.sub(r'<[^>]+>', '', s)
+    # replace non-alphanumeric characters with hyphens
+    s = re.sub(r'[^a-z0-9]+', '-', s)
+    s = s.strip('-')
+    if not s:
+        return "untitled"
+    if len(s) > max_length:
+        s = s[:max_length].rstrip('-')
+    return s
+
+
+def get_unique_id(base: str, counts: dict) -> str:
+    """Return a unique id by using and updating `counts` for collisions."""
+    if base not in counts:
+        counts[base] = 1
+        return base
+    counts[base] += 1
+    return f"{base}-{counts[base]-1}"
+
+
+def generate_outline_html(headings: list) -> str:
+    """Generate nested HTML outline (<nav><ul>...) from a flat list of headings.
+
+    Each heading is a dict: {'level': int, 'text': str, 'id': str}
+    """
+    if not headings:
+        return ""
+    out = ['<nav class="calibre-outline" aria-label="Document outline">']
+    out.append('<ul class="calibre-outline-list">')
+    stack_level = 1
+    for h in headings:
+        lvl = max(1, min(6, int(h.get('level', 1))))
+        # open nested lists as needed
+        while lvl > stack_level:
+            out.append('<ul>')
+            stack_level += 1
+        # close lists as needed
+        while lvl < stack_level:
+            out.append('</ul>')
+            stack_level -= 1
+        text = h.get('text', '').strip() or 'Untitled'
+        hid = h.get('id')
+        out.append(f'<li class="calibre-outline-item lvl-{lvl}"><a href="#{hid}">{text}</a></li>')
+    # close remaining open lists
+    while stack_level > 1:
+        out.append('</ul>')
+        stack_level -= 1
+    out.append('</ul>')
+    out.append('</nav>')
+    return '\n'.join(out)
+
+
+def format_annotations_to_html(json_annotations_string: str, markdown_string: str) -> str:
+    """
+    Formats Markdown text by wrapping Calibre annotations with styled HTML blockquotes.
+
+    This function processes Calibre annotations by replacing the Markdown version of a highlight
+    with an HTML `<blockquote>` that contains the highlight text from the JSON source, an HTML
+    link, and any associated notes. Headers in the original Markdown are preserved.
+
+    Args:
+        json_annotations_string: A JSON string containing Calibre annotation data.
+        markdown_string: A Markdown string to be styled.
+
+    Returns:
+        The new HTML/Markdown string with styled annotations and a prepended <style> tag.
+    
+    Raises:
+        ValueError: If JSON parsing fails or the JSON structure is invalid.
+    """
+    if not json_annotations_string.strip():
+        raise ValueError("Invalid input: Resolved JSON annotations string is empty.")
+    
+    try:
+        data = json.loads(json_annotations_string)
+    except json.JSONDecodeError as e:
+        snippet = json_annotations_string[:100]
+        raise ValueError(f"Invalid JSON data: {e}. Problem near: \"{snippet}...\"") from e
+
+    json_annotation_list = data.get("annotations")
+    if not isinstance(json_annotation_list, list):
+        json_annotation_list = data.get("highlights")
+    if not isinstance(json_annotation_list, list):
+        raise ValueError('Invalid JSON structure: "annotations" array not found.')
+
+    cfi_to_annotation_map = {}
+    used_colors = set()
+
+    # Collect headings for outline generation and track id collisions
+    outline_headings = []
+    heading_id_counts = {}
+
+    for ann in json_annotation_list:
+        if ann.get("start_cfi") and isinstance(ann.get("spine_index"), int):
+            # The CFI key is constructed as it appears in the decoded Calibre link.
+            cfi_key = f"/{ (ann['spine_index'] * 2) + 2 }{ ann['start_cfi'] }"
+            cfi_to_annotation_map[cfi_key] = ann
+            
+            style = ann.get("style", {})
+            stype = style.get("type")
+            skind = style.get("kind")
+            
+            if stype == "builtin" and skind != "decoration":
+                color = style.get("which", "yellow")
+                used_colors.add(color)
+            elif stype == "custom" and skind == "color":
+                custom_dict = style.get("custom", {})
+                color = custom_dict.get("light") or style.get("light") or "default"
+                used_colors.add(color)
+
+    # Split markdown by '---' delimiter, keeping the delimiter for reconstruction
+    rgx_split_delim = r'(\n-{3,}\n)'
+    markdown_parts = re.split(rgx_split_delim, markdown_string)
+    new_markdown_parts = []
+    
+    # Regex to find the calibre link and extract its text and URL
+    link_regex = re.compile(r'\[(.*?)\]\((calibre:\/\/.*?open_at=epubcfi%28(.*?)%29)\)')
+
+    for part in markdown_parts:
+        if re.search(rgx_split_delim, part):
+            new_markdown_parts.append(part)
+            continue
+        
+        link_match = link_regex.search(part)
+        
+        if not link_match:
+            new_markdown_parts.append(part)
+            continue
+
+        try:
+            # The URL-encoded CFI part is the 3rd capture group
+            cfi_in_link_decoded = unquote(link_match.group(3))
+        except Exception as e:
+            print(f"Could not decode CFI from link: {link_match.group(2)}. Error: {e}")
+            new_markdown_parts.append(part)
+            continue
+            
+        json_annotation = cfi_to_annotation_map.get(cfi_in_link_decoded)
+
+        if not json_annotation:
+            new_markdown_parts.append(part)
+            continue
+
+        style = json_annotation.get("style", {})
+        stype = style.get("type")
+        skind = style.get("kind")
+        
+        color = None
+        fname = None
+        is_decoration = False
+        
+        if stype == "builtin" and skind != "decoration":
+            color = style.get("which", "yellow")
+        elif stype == "builtin" and skind == "decoration":
+            fname = style.get("which", "wavy")
+            if fname:
+                is_decoration = True
+        elif stype == "custom" and skind == "color":
+            custom_dict = style.get("custom", {})
+            color = custom_dict.get("light") or style.get("light") or "default"
+        elif stype == "custom" and skind == "decoration":
+            fname = style.get("friendly_name")
+            if fname:
+                is_decoration = True
+        else:
+            color = "default"
+        
+        # --- Annotation found, now reconstruct the content ---
+        
+        # 1. Separate headers from the main content and convert Markdown headers to HTML
+        prefix_content = ""
+        annotation_content_to_replace = part
+        lines = part.split('\n')
+        first_non_header_line_idx = 0
+        for i, line in enumerate(lines):
+            line_trimmed = line.strip()
+            if line_trimmed.startswith('#'):
+                # Count number of leading hashes for header level
+                header_match = re.match(r'^(#+)\s*(.*)', line_trimmed)
+                if header_match:
+                    header_level = min(len(header_match.group(1)), 6)
+                    header_text = header_match.group(2)
+                    # create a slug/id and ensure uniqueness
+                    base = slugify(header_text)
+                    hdr_id = get_unique_id(f"outline-{base}", heading_id_counts)
+                    prefix_content += f"<h{header_level} id=\"{hdr_id}\">{header_text}</h{header_level}>\n"
+                    outline_headings.append({'level': header_level, 'text': header_text, 'id': hdr_id})
+                first_non_header_line_idx = i + 1
+            elif line_trimmed == "" and prefix_content:
+                prefix_content += '\n'
+                first_non_header_line_idx = i + 1
+            elif line_trimmed != "":
+                break # First non-empty, non-header line
+            else: # Empty line before any real content
+                prefix_content += '\n'
+                first_non_header_line_idx = i + 1
+        
+        annotation_content_to_replace = '\n'.join(lines[first_non_header_line_idx:])
+        json_highlighted_text = json_annotation.get("highlighted_text", "")
+        
+        # Convert Markdown link to HTML <a> tag
+        link_text = link_match.group(1)
+        link_url = link_match.group(2)
+        html_link = f'<a href="{link_url}">{link_text}</a>'
+        
+        # Process note
+        note_for_blockquote = ""
+        original_md_link_str = link_match.group(0)
+        note_section_in_md = annotation_content_to_replace.split(original_md_link_str, 1)[-1]
+        
+        leading_ws_match = re.match(r'^\s*', note_section_in_md)
+        leading_ws_for_note = leading_ws_match.group(0) if leading_ws_match else ""
+        actual_md_note_text = note_section_in_md.lstrip()
+        
+        json_note = json_annotation.get("notes", "")
+        if json_note and json_note.strip() != "" and actual_md_note_text.strip() != "":
+            note_for_blockquote = f"{leading_ws_for_note}<br><em>Note: </em>{actual_md_note_text}"
+        elif actual_md_note_text.strip() != "":
+            note_for_blockquote = note_section_in_md
+
+        # Assemble content
+        inner_content = f"{json_highlighted_text}\n{html_link}"
+        if note_for_blockquote.strip():
+            inner_content += ('\n' if not note_for_blockquote.startswith('\n') else '') + note_for_blockquote.rstrip()
+            
+        if is_decoration:
+            tag = re.sub(r'[^a-zA-Z0-9-]', '', fname).lower()
+            html_element = f'<{tag} class="calibre-annotation decor-{tag}">\n{inner_content}\n</{tag}>'
+        else:
+            safe_color = sanitize_color(color) if color else "default"
+            html_element = f'<blockquote class="calibre-annotation bq-{safe_color}">\n{inner_content}\n</blockquote>'
+        
+        # Add the prefix (headers) and the new element
+        new_markdown_parts.append(prefix_content.rstrip() + ('\n\n' if prefix_content.strip() else '') + html_element)
+
+    final_markdown = "".join(new_markdown_parts)
+
+    # Prepend CSS styles
+    style_lines = ["<style>", "/* Calibre Annotation Styles */"]
+    
+    style_lines.extend([
+        ".calibre-annotations-container { font-family: sans-serif; }",
+        ".calibre-filter-controls { margin-bottom: 20px; display: flex; gap: 10px; flex-wrap: wrap; }",
+        ".calibre-filter-label { padding: 5px 15px; border-radius: 20px; cursor: pointer; border: 2px solid #ccc; background: #f9f9f9; color: #333; font-size: 14px; font-weight: bold; }",
+        ".calibre-filter-label:hover { opacity: 0.8; }",
+        "input.calibre-filter-cb:checked + label { background-color: #e0e0e0; }",
+        "input.calibre-filter-cb:checked ~ .calibre-annotation { display: none !important; }"
+    ])
+    ids = []
+    filter_inputs = []
+    filter_labels = []
+    
+    # Show All reset button (works because everything is wrapped in a form)
+    filter_labels.append('<button type="reset" class="calibre-filter-label" style="background:#ddd;">Show All</button>')
+    
+    if not used_colors and cfi_to_annotation_map:
+        used_colors.add("default")
+        
+    for color in sorted(list(used_colors)): # Sort for consistent output
+        sanitized_color = sanitize_color(color)
+        if not sanitized_color: continue
+        
+        border_color = color if sanitized_color != "default" else "#cccccc"
+        if color == "yellow": border_color = "#ffeb3b"
+        elif color == "blue": border_color = "#2196f3"
+        elif color == "green": border_color = "#4caf50"
+        elif color == "red": border_color = "#f44336"
+        
+        # Pill styling for label
+        filter_inputs.append(f'<input type="checkbox" id="filter-color-{sanitized_color}" class="calibre-filter-cb" style="display:none;">')
+        filter_labels.append(f'<label for="filter-color-{sanitized_color}" class="calibre-filter-label" style="border-color:{border_color};">{color}</label>')
+        ids.append(f"filter-color-{sanitized_color}")
+        # Filter logic overrides the generic hide rule
+        style_lines.append(f"input#filter-color-{sanitized_color}:checked ~ .bq-{sanitized_color} {{ display: block !important; }}")
+        
+        link_colors = {"yellow": "#795548", "blue": "#0d47a1", "green": "#1b5e20", "red": "#b71c1c", "default": "#333333"}
+        link_color = link_colors.get(sanitized_color)
+        if link_color == None:
+            try:
+                link_color = color_contrasting(sanitized_color)
+            except Exception as e:
+                print(f"Error computing contrasting color for '{sanitized_color}': {e}")
+                link_color = "#333333"
+        
+        style_lines.extend([
+            f".bq-{sanitized_color} {{",
+            f"  border-left: 3px solid {border_color} !important;",
+            f"  padding: 0.5em 10px;",
+            f"  margin: 1em 0;",
+            f"}}",
+            f".bq-{sanitized_color} a {{",
+            f"  color: {link_color};",
+            f"  font-weight: bold;",
+            f"}}",
+            f".bq-{sanitized_color} em {{",
+            f"  font-style: italic;",
+            f"  font-weight: bold;",
+            f"  color: {link_color};",
+            f"}}"
+        ])
+        
+    # Handle decorations in styles
+    used_decorations = {}
+    for ann in json_annotation_list:
+        if ann.get("start_cfi") and isinstance(ann.get("spine_index"), int):
+            style = ann.get("style", {})
+            stype = style.get("type")
+            skind = style.get("kind")
+            if stype == "custom" and skind == "decoration":
+                fname = style.get("friendly_name")
+                if fname:
+                    used_decorations[fname] = style
+            elif stype == "builtin" and skind == "decoration":
+                fname = style.get("which")
+                if fname:
+                    used_decorations[fname] = {
+                        "text-decoration-color": "#000000",
+                        "text-decoration-line": "underline",
+                        "text-decoration-style": fname
+                    }
+
+    for fname, dec_style in used_decorations.items():
+        safe_fname = re.sub(r'[^a-zA-Z0-9-]', '', fname).lower()
+        dec_color = dec_style.get("text-decoration-color", "#000")
+        dec_line = dec_style.get("text-decoration-line", "underline")
+        dec_style_type = dec_style.get("text-decoration-style", "solid")
+        
+        filter_inputs.append(f'<input type="checkbox" id="filter-decor-{safe_fname}" class="calibre-filter-cb" style="display:none;">')
+        filter_labels.append(f'<label for="filter-decor-{safe_fname}" class="calibre-filter-label" style="text-decoration: {dec_line} {dec_style_type} {dec_color};">{fname}</label>')
+        ids.append(f"filter-decor-{safe_fname}")
+        # Filter logic overrides the generic hide rule
+        style_lines.append(f"input#filter-decor-{safe_fname}:checked ~ .decor-{safe_fname} {{ display: block !important; }}")
+        
+        style_lines.extend([
+            f".decor-{safe_fname} {{",
+            f"  text-decoration-color: {dec_color};",
+            f"  text-decoration-line: {dec_line};",
+            f"  text-decoration-style: {dec_style_type};",
+            f"  display: block;",
+            f"  margin: 1em 0;",
+            f"}}"
+        ])
+    # Add CSS Bevel to indicate selected Pills
+    for i, id in enumerate(ids):
+        ids[i] = f'form.calibre-annotations-container:has(#{id}:checked) label[for="{id}"]'
+    
+    style_lines.extend([f'\n{", ".join(ids)} {{\n    /* The inner bevel effect */\n',
+    '    box-shadow: inset 2px 2px 4px rgba(0, 0, 0, 0.3),\n',
+    '    inset -1px -1px 2px rgba(255, 255, 255, 0.5);\n\n',
+    '    /* Optional: slightly darken the background to enhance the \"pressed\" look */\n',
+    '    background-color: #ebebeb;\n\n',
+    '    /* Optional: move the text slightly down to mimic a physical button press */\n',
+    '    padding-top: 6px;\n',
+    '    padding-bottom: 4px;\n',
+    '}\n'])
+    # Styles for the generated outline sidebar and main content
+    style_lines.extend([
+        ".calibre-wrapper { display: flex; min-height: 100vh; }",
+        ".calibre-outline { width: 280px; position: fixed; left: 0; top: 0; bottom: 0; overflow-y: auto; background: #fafafa; border-right: 1px solid #eee; padding: 2em 1.5em 1.5em 1.5em; box-sizing: border-box; z-index: 100; transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1); box-shadow: 2px 0 8px rgba(0, 0, 0, 0.03); }",
+        ".calibre-main { margin-left: 280px; padding: 2em 3em; box-sizing: border-box; width: 100%; transition: margin-left 0.3s cubic-bezier(0.4, 0, 0.2, 1); }",
+        ".calibre-toggle { position: fixed; left: 295px; top: 20px; z-index: 200; width: 40px; height: 40px; display: flex; align-items: center; justify-content: center; cursor: pointer; border-radius: 50%; border: 1px solid #e2e8f0; background: #ffffff; box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06); transition: left 0.3s cubic-bezier(0.4, 0, 0.2, 1), background-color 0.2s, color 0.2s, transform 0.2s; font-size: 1.25em; color: #4a5568; }",
+        ".calibre-toggle:hover { background: #f7fafc; color: #1a202c; transform: scale(1.05); }",
+        ".calibre-wrapper.sidebar-collapsed .calibre-outline { transform: translateX(-100%); }",
+        ".calibre-wrapper.sidebar-collapsed .calibre-main { margin-left: 0; padding-left: 5em; }",
+        ".calibre-wrapper.sidebar-collapsed .calibre-toggle { left: 20px; }",
+        ".calibre-outline-list { list-style: none; padding-left: 0; margin: 0; }",
+        ".calibre-outline-list ul { list-style: none; padding-left: 1.2em; margin: 0.25em 0; border-left: 1px solid #edf2f7; }",
+        ".calibre-outline-item { margin: 0.4em 0; }",
+        ".calibre-outline a { color: #4a5568; text-decoration: none; font-size: 0.9em; transition: color 0.15s ease; display: inline-block; padding: 2px 0; }",
+        ".calibre-outline a:hover { color: #3182ce; }",
+        ".calibre-outline a.active { font-weight: 600; color: #2b6cb0; }",
+        "@media (max-width: 900px) {",
+        "  .calibre-outline { transform: translateX(-100%); box-shadow: 4px 0 15px rgba(0, 0, 0, 0.1); }",
+        "  .calibre-main { margin-left: 0; padding: 1.5em; padding-top: 5em; }",
+        "  .calibre-toggle { left: 20px !important; top: 20px; }",
+        "  .calibre-wrapper.sidebar-open .calibre-outline { transform: translateX(0); }",
+        "  .calibre-sidebar-overlay { display: none; position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0, 0, 0, 0.4); z-index: 90; opacity: 0; transition: opacity 0.3s ease; }",
+        "  .calibre-wrapper.sidebar-open .calibre-sidebar-overlay { display: block; opacity: 1; }",
+        "}"
+    ])
+
+    style_lines.append("</style>\n")
+    
+    # Build outline HTML from collected headings
+    outline_html = generate_outline_html(outline_headings)
+
+    html_output = "\n".join(style_lines) + "\n\n"
+    html_output += '<div class="calibre-wrapper">\n'
+    html_output += outline_html + "\n"
+    html_output += '<main class="calibre-main">\n'
+    html_output += '<form class="calibre-annotations-container">\n'
+    html_output += "\n".join(filter_inputs) + "\n"
+    html_output += '<div class="calibre-filter-controls">\n' + "\n".join(filter_labels) + '\n</div>\n\n'
+    html_output += final_markdown
+    html_output += '\n</form>\n'
+    html_output += '</main>\n</div>\n'
+
+    # Inline JS for toggle, smooth scroll, and active-heading highlighting
+    html_output += '''<script>
+(function(){
+    var wrapper = document.querySelector('.calibre-wrapper');
+    var nav = document.querySelector('.calibre-outline');
+    if(!wrapper || !nav) return;
+
+    // Create backdrop overlay for mobile
+    var overlay = document.createElement('div');
+    overlay.className = 'calibre-sidebar-overlay';
+    wrapper.appendChild(overlay);
+
+    // Create toggle button
+    var btn = document.createElement('button');
+    btn.id = 'outline-toggle';
+    btn.className = 'calibre-toggle';
+    btn.setAttribute('aria-label', 'Toggle sidebar outline');
+    btn.innerHTML = '☰';
+    wrapper.insertBefore(btn, wrapper.firstChild);
+
+    // Toggle click handler
+    btn.addEventListener('click', function(e){
+        e.stopPropagation();
+        var isMobile = window.innerWidth <= 900;
+        if (isMobile) {
+            wrapper.classList.toggle('sidebar-open');
+        } else {
+            wrapper.classList.toggle('sidebar-collapsed');
+        }
+    });
+
+    // Close mobile sidebar when clicking overlay
+    overlay.addEventListener('click', function(){
+        wrapper.classList.remove('sidebar-open');
+    });
+
+    // Handle outline link clicks
+    nav.addEventListener('click', function(e){
+        var a = e.target.closest('a');
+        if(!a) return;
+        
+        if (window.innerWidth <= 900) {
+            wrapper.classList.remove('sidebar-open');
+        }
+
+        var href = a.getAttribute('href');
+        if(href && href.charAt(0) === '#'){
+            var id = href.slice(1);
+            var el = document.getElementById(id);
+            if(el){
+                e.preventDefault();
+                el.scrollIntoView({behavior:'smooth', block:'start'});
+                history.replaceState(null, '', '#'+id);
+            }
+        }
+    });
+
+    var headings = Array.prototype.slice.call(document.querySelectorAll('.calibre-main h1, .calibre-main h2, .calibre-main h3, .calibre-main h4, .calibre-main h5, .calibre-main h6'));
+    var links = Array.prototype.slice.call(nav.querySelectorAll('a'));
+    function onScroll(){
+        var fromTop = window.scrollY + 10;
+        var current = null;
+        for(var i=0;i<headings.length;i++){
+            if(headings[i].offsetTop <= fromTop) current = headings[i];
+        }
+        links.forEach(function(l){ l.classList.remove('active'); });
+        if(current){
+            var activeLink = nav.querySelector('a[href="#'+current.id+'"]');
+            if(activeLink) activeLink.classList.add('active');
+        }
+    }
+    window.addEventListener('scroll', onScroll, {passive:true});
+    onScroll();
+})();
+</script>'''
+    
+    final_output_string = html_output
+    # Replace all lines matching `rgx_split_delim` with <hr> tags
+    final_output_string = re.sub(rgx_split_delim, "\n<hr>\n", final_output_string)
+
+    return final_output_string
 
 
 def friendly_username(user_type, user):
@@ -306,6 +834,7 @@ class Export(Dialog):  # {{{
         self.export_format = ef = QComboBox(self)
         ef.addItem(_('Plain text'), 'txt')
         ef.addItem(_('Markdown'), 'md')
+        ef.addItem(_('HTML'), 'html')
         ef.addItem(*self.file_type_data())
         idx = ef.findData(self.prefs[self.pref_name])
         if idx > -1:
@@ -330,10 +859,11 @@ class Export(Dialog):  # {{{
         self.accept()
 
     def save_to_file(self):
-        filters = [(self.export_format.currentText(), [self.export_format.currentData()])]
+        fmt = self.export_format.currentData()
+        filters = [(self.export_format.currentText(), [fmt])]
         path = choose_save_file(
             self, 'annots-export-save', _('File for exports'), filters=filters,
-            initial_filename=self.initial_filename() + '.' + filters[0][1][0])
+            initial_filename=self.initial_filename() + '.' + fmt)
         if path:
             data = self.exported_data().encode('utf-8')
             with open(path, 'wb') as f:
@@ -343,29 +873,57 @@ class Export(Dialog):  # {{{
 
     def exported_data(self):
         fmt = self.export_format.currentData()
+        db = current_db()
         if fmt == 'calibre_annotation_collection':
             return json.dumps({
                 'version': 1,
                 'type': 'calibre_annotation_collection',
                 'annotations': self.annotations,
             }, ensure_ascii=False, sort_keys=True, indent=2)
+
+        def link_prefix_func(book_id, book_format, a):
+            library_id = getattr(db, 'server_library_id', None)
+            if library_id:
+                library_id = '_hex_-' + library_id.encode('utf-8').hex()
+                return f'calibre://view-book/{library_id}/{book_id}/{book_format}?open_at='
+            return ''
+
+        def _generate_markdown():
+            lines = []
+            bid_groups = {}
+            for a in self.annotations:
+                bid_groups.setdefault(a['book_id'], []).append(a)
+            for book_id, group in bid_groups.items():
+                root = ChapterGroup(level=1)
+                for a in group:
+                    root.add_annot(a)
+                link_prefix = link_prefix_func(book_id, a['format'], a) or None
+
+                lines.append('# ' + db.field_for('title', book_id))
+                lines.append('')
+                root.render_as_text(lines, True, link_prefix)
+                lines.append('')
+            return '\n'.join(lines).strip()
+
+        if fmt == 'html':
+            json_data = json.dumps({
+                'version': 1,
+                'type': 'calibre_annotation_collection',
+                'annotations': self.annotations,
+            })
+            md_data = _generate_markdown()
+            return format_annotations_to_html(json_data, md_data)
+
         lines = []
-        db = current_db()
         bid_groups = {}
         as_markdown = fmt == 'md'
-        library_id = getattr(db, 'server_library_id', None)
-        if library_id:
-            library_id = '_hex_-' + library_id.encode('utf-8').hex()
         for a in self.annotations:
             bid_groups.setdefault(a['book_id'], []).append(a)
         for book_id, group in bid_groups.items():
             root = ChapterGroup(level=1)
             for a in group:
                 root.add_annot(a)
-            if library_id:
-                link_prefix = f'calibre://view-book/{library_id}/{book_id}/{a["format"]}?open_at='
-            else:
-                link_prefix = None
+            link_prefix = link_prefix_func(book_id, a['format'], a) or None
 
             lines.append('# ' + db.field_for('title', book_id))
             lines.append('')

--- a/src/calibre/gui2/library/annotations.py
+++ b/src/calibre/gui2/library/annotations.py
@@ -86,6 +86,60 @@ def render_highlight_as_text(hl, lines, as_markdown=False, link_prefix=None):
         lines.append('───')
     lines.append('')
 
+def get_annotation_style_classes(style):
+    stype = style.get('type')
+    skind = style.get('kind')
+    
+    color = None
+    fname = None
+    is_decoration = False
+    
+    if stype == 'builtin' and skind != 'decoration':
+        color = style.get('which', 'yellow')
+    elif stype == 'builtin' and skind == 'decoration':
+        fname = style.get('which', 'wavy')
+        if fname:
+            is_decoration = True
+    elif stype == 'custom' and skind == 'color':
+        custom_dict = style.get('custom', {})
+        color = custom_dict.get('light') or style.get('light') or 'default'
+    elif stype == 'custom' and skind == 'decoration':
+        fname = style.get('friendly_name')
+        if fname:
+            is_decoration = True
+    else:
+        color = 'default'
+
+    if is_decoration:
+        tag = re.sub(r'[^a-zA-Z0-9-]', '', fname).lower()
+        return tag, f"decor-{tag}"
+    else:
+        safe_color = sanitize_color(color) if color else 'default'
+        return 'blockquote', f"bq-{safe_color}"
+
+def render_highlight_as_html(hl, lines, link_prefix=None):
+    tag, css_class = get_annotation_style_classes(hl.get('style', {}))
+    lines.append(f'<{tag} class="calibre-annotation {css_class}">')
+    
+    lines.append(hl.get('highlighted_text', ''))
+    
+    date = render_timestamp(hl['timestamp'])
+    if link_prefix:
+        cfi = hl['start_cfi']
+        spine_index = (1 + hl['spine_index']) * 2
+        link = (link_prefix + quote(f'epubcfi(/{spine_index}{cfi})')).replace(')', '%29')
+        date_link = f'<a href="{link}">{date}</a>'
+    else:
+        date_link = f'<strong>{date}</strong>'
+
+    lines.append(date_link)
+
+    json_note = hl.get('notes')
+    if json_note and json_note.strip():
+        lines.append(f"<br><em>Note: </em>{json_note}")
+
+    lines.append(f'</{tag}>')
+    lines.append('<hr>')
 
 def render_bookmark_as_text(b, lines, as_markdown=False, link_prefix=None):
     '''Render a bookmark as text.
@@ -108,6 +162,27 @@ def render_bookmark_as_text(b, lines, as_markdown=False, link_prefix=None):
     else:
         lines.append('───')
     lines.append('')
+
+def render_bookmark_as_html(b, lines, link_prefix=None):
+    '''Render a bookmark as HTML.
+
+    Args:
+        b (dict): The bookmark data.
+        lines (list): The list to which the text lines will be appended.
+        link_prefix (str): The prefix for location links.
+    '''
+    # We will use a div for bookmarks to separate them from highlights
+    lines.append('<div class="calibre-annotation calibre-bookmark">')
+    lines.append(f'<strong>{b.get("title", "")}</strong><br>')
+    date = render_timestamp(b['timestamp'])
+    if link_prefix and b.get('pos_type') == 'epubcfi':
+        link = (link_prefix + quote(b['pos'])).replace(')', '%29')
+        date = f'<a href="{link}">{date}</a>'
+    else:
+        date = f'<span>{date}</span>'
+    lines.append(date)
+    lines.append('</div>')
+    lines.append('<hr>')
 
 
 def sanitize_color(color):
@@ -172,6 +247,284 @@ class ChapterGroup:
                 render_highlight_as_text(hl, lines, as_markdown=as_markdown, link_prefix=link_prefix)
         for sg in self.subgroups.values():
             sg.render_as_text(lines, as_markdown, link_prefix)
+
+    def _collect_outline_and_colors(self, outline_headings, heading_id_counts, used_colors, used_decorations):
+        if self.title:
+            level = min(self.level, 6)
+            base = slugify(self.title)
+            hdr_id = get_unique_id(f"outline-{base}", heading_id_counts)
+            self.html_id = hdr_id
+            outline_headings.append({'level': level, 'text': self.title, 'id': hdr_id})
+        
+        for hl in self.annotations:
+            style = hl.get('style', {})
+            stype = style.get('type')
+            skind = style.get('kind')
+            
+            if stype == 'builtin' and skind != 'decoration':
+                color = style.get('which', 'yellow')
+                used_colors.add(color)
+            elif stype == 'custom' and skind == 'color':
+                custom_dict = style.get('custom', {})
+                color = custom_dict.get('light') or style.get('light') or 'default'
+                used_colors.add(color)
+            elif stype == 'custom' and skind == 'decoration':
+                fname = style.get('friendly_name')
+                if fname:
+                    used_decorations[fname] = style
+            elif stype == 'builtin' and skind == 'decoration':
+                fname = style.get('which')
+                if fname:
+                    used_decorations[fname] = {
+                        'text-decoration-color': '#000000',
+                        'text-decoration-line': 'underline',
+                        'text-decoration-style': fname
+                    }
+                    
+        for sg in self.subgroups.values():
+            sg._collect_outline_and_colors(outline_headings, heading_id_counts, used_colors, used_decorations)
+
+    def _render_nodes(self, lines, link_prefix):
+        if self.title:
+            level = min(self.level, 6)
+            lines.append(f'<h{level} id="{getattr(self, "html_id", "")}">{self.title}</h{level}>')
+        for hl in self.annotations:
+            atype = hl.get('type', 'highlight')
+            if atype == 'bookmark':
+                render_bookmark_as_html(hl, lines, link_prefix=link_prefix)
+            else:
+                render_highlight_as_html(hl, lines, link_prefix=link_prefix)
+        for sg in self.subgroups.values():
+            sg._render_nodes(lines, link_prefix)
+
+    def render_as_html(self, link_prefix=None):
+        outline_headings = []
+        heading_id_counts = {}
+        used_colors = set()
+        used_decorations = {}
+        
+        # Traverse the tree to populate outline, colors, and decorations
+        self._collect_outline_and_colors(outline_headings, heading_id_counts, used_colors, used_decorations)
+        
+        # Render the HTML content
+        content_lines = []
+        self._render_nodes(content_lines, link_prefix)
+        final_markdown = '\n'.join(content_lines)
+
+        # Prepend CSS styles
+        style_lines = ['<style>', '/* Calibre Annotation Styles */']
+        
+        style_lines.extend([
+            '.calibre-annotations-container { font-family: sans-serif; }',
+            '.calibre-filter-controls { margin-bottom: 20px; display: flex; gap: 10px; flex-wrap: wrap; }',
+            '.calibre-filter-label { padding: 5px 15px; border-radius: 20px; cursor: pointer; border: 2px solid #ccc; background: #f9f9f9; color: #333; font-size: 14px; font-weight: bold; }',
+            '.calibre-filter-label:hover { opacity: 0.8; }',
+            'input.calibre-filter-cb:checked + label { background-color: #e0e0e0; }',
+            'input.calibre-filter-cb:checked ~ .calibre-annotation { display: none !important; }'
+        ])
+        ids = []
+        filter_inputs = []
+        filter_labels = []
+        
+        filter_labels.append('<button type="reset" class="calibre-filter-label" style="background:#ddd;">Show All</button>')
+        
+        if not used_colors and len(self.annotations) > 0:
+            used_colors.add('default')
+            
+        for color in sorted(list(used_colors)): 
+            sanitized_color = sanitize_color(color)
+            if not sanitized_color: continue
+            
+            border_color = color if sanitized_color != 'default' else '#cccccc'
+            if color == 'yellow': border_color = '#ffeb3b'
+            elif color == 'blue': border_color = '#2196f3'
+            elif color == 'green': border_color = '#4caf50'
+            elif color == 'red': border_color = '#f44336'
+            
+            filter_inputs.append(f'<input type="checkbox" id="filter-color-{sanitized_color}" class="calibre-filter-cb" style="display:none;">')
+            filter_labels.append(f'<label for="filter-color-{sanitized_color}" class="calibre-filter-label" style="border-color:{border_color};">{color}</label>')
+            ids.append(f"filter-color-{sanitized_color}")
+            style_lines.append(f"input#filter-color-{sanitized_color}:checked ~ .bq-{sanitized_color} {{ display: block !important; }}")
+            
+            link_colors = {'yellow': '#795548', 'blue': '#0d47a1', 'green': '#1b5e20', 'red': '#b71c1c', 'default': '#333333'}
+            link_color = link_colors.get(sanitized_color)
+            if link_color == None:
+                try:
+                    link_color = color_contrasting(sanitized_color)
+                except Exception as e:
+                    print(f"Error computing contrasting color for '{sanitized_color}': {e}")
+                    link_color = '#333333'
+            
+            style_lines.extend([
+                f".bq-{sanitized_color} {{",
+                f"  border-left: 3px solid {border_color} !important;",
+                f"  padding: 0.5em 10px;",
+                f"  margin: 1em 0;",
+                f"}}",
+                f".bq-{sanitized_color} a {{",
+                f"  color: {link_color};",
+                f"  font-weight: bold;",
+                f"}}",
+                f".bq-{sanitized_color} em {{",
+                f"  font-style: italic;",
+                f"  font-weight: bold;",
+                f"  color: {link_color};",
+                f"}}"
+            ])
+
+        for fname, dec_style in used_decorations.items():
+            safe_fname = re.sub(r'[^a-zA-Z0-9-]', '', fname).lower()
+            dec_color = dec_style.get('text-decoration-color', '#000')
+            dec_line = dec_style.get('text-decoration-line', 'underline')
+            dec_style_type = dec_style.get('text-decoration-style', 'solid')
+            
+            filter_inputs.append(f'<input type="checkbox" id="filter-decor-{safe_fname}" class="calibre-filter-cb" style="display:none;">')
+            filter_labels.append(f'<label for="filter-decor-{safe_fname}" class="calibre-filter-label" style="text-decoration: {dec_line} {dec_style_type} {dec_color};">{fname}</label>')
+            ids.append(f"filter-decor-{safe_fname}")
+        # Filter logic overrides the generic hide rule
+            style_lines.append(f"input#filter-decor-{safe_fname}:checked ~ .decor-{safe_fname} {{ display: block !important; }}")
+            
+            style_lines.extend([
+                f".decor-{safe_fname} {{",
+                f"  text-decoration-color: {dec_color};",
+                f"  text-decoration-line: {dec_line};",
+                f"  text-decoration-style: {dec_style_type};",
+                f"  display: block;",
+                f"  margin: 1em 0;",
+                f"}}"
+            ])
+    # Add CSS Bevel to indicate selected Pills
+        for i, id in enumerate(ids):
+            ids[i] = f'form.calibre-annotations-container:has(#{id}:checked) label[for="{id}"]'
+        
+        style_lines.extend([f'\n{", ".join(ids)} {{\n    /* The inner bevel effect */\n',
+        '    box-shadow: inset 2px 2px 4px rgba(0, 0, 0, 0.3),\n',
+        '    inset -1px -1px 2px rgba(255, 255, 255, 0.5);\n\n',
+        '    /* Optional: slightly darken the background to enhance the "pressed" look */\n',
+        '    background-color: #ebebeb;\n\n',
+        '    /* Optional: move the text slightly down to mimic a physical button press */\n',
+        '    padding-top: 6px;\n',
+        '    padding-bottom: 4px;\n',
+        '}\n'])
+    # Styles for the generated outline sidebar and main content
+        style_lines.extend([
+            '.calibre-wrapper { display: flex; min-height: 100vh; }',
+            '.calibre-outline { width: 280px; position: fixed; left: 0; top: 0; bottom: 0; overflow-y: auto; background: #fafafa; border-right: 1px solid #eee; padding: 2em 1.5em 1.5em 1.5em; box-sizing: border-box; z-index: 100; transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1); box-shadow: 2px 0 8px rgba(0, 0, 0, 0.03); }',
+            '.calibre-main { margin-left: 280px; padding: 2em 3em; box-sizing: border-box; width: 100%; transition: margin-left 0.3s cubic-bezier(0.4, 0, 0.2, 1); }',
+            '.calibre-toggle { position: fixed; left: 295px; top: 20px; z-index: 200; width: 40px; height: 40px; display: flex; align-items: center; justify-content: center; cursor: pointer; border-radius: 50%; border: 1px solid #e2e8f0; background: #ffffff; box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06); transition: left 0.3s cubic-bezier(0.4, 0, 0.2, 1), background-color 0.2s, color 0.2s, transform 0.2s; font-size: 1.25em; color: #4a5568; }',
+            '.calibre-toggle:hover { background: #f7fafc; color: #1a202c; transform: scale(1.05); }',
+            '.calibre-wrapper.sidebar-collapsed .calibre-outline { transform: translateX(-100%); }',
+            '.calibre-wrapper.sidebar-collapsed .calibre-main { margin-left: 0; padding-left: 5em; }',
+            '.calibre-wrapper.sidebar-collapsed .calibre-toggle { left: 20px; }',
+            '.calibre-outline-list { list-style: none; padding-left: 0; margin: 0; }',
+            '.calibre-outline-list ul { list-style: none; padding-left: 1.2em; margin: 0.25em 0; border-left: 1px solid #edf2f7; }',
+            '.calibre-outline-item { margin: 0.4em 0; }',
+            '.calibre-outline a { color: #4a5568; text-decoration: none; font-size: 0.9em; transition: color 0.15s ease; display: inline-block; padding: 2px 0; }',
+            '.calibre-outline a:hover { color: #3182ce; }',
+            '.calibre-outline a.active { font-weight: 600; color: #2b6cb0; }',
+            '@media (max-width: 900px) {',
+            '  .calibre-outline { transform: translateX(-100%); box-shadow: 4px 0 15px rgba(0, 0, 0, 0.1); }',
+            '  .calibre-main { margin-left: 0; padding: 1.5em; padding-top: 5em; }',
+            '  .calibre-toggle { left: 20px !important; top: 20px; }',
+            '  .calibre-wrapper.sidebar-open .calibre-outline { transform: translateX(0); }',
+            '  .calibre-sidebar-overlay { display: none; position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0, 0, 0, 0.4); z-index: 90; opacity: 0; transition: opacity 0.3s ease; }',
+            '  .calibre-wrapper.sidebar-open .calibre-sidebar-overlay { display: block; opacity: 1; }',
+            '}'
+        ])
+
+        style_lines.append('</style>\n')
+        
+    # Build outline HTML from collected headings
+        outline_html = generate_outline_html(outline_headings)
+
+        html_output = '\n'.join(style_lines) + '\n\n'
+        html_output += '<div class="calibre-wrapper">\n'
+        html_output += outline_html + '\n'
+        html_output += '<main class="calibre-main">\n'
+        html_output += '<form class="calibre-annotations-container">\n'
+        html_output += '\n'.join(filter_inputs) + '\n'
+        html_output += '<div class="calibre-filter-controls">\n' + '\n'.join(filter_labels) + '\n</div>\n\n'
+        html_output += final_markdown
+        html_output += '\n</form>\n'
+        html_output += '</main>\n</div>\n'
+
+    # Inline JS for toggle, smooth scroll, and active-heading highlighting
+        html_output += '''<script>
+(function(){
+    var wrapper = document.querySelector('.calibre-wrapper');
+    var nav = document.querySelector('.calibre-outline');
+    if(!wrapper || !nav) return;
+
+    // Create backdrop overlay for mobile
+    var overlay = document.createElement('div');
+    overlay.className = 'calibre-sidebar-overlay';
+    wrapper.appendChild(overlay);
+
+    // Create toggle button
+    var btn = document.createElement('button');
+    btn.id = 'outline-toggle';
+    btn.className = 'calibre-toggle';
+    btn.setAttribute('aria-label', 'Toggle sidebar outline');
+    btn.innerHTML = '☰';
+    wrapper.insertBefore(btn, wrapper.firstChild);
+
+    // Toggle click handler
+    btn.addEventListener('click', function(e){
+        e.stopPropagation();
+        var isMobile = window.innerWidth <= 900;
+        if (isMobile) {
+            wrapper.classList.toggle('sidebar-open');
+        } else {
+            wrapper.classList.toggle('sidebar-collapsed');
+        }
+    });
+
+    // Close mobile sidebar when clicking overlay
+    overlay.addEventListener('click', function(){
+        wrapper.classList.remove('sidebar-open');
+    });
+
+    // Handle outline link clicks
+    nav.addEventListener('click', function(e){
+        var a = e.target.closest('a');
+        if(!a) return;
+        
+        if (window.innerWidth <= 900) {
+            wrapper.classList.remove('sidebar-open');
+        }
+
+        var href = a.getAttribute('href');
+        if(href && href.charAt(0) === '#'){
+            var id = href.slice(1);
+            var el = document.getElementById(id);
+            if(el){
+                e.preventDefault();
+                el.scrollIntoView({behavior:'smooth', block:'start'});
+                history.replaceState(null, '', '#'+id);
+            }
+        }
+    });
+
+    var headings = Array.prototype.slice.call(document.querySelectorAll('.calibre-main h1, .calibre-main h2, .calibre-main h3, .calibre-main h4, .calibre-main h5, .calibre-main h6'));
+    var links = Array.prototype.slice.call(nav.querySelectorAll('a'));
+    function onScroll(){
+        var fromTop = window.scrollY + 10;
+        var current = null;
+        for(var i=0;i<headings.length;i++){
+            if(headings[i].offsetTop <= fromTop) current = headings[i];
+        }
+        links.forEach(function(l){ l.classList.remove('active'); });
+        if(current){
+            var activeLink = nav.querySelector('a[href="#'+current.id+'"]');
+            if(activeLink) activeLink.classList.add('active');
+        }
+    }
+    window.addEventListener('scroll', onScroll, {passive:true});
+    onScroll();
+})();
+</script>'''
+
+        return html_output
 
 
 url_prefixes = 'http', 'https'
@@ -294,434 +647,6 @@ def generate_outline_html(headings: list) -> str:
     out.append('</ul>')
     out.append('</nav>')
     return '\n'.join(out)
-
-
-def format_annotations_to_html(json_annotations_string: str, markdown_string: str) -> str:
-    '''
-    Formats Markdown text by wrapping Calibre annotations with styled HTML blockquotes.
-
-    This function processes Calibre annotations by replacing the Markdown version of a highlight
-    with an HTML `<blockquote>` that contains the highlight text from the JSON source, an HTML
-    link, and any associated notes. Headers in the original Markdown are preserved.
-
-    Args:
-        json_annotations_string: A JSON string containing Calibre annotation data.
-        markdown_string: A Markdown string to be styled.
-
-    Returns:
-        The new HTML/Markdown string with styled annotations and a prepended <style> tag.
-    
-    Raises:
-        ValueError: If JSON parsing fails or the JSON structure is invalid.
-    '''
-    if not json_annotations_string.strip():
-        raise ValueError('Invalid input: Resolved JSON annotations string is empty.')
-    
-    try:
-        data = json.loads(json_annotations_string)
-    except json.JSONDecodeError as e:
-        snippet = json_annotations_string[:100]
-        raise ValueError(f"Invalid JSON data: {e}. Problem near: \"{snippet}...\"") from e
-
-    json_annotation_list = data.get('annotations')
-    if not isinstance(json_annotation_list, list):
-        json_annotation_list = data.get('highlights')
-    if not isinstance(json_annotation_list, list):
-        raise ValueError('Invalid JSON structure: "annotations" array not found.')
-
-    cfi_to_annotation_map = {}
-    used_colors = set()
-
-    # Collect headings for outline generation and track id collisions
-    outline_headings = []
-    heading_id_counts = {}
-
-    for ann in json_annotation_list:
-        if ann.get('start_cfi') and isinstance(ann.get('spine_index'), int):
-            # The CFI key is constructed as it appears in the decoded Calibre link.
-            cfi_key = f"/{ (ann['spine_index'] * 2) + 2 }{ ann['start_cfi'] }"
-            cfi_to_annotation_map[cfi_key] = ann
-            
-            style = ann.get('style', {})
-            stype = style.get('type')
-            skind = style.get('kind')
-            
-            if stype == 'builtin' and skind != 'decoration':
-                color = style.get('which', 'yellow')
-                used_colors.add(color)
-            elif stype == 'custom' and skind == 'color':
-                custom_dict = style.get('custom', {})
-                color = custom_dict.get('light') or style.get('light') or 'default'
-                used_colors.add(color)
-
-    # Split markdown by '---' delimiter, keeping the delimiter for reconstruction
-    rgx_split_delim = r'(\n-{3,}\n)'
-    markdown_parts = re.split(rgx_split_delim, markdown_string)
-    new_markdown_parts = []
-    
-    # Regex to find the calibre link and extract its text and URL
-    link_regex = re.compile(r'\[(.*?)\]\((calibre:\/\/.*?open_at=epubcfi%28(.*?)%29)\)')
-
-    for part in markdown_parts:
-        if re.search(rgx_split_delim, part):
-            new_markdown_parts.append(part)
-            continue
-        
-        link_match = link_regex.search(part)
-        
-        if not link_match:
-            new_markdown_parts.append(part)
-            continue
-
-        try:
-            # The URL-encoded CFI part is the 3rd capture group
-            cfi_in_link_decoded = unquote(link_match.group(3))
-        except Exception as e:
-            print(f"Could not decode CFI from link: {link_match.group(2)}. Error: {e}")
-            new_markdown_parts.append(part)
-            continue
-            
-        json_annotation = cfi_to_annotation_map.get(cfi_in_link_decoded)
-
-        if not json_annotation:
-            new_markdown_parts.append(part)
-            continue
-
-        style = json_annotation.get('style', {})
-        stype = style.get('type')
-        skind = style.get('kind')
-        
-        color = None
-        fname = None
-        is_decoration = False
-        
-        if stype == 'builtin' and skind != 'decoration':
-            color = style.get('which', 'yellow')
-        elif stype == 'builtin' and skind == 'decoration':
-            fname = style.get('which', 'wavy')
-            if fname:
-                is_decoration = True
-        elif stype == 'custom' and skind == 'color':
-            custom_dict = style.get('custom', {})
-            color = custom_dict.get('light') or style.get('light') or 'default'
-        elif stype == 'custom' and skind == 'decoration':
-            fname = style.get('friendly_name')
-            if fname:
-                is_decoration = True
-        else:
-            color = 'default'
-        
-        # --- Annotation found, now reconstruct the content ---
-        
-        # 1. Separate headers from the main content and convert Markdown headers to HTML
-        prefix_content = ''
-        annotation_content_to_replace = part
-        lines = part.split('\n')
-        first_non_header_line_idx = 0
-        for i, line in enumerate(lines):
-            line_trimmed = line.strip()
-            if line_trimmed.startswith('#'):
-                # Count number of leading hashes for header level
-                header_match = re.match(r'^(#+)\s*(.*)', line_trimmed)
-                if header_match:
-                    header_level = min(len(header_match.group(1)), 6)
-                    header_text = header_match.group(2)
-                    # create a slug/id and ensure uniqueness
-                    base = slugify(header_text)
-                    hdr_id = get_unique_id(f"outline-{base}", heading_id_counts)
-                    prefix_content += f"<h{header_level} id=\"{hdr_id}\">{header_text}</h{header_level}>\n"
-                    outline_headings.append({'level': header_level, 'text': header_text, 'id': hdr_id})
-                first_non_header_line_idx = i + 1
-            elif line_trimmed == '' and prefix_content:
-                prefix_content += '\n'
-                first_non_header_line_idx = i + 1
-            elif line_trimmed != '':
-                break # First non-empty, non-header line
-            else: # Empty line before any real content
-                prefix_content += '\n'
-                first_non_header_line_idx = i + 1
-        
-        annotation_content_to_replace = '\n'.join(lines[first_non_header_line_idx:])
-        json_highlighted_text = json_annotation.get('highlighted_text', '')
-        
-        # Convert Markdown link to HTML <a> tag
-        link_text = link_match.group(1)
-        link_url = link_match.group(2)
-        html_link = f'<a href="{link_url}">{link_text}</a>'
-        
-        # Process note
-        note_for_blockquote = ''
-        original_md_link_str = link_match.group(0)
-        note_section_in_md = annotation_content_to_replace.split(original_md_link_str, 1)[-1]
-        
-        leading_ws_match = re.match(r'^\s*', note_section_in_md)
-        leading_ws_for_note = leading_ws_match.group(0) if leading_ws_match else ''
-        actual_md_note_text = note_section_in_md.lstrip()
-        
-        json_note = json_annotation.get('notes', '')
-        if json_note and json_note.strip() != '' and actual_md_note_text.strip() != '':
-            note_for_blockquote = f"{leading_ws_for_note}<br><em>Note: </em>{actual_md_note_text}"
-        elif actual_md_note_text.strip() != '':
-            note_for_blockquote = note_section_in_md
-
-        # Assemble content
-        inner_content = f"{json_highlighted_text}\n{html_link}"
-        if note_for_blockquote.strip():
-            inner_content += ('\n' if not note_for_blockquote.startswith('\n') else '') + note_for_blockquote.rstrip()
-            
-        if is_decoration:
-            tag = re.sub(r'[^a-zA-Z0-9-]', '', fname).lower()
-            html_element = f'<{tag} class="calibre-annotation decor-{tag}">\n{inner_content}\n</{tag}>'
-        else:
-            safe_color = sanitize_color(color) if color else 'default'
-            html_element = f'<blockquote class="calibre-annotation bq-{safe_color}">\n{inner_content}\n</blockquote>'
-        
-        # Add the prefix (headers) and the new element
-        new_markdown_parts.append(prefix_content.rstrip() + ('\n\n' if prefix_content.strip() else '') + html_element)
-
-    final_markdown = ''.join(new_markdown_parts)
-
-    # Prepend CSS styles
-    style_lines = ['<style>', '/* Calibre Annotation Styles */']
-    
-    style_lines.extend([
-        '.calibre-annotations-container { font-family: sans-serif; }',
-        '.calibre-filter-controls { margin-bottom: 20px; display: flex; gap: 10px; flex-wrap: wrap; }',
-        '.calibre-filter-label { padding: 5px 15px; border-radius: 20px; cursor: pointer; border: 2px solid #ccc; background: #f9f9f9; color: #333; font-size: 14px; font-weight: bold; }',
-        '.calibre-filter-label:hover { opacity: 0.8; }',
-        'input.calibre-filter-cb:checked + label { background-color: #e0e0e0; }',
-        'input.calibre-filter-cb:checked ~ .calibre-annotation { display: none !important; }'
-    ])
-    ids = []
-    filter_inputs = []
-    filter_labels = []
-    
-    # Show All reset button (works because everything is wrapped in a form)
-    filter_labels.append('<button type="reset" class="calibre-filter-label" style="background:#ddd;">Show All</button>')
-    
-    if not used_colors and cfi_to_annotation_map:
-        used_colors.add('default')
-        
-    for color in sorted(list(used_colors)): # Sort for consistent output
-        sanitized_color = sanitize_color(color)
-        if not sanitized_color: continue
-        
-        border_color = color if sanitized_color != 'default' else '#cccccc'
-        if color == 'yellow': border_color = '#ffeb3b'
-        elif color == 'blue': border_color = '#2196f3'
-        elif color == 'green': border_color = '#4caf50'
-        elif color == 'red': border_color = '#f44336'
-        
-        # Pill styling for label
-        filter_inputs.append(f'<input type="checkbox" id="filter-color-{sanitized_color}" class="calibre-filter-cb" style="display:none;">')
-        filter_labels.append(f'<label for="filter-color-{sanitized_color}" class="calibre-filter-label" style="border-color:{border_color};">{color}</label>')
-        ids.append(f"filter-color-{sanitized_color}")
-        # Filter logic overrides the generic hide rule
-        style_lines.append(f"input#filter-color-{sanitized_color}:checked ~ .bq-{sanitized_color} {{ display: block !important; }}")
-        
-        link_colors = {'yellow': '#795548', 'blue': '#0d47a1', 'green': '#1b5e20', 'red': '#b71c1c', 'default': '#333333'}
-        link_color = link_colors.get(sanitized_color)
-        if link_color == None:
-            try:
-                link_color = color_contrasting(sanitized_color)
-            except Exception as e:
-                print(f'Error computing contrasting color for \'{sanitized_color}\': {e}')
-                link_color = '#333333'
-        
-        style_lines.extend([
-            f".bq-{sanitized_color} {{",
-            f"  border-left: 3px solid {border_color} !important;",
-            f"  padding: 0.5em 10px;",
-            f"  margin: 1em 0;",
-            f"}}",
-            f".bq-{sanitized_color} a {{",
-            f"  color: {link_color};",
-            f"  font-weight: bold;",
-            f"}}",
-            f".bq-{sanitized_color} em {{",
-            f"  font-style: italic;",
-            f"  font-weight: bold;",
-            f"  color: {link_color};",
-            f"}}"
-        ])
-        
-    # Handle decorations in styles
-    used_decorations = {}
-    for ann in json_annotation_list:
-        if ann.get('start_cfi') and isinstance(ann.get('spine_index'), int):
-            style = ann.get('style', {})
-            stype = style.get('type')
-            skind = style.get('kind')
-            if stype == 'custom' and skind == 'decoration':
-                fname = style.get('friendly_name')
-                if fname:
-                    used_decorations[fname] = style
-            elif stype == 'builtin' and skind == 'decoration':
-                fname = style.get('which')
-                if fname:
-                    used_decorations[fname] = {
-                        'text-decoration-color': '#000000',
-                        'text-decoration-line': 'underline',
-                        'text-decoration-style': fname
-                    }
-
-    for fname, dec_style in used_decorations.items():
-        safe_fname = re.sub(r'[^a-zA-Z0-9-]', '', fname).lower()
-        dec_color = dec_style.get('text-decoration-color', '#000')
-        dec_line = dec_style.get('text-decoration-line', 'underline')
-        dec_style_type = dec_style.get('text-decoration-style', 'solid')
-        
-        filter_inputs.append(f'<input type="checkbox" id="filter-decor-{safe_fname}" class="calibre-filter-cb" style="display:none;">')
-        filter_labels.append(f'<label for="filter-decor-{safe_fname}" class="calibre-filter-label" style="text-decoration: {dec_line} {dec_style_type} {dec_color};">{fname}</label>')
-        ids.append(f"filter-decor-{safe_fname}")
-        # Filter logic overrides the generic hide rule
-        style_lines.append(f"input#filter-decor-{safe_fname}:checked ~ .decor-{safe_fname} {{ display: block !important; }}")
-        
-        style_lines.extend([
-            f".decor-{safe_fname} {{",
-            f"  text-decoration-color: {dec_color};",
-            f"  text-decoration-line: {dec_line};",
-            f"  text-decoration-style: {dec_style_type};",
-            f"  display: block;",
-            f"  margin: 1em 0;",
-            f"}}"
-        ])
-    # Add CSS Bevel to indicate selected Pills
-    for i, id in enumerate(ids):
-        ids[i] = f'form.calibre-annotations-container:has(#{id}:checked) label[for="{id}"]'
-    
-    style_lines.extend([f'\n{', '.join(ids)} {{\n    /* The inner bevel effect */\n',
-    '    box-shadow: inset 2px 2px 4px rgba(0, 0, 0, 0.3),\n',
-    '    inset -1px -1px 2px rgba(255, 255, 255, 0.5);\n\n',
-    '    /* Optional: slightly darken the background to enhance the \"pressed\" look */\n',
-    '    background-color: #ebebeb;\n\n',
-    '    /* Optional: move the text slightly down to mimic a physical button press */\n',
-    '    padding-top: 6px;\n',
-    '    padding-bottom: 4px;\n',
-    '}\n'])
-    # Styles for the generated outline sidebar and main content
-    style_lines.extend([
-        '.calibre-wrapper { display: flex; min-height: 100vh; }',
-        '.calibre-outline { width: 280px; position: fixed; left: 0; top: 0; bottom: 0; overflow-y: auto; background: #fafafa; border-right: 1px solid #eee; padding: 2em 1.5em 1.5em 1.5em; box-sizing: border-box; z-index: 100; transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1); box-shadow: 2px 0 8px rgba(0, 0, 0, 0.03); }',
-        '.calibre-main { margin-left: 280px; padding: 2em 3em; box-sizing: border-box; width: 100%; transition: margin-left 0.3s cubic-bezier(0.4, 0, 0.2, 1); }',
-        '.calibre-toggle { position: fixed; left: 295px; top: 20px; z-index: 200; width: 40px; height: 40px; display: flex; align-items: center; justify-content: center; cursor: pointer; border-radius: 50%; border: 1px solid #e2e8f0; background: #ffffff; box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06); transition: left 0.3s cubic-bezier(0.4, 0, 0.2, 1), background-color 0.2s, color 0.2s, transform 0.2s; font-size: 1.25em; color: #4a5568; }',
-        '.calibre-toggle:hover { background: #f7fafc; color: #1a202c; transform: scale(1.05); }',
-        '.calibre-wrapper.sidebar-collapsed .calibre-outline { transform: translateX(-100%); }',
-        '.calibre-wrapper.sidebar-collapsed .calibre-main { margin-left: 0; padding-left: 5em; }',
-        '.calibre-wrapper.sidebar-collapsed .calibre-toggle { left: 20px; }',
-        '.calibre-outline-list { list-style: none; padding-left: 0; margin: 0; }',
-        '.calibre-outline-list ul { list-style: none; padding-left: 1.2em; margin: 0.25em 0; border-left: 1px solid #edf2f7; }',
-        '.calibre-outline-item { margin: 0.4em 0; }',
-        '.calibre-outline a { color: #4a5568; text-decoration: none; font-size: 0.9em; transition: color 0.15s ease; display: inline-block; padding: 2px 0; }',
-        '.calibre-outline a:hover { color: #3182ce; }',
-        '.calibre-outline a.active { font-weight: 600; color: #2b6cb0; }',
-        '@media (max-width: 900px) {',
-        '  .calibre-outline { transform: translateX(-100%); box-shadow: 4px 0 15px rgba(0, 0, 0, 0.1); }',
-        '  .calibre-main { margin-left: 0; padding: 1.5em; padding-top: 5em; }',
-        '  .calibre-toggle { left: 20px !important; top: 20px; }',
-        '  .calibre-wrapper.sidebar-open .calibre-outline { transform: translateX(0); }',
-        '  .calibre-sidebar-overlay { display: none; position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0, 0, 0, 0.4); z-index: 90; opacity: 0; transition: opacity 0.3s ease; }',
-        '  .calibre-wrapper.sidebar-open .calibre-sidebar-overlay { display: block; opacity: 1; }',
-        '}'
-    ])
-
-    style_lines.append('</style>\n')
-    
-    # Build outline HTML from collected headings
-    outline_html = generate_outline_html(outline_headings)
-
-    html_output = '\n'.join(style_lines) + '\n\n'
-    html_output += '<div class="calibre-wrapper">\n'
-    html_output += outline_html + '\n'
-    html_output += '<main class="calibre-main">\n'
-    html_output += '<form class="calibre-annotations-container">\n'
-    html_output += '\n'.join(filter_inputs) + '\n'
-    html_output += '<div class="calibre-filter-controls">\n' + '\n'.join(filter_labels) + '\n</div>\n\n'
-    html_output += final_markdown
-    html_output += '\n</form>\n'
-    html_output += '</main>\n</div>\n'
-
-    # Inline JS for toggle, smooth scroll, and active-heading highlighting
-    html_output += '''<script>
-(function(){
-    var wrapper = document.querySelector('.calibre-wrapper');
-    var nav = document.querySelector('.calibre-outline');
-    if(!wrapper || !nav) return;
-
-    // Create backdrop overlay for mobile
-    var overlay = document.createElement('div');
-    overlay.className = 'calibre-sidebar-overlay';
-    wrapper.appendChild(overlay);
-
-    // Create toggle button
-    var btn = document.createElement('button');
-    btn.id = 'outline-toggle';
-    btn.className = 'calibre-toggle';
-    btn.setAttribute('aria-label', 'Toggle sidebar outline');
-    btn.innerHTML = '☰';
-    wrapper.insertBefore(btn, wrapper.firstChild);
-
-    // Toggle click handler
-    btn.addEventListener('click', function(e){
-        e.stopPropagation();
-        var isMobile = window.innerWidth <= 900;
-        if (isMobile) {
-            wrapper.classList.toggle('sidebar-open');
-        } else {
-            wrapper.classList.toggle('sidebar-collapsed');
-        }
-    });
-
-    // Close mobile sidebar when clicking overlay
-    overlay.addEventListener('click', function(){
-        wrapper.classList.remove('sidebar-open');
-    });
-
-    // Handle outline link clicks
-    nav.addEventListener('click', function(e){
-        var a = e.target.closest('a');
-        if(!a) return;
-        
-        if (window.innerWidth <= 900) {
-            wrapper.classList.remove('sidebar-open');
-        }
-
-        var href = a.getAttribute('href');
-        if(href && href.charAt(0) === '#'){
-            var id = href.slice(1);
-            var el = document.getElementById(id);
-            if(el){
-                e.preventDefault();
-                el.scrollIntoView({behavior:'smooth', block:'start'});
-                history.replaceState(null, '', '#'+id);
-            }
-        }
-    });
-
-    var headings = Array.prototype.slice.call(document.querySelectorAll('.calibre-main h1, .calibre-main h2, .calibre-main h3, .calibre-main h4, .calibre-main h5, .calibre-main h6'));
-    var links = Array.prototype.slice.call(nav.querySelectorAll('a'));
-    function onScroll(){
-        var fromTop = window.scrollY + 10;
-        var current = null;
-        for(var i=0;i<headings.length;i++){
-            if(headings[i].offsetTop <= fromTop) current = headings[i];
-        }
-        links.forEach(function(l){ l.classList.remove('active'); });
-        if(current){
-            var activeLink = nav.querySelector('a[href="#'+current.id+'"]');
-            if(activeLink) activeLink.classList.add('active');
-        }
-    }
-    window.addEventListener('scroll', onScroll, {passive:true});
-    onScroll();
-})();
-</script>'''
-    
-    final_output_string = html_output
-    # Replace all lines matching `rgx_split_delim` with <hr> tags
-    final_output_string = re.sub(rgx_split_delim, '\n<hr>\n', final_output_string)
-
-    return final_output_string
 
 
 def friendly_username(user_type, user):

--- a/src/calibre/gui2/library/annotations.py
+++ b/src/calibre/gui2/library/annotations.py
@@ -88,14 +88,14 @@ def render_highlight_as_text(hl, lines, as_markdown=False, link_prefix=None):
 
 
 def render_bookmark_as_text(b, lines, as_markdown=False, link_prefix=None):
-    """Render a bookmark as text.
+    '''Render a bookmark as text.
 
     Args:
         b (dict): The bookmark data.
         lines (list): The list to which the text lines will be appended.
         as_markdown (bool): Whether to render as markdown.
         link_prefix (str): The prefix for location links.
-    """
+    '''
     lines.append(b['title'])
     date = render_timestamp(b['timestamp'])
     if as_markdown and link_prefix and b['pos_type'] == 'epubcfi':
@@ -111,19 +111,19 @@ def render_bookmark_as_text(b, lines, as_markdown=False, link_prefix=None):
 
 
 def sanitize_color(color):
-    """
+    '''
     Extract the hex code from a hexadecimal color
     Args:
         color: A hexadecimal color string (e.g., "#rrggbb").
 
     Returns:
         The hexadecimal color string with the #.
-    """
+    '''
     return re.sub(r'[^a-zA-Z0-9-]', '', color)
 
 
 def color_contrasting(hex_color):
-    """
+    '''
     Generates a contrasting hexadecimal color.
 
     Args:
@@ -131,11 +131,11 @@ def color_contrasting(hex_color):
 
     Returns:
         A contrasting hexadecimal color string.
-    """
-    hex_color = hex_color.lstrip("#")
+    '''
+    hex_color = hex_color.lstrip('#')
     rgb = tuple(int(hex_color[i:i+2], 16) for i in (0, 2, 4))
     contrasting_rgb = tuple(255 - c for c in rgb)
-    return "#{:02x}{:02x}{:02x}".format(*contrasting_rgb)
+    return '#{:02x}{:02x}{:02x}'.format(*contrasting_rgb)
 
 
 class ChapterGroup:
@@ -188,7 +188,7 @@ def url_pat():
     return re.compile(url_pattern, flags=re.I)
 
 
-closing_bracket_map = {'(': ')', '[': ']', '{': '}', '<': '>', '*': '*', '"': '"', "'": "'"}
+closing_bracket_map = {'(': ')', '[': ']', '{': '}', '<': '>', '*': '*', '"': '"', '\'': '\''}
 
 
 def url(text: str, s: int, e: int):
@@ -233,15 +233,15 @@ def render_notes(notes, tag='p'):
 
 
 def slugify(text: str, max_length: int = 60) -> str:
-    """
+    '''
     Convert header text into a URL-safe slug suitable for element IDs.
     - Lowercase
     - Replace non-alphanumeric runs with hyphens
     - Trim leading/trailing hyphens
     - Truncate to `max_length`
-    """
+    '''
     if not text:
-        return "untitled"
+        return 'untitled'
     s = text.strip().lower()
     # replace HTML tags if present
     s = re.sub(r'<[^>]+>', '', s)
@@ -249,14 +249,14 @@ def slugify(text: str, max_length: int = 60) -> str:
     s = re.sub(r'[^a-z0-9]+', '-', s)
     s = s.strip('-')
     if not s:
-        return "untitled"
+        return 'untitled'
     if len(s) > max_length:
         s = s[:max_length].rstrip('-')
     return s
 
 
 def get_unique_id(base: str, counts: dict) -> str:
-    """Return a unique id by using and updating `counts` for collisions."""
+    '''Return a unique id by using and updating `counts` for collisions.'''
     if base not in counts:
         counts[base] = 1
         return base
@@ -265,12 +265,12 @@ def get_unique_id(base: str, counts: dict) -> str:
 
 
 def generate_outline_html(headings: list) -> str:
-    """Generate nested HTML outline (<nav><ul>...) from a flat list of headings.
+    '''Generate nested HTML outline (<nav><ul>...) from a flat list of headings.
 
     Each heading is a dict: {'level': int, 'text': str, 'id': str}
-    """
+    '''
     if not headings:
-        return ""
+        return ''
     out = ['<nav class="calibre-outline" aria-label="Document outline">']
     out.append('<ul class="calibre-outline-list">')
     stack_level = 1
@@ -297,7 +297,7 @@ def generate_outline_html(headings: list) -> str:
 
 
 def format_annotations_to_html(json_annotations_string: str, markdown_string: str) -> str:
-    """
+    '''
     Formats Markdown text by wrapping Calibre annotations with styled HTML blockquotes.
 
     This function processes Calibre annotations by replacing the Markdown version of a highlight
@@ -313,9 +313,9 @@ def format_annotations_to_html(json_annotations_string: str, markdown_string: st
     
     Raises:
         ValueError: If JSON parsing fails or the JSON structure is invalid.
-    """
+    '''
     if not json_annotations_string.strip():
-        raise ValueError("Invalid input: Resolved JSON annotations string is empty.")
+        raise ValueError('Invalid input: Resolved JSON annotations string is empty.')
     
     try:
         data = json.loads(json_annotations_string)
@@ -323,9 +323,9 @@ def format_annotations_to_html(json_annotations_string: str, markdown_string: st
         snippet = json_annotations_string[:100]
         raise ValueError(f"Invalid JSON data: {e}. Problem near: \"{snippet}...\"") from e
 
-    json_annotation_list = data.get("annotations")
+    json_annotation_list = data.get('annotations')
     if not isinstance(json_annotation_list, list):
-        json_annotation_list = data.get("highlights")
+        json_annotation_list = data.get('highlights')
     if not isinstance(json_annotation_list, list):
         raise ValueError('Invalid JSON structure: "annotations" array not found.')
 
@@ -337,21 +337,21 @@ def format_annotations_to_html(json_annotations_string: str, markdown_string: st
     heading_id_counts = {}
 
     for ann in json_annotation_list:
-        if ann.get("start_cfi") and isinstance(ann.get("spine_index"), int):
+        if ann.get('start_cfi') and isinstance(ann.get('spine_index'), int):
             # The CFI key is constructed as it appears in the decoded Calibre link.
             cfi_key = f"/{ (ann['spine_index'] * 2) + 2 }{ ann['start_cfi'] }"
             cfi_to_annotation_map[cfi_key] = ann
             
-            style = ann.get("style", {})
-            stype = style.get("type")
-            skind = style.get("kind")
+            style = ann.get('style', {})
+            stype = style.get('type')
+            skind = style.get('kind')
             
-            if stype == "builtin" and skind != "decoration":
-                color = style.get("which", "yellow")
+            if stype == 'builtin' and skind != 'decoration':
+                color = style.get('which', 'yellow')
                 used_colors.add(color)
-            elif stype == "custom" and skind == "color":
-                custom_dict = style.get("custom", {})
-                color = custom_dict.get("light") or style.get("light") or "default"
+            elif stype == 'custom' and skind == 'color':
+                custom_dict = style.get('custom', {})
+                color = custom_dict.get('light') or style.get('light') or 'default'
                 used_colors.add(color)
 
     # Split markdown by '---' delimiter, keeping the delimiter for reconstruction
@@ -387,34 +387,34 @@ def format_annotations_to_html(json_annotations_string: str, markdown_string: st
             new_markdown_parts.append(part)
             continue
 
-        style = json_annotation.get("style", {})
-        stype = style.get("type")
-        skind = style.get("kind")
+        style = json_annotation.get('style', {})
+        stype = style.get('type')
+        skind = style.get('kind')
         
         color = None
         fname = None
         is_decoration = False
         
-        if stype == "builtin" and skind != "decoration":
-            color = style.get("which", "yellow")
-        elif stype == "builtin" and skind == "decoration":
-            fname = style.get("which", "wavy")
+        if stype == 'builtin' and skind != 'decoration':
+            color = style.get('which', 'yellow')
+        elif stype == 'builtin' and skind == 'decoration':
+            fname = style.get('which', 'wavy')
             if fname:
                 is_decoration = True
-        elif stype == "custom" and skind == "color":
-            custom_dict = style.get("custom", {})
-            color = custom_dict.get("light") or style.get("light") or "default"
-        elif stype == "custom" and skind == "decoration":
-            fname = style.get("friendly_name")
+        elif stype == 'custom' and skind == 'color':
+            custom_dict = style.get('custom', {})
+            color = custom_dict.get('light') or style.get('light') or 'default'
+        elif stype == 'custom' and skind == 'decoration':
+            fname = style.get('friendly_name')
             if fname:
                 is_decoration = True
         else:
-            color = "default"
+            color = 'default'
         
         # --- Annotation found, now reconstruct the content ---
         
         # 1. Separate headers from the main content and convert Markdown headers to HTML
-        prefix_content = ""
+        prefix_content = ''
         annotation_content_to_replace = part
         lines = part.split('\n')
         first_non_header_line_idx = 0
@@ -432,17 +432,17 @@ def format_annotations_to_html(json_annotations_string: str, markdown_string: st
                     prefix_content += f"<h{header_level} id=\"{hdr_id}\">{header_text}</h{header_level}>\n"
                     outline_headings.append({'level': header_level, 'text': header_text, 'id': hdr_id})
                 first_non_header_line_idx = i + 1
-            elif line_trimmed == "" and prefix_content:
+            elif line_trimmed == '' and prefix_content:
                 prefix_content += '\n'
                 first_non_header_line_idx = i + 1
-            elif line_trimmed != "":
+            elif line_trimmed != '':
                 break # First non-empty, non-header line
             else: # Empty line before any real content
                 prefix_content += '\n'
                 first_non_header_line_idx = i + 1
         
         annotation_content_to_replace = '\n'.join(lines[first_non_header_line_idx:])
-        json_highlighted_text = json_annotation.get("highlighted_text", "")
+        json_highlighted_text = json_annotation.get('highlighted_text', '')
         
         # Convert Markdown link to HTML <a> tag
         link_text = link_match.group(1)
@@ -450,18 +450,18 @@ def format_annotations_to_html(json_annotations_string: str, markdown_string: st
         html_link = f'<a href="{link_url}">{link_text}</a>'
         
         # Process note
-        note_for_blockquote = ""
+        note_for_blockquote = ''
         original_md_link_str = link_match.group(0)
         note_section_in_md = annotation_content_to_replace.split(original_md_link_str, 1)[-1]
         
         leading_ws_match = re.match(r'^\s*', note_section_in_md)
-        leading_ws_for_note = leading_ws_match.group(0) if leading_ws_match else ""
+        leading_ws_for_note = leading_ws_match.group(0) if leading_ws_match else ''
         actual_md_note_text = note_section_in_md.lstrip()
         
-        json_note = json_annotation.get("notes", "")
-        if json_note and json_note.strip() != "" and actual_md_note_text.strip() != "":
+        json_note = json_annotation.get('notes', '')
+        if json_note and json_note.strip() != '' and actual_md_note_text.strip() != '':
             note_for_blockquote = f"{leading_ws_for_note}<br><em>Note: </em>{actual_md_note_text}"
-        elif actual_md_note_text.strip() != "":
+        elif actual_md_note_text.strip() != '':
             note_for_blockquote = note_section_in_md
 
         # Assemble content
@@ -473,24 +473,24 @@ def format_annotations_to_html(json_annotations_string: str, markdown_string: st
             tag = re.sub(r'[^a-zA-Z0-9-]', '', fname).lower()
             html_element = f'<{tag} class="calibre-annotation decor-{tag}">\n{inner_content}\n</{tag}>'
         else:
-            safe_color = sanitize_color(color) if color else "default"
+            safe_color = sanitize_color(color) if color else 'default'
             html_element = f'<blockquote class="calibre-annotation bq-{safe_color}">\n{inner_content}\n</blockquote>'
         
         # Add the prefix (headers) and the new element
         new_markdown_parts.append(prefix_content.rstrip() + ('\n\n' if prefix_content.strip() else '') + html_element)
 
-    final_markdown = "".join(new_markdown_parts)
+    final_markdown = ''.join(new_markdown_parts)
 
     # Prepend CSS styles
-    style_lines = ["<style>", "/* Calibre Annotation Styles */"]
+    style_lines = ['<style>', '/* Calibre Annotation Styles */']
     
     style_lines.extend([
-        ".calibre-annotations-container { font-family: sans-serif; }",
-        ".calibre-filter-controls { margin-bottom: 20px; display: flex; gap: 10px; flex-wrap: wrap; }",
-        ".calibre-filter-label { padding: 5px 15px; border-radius: 20px; cursor: pointer; border: 2px solid #ccc; background: #f9f9f9; color: #333; font-size: 14px; font-weight: bold; }",
-        ".calibre-filter-label:hover { opacity: 0.8; }",
-        "input.calibre-filter-cb:checked + label { background-color: #e0e0e0; }",
-        "input.calibre-filter-cb:checked ~ .calibre-annotation { display: none !important; }"
+        '.calibre-annotations-container { font-family: sans-serif; }',
+        '.calibre-filter-controls { margin-bottom: 20px; display: flex; gap: 10px; flex-wrap: wrap; }',
+        '.calibre-filter-label { padding: 5px 15px; border-radius: 20px; cursor: pointer; border: 2px solid #ccc; background: #f9f9f9; color: #333; font-size: 14px; font-weight: bold; }',
+        '.calibre-filter-label:hover { opacity: 0.8; }',
+        'input.calibre-filter-cb:checked + label { background-color: #e0e0e0; }',
+        'input.calibre-filter-cb:checked ~ .calibre-annotation { display: none !important; }'
     ])
     ids = []
     filter_inputs = []
@@ -500,17 +500,17 @@ def format_annotations_to_html(json_annotations_string: str, markdown_string: st
     filter_labels.append('<button type="reset" class="calibre-filter-label" style="background:#ddd;">Show All</button>')
     
     if not used_colors and cfi_to_annotation_map:
-        used_colors.add("default")
+        used_colors.add('default')
         
     for color in sorted(list(used_colors)): # Sort for consistent output
         sanitized_color = sanitize_color(color)
         if not sanitized_color: continue
         
-        border_color = color if sanitized_color != "default" else "#cccccc"
-        if color == "yellow": border_color = "#ffeb3b"
-        elif color == "blue": border_color = "#2196f3"
-        elif color == "green": border_color = "#4caf50"
-        elif color == "red": border_color = "#f44336"
+        border_color = color if sanitized_color != 'default' else '#cccccc'
+        if color == 'yellow': border_color = '#ffeb3b'
+        elif color == 'blue': border_color = '#2196f3'
+        elif color == 'green': border_color = '#4caf50'
+        elif color == 'red': border_color = '#f44336'
         
         # Pill styling for label
         filter_inputs.append(f'<input type="checkbox" id="filter-color-{sanitized_color}" class="calibre-filter-cb" style="display:none;">')
@@ -519,14 +519,14 @@ def format_annotations_to_html(json_annotations_string: str, markdown_string: st
         # Filter logic overrides the generic hide rule
         style_lines.append(f"input#filter-color-{sanitized_color}:checked ~ .bq-{sanitized_color} {{ display: block !important; }}")
         
-        link_colors = {"yellow": "#795548", "blue": "#0d47a1", "green": "#1b5e20", "red": "#b71c1c", "default": "#333333"}
+        link_colors = {'yellow': '#795548', 'blue': '#0d47a1', 'green': '#1b5e20', 'red': '#b71c1c', 'default': '#333333'}
         link_color = link_colors.get(sanitized_color)
         if link_color == None:
             try:
                 link_color = color_contrasting(sanitized_color)
             except Exception as e:
-                print(f"Error computing contrasting color for '{sanitized_color}': {e}")
-                link_color = "#333333"
+                print(f'Error computing contrasting color for \'{sanitized_color}\': {e}')
+                link_color = '#333333'
         
         style_lines.extend([
             f".bq-{sanitized_color} {{",
@@ -548,28 +548,28 @@ def format_annotations_to_html(json_annotations_string: str, markdown_string: st
     # Handle decorations in styles
     used_decorations = {}
     for ann in json_annotation_list:
-        if ann.get("start_cfi") and isinstance(ann.get("spine_index"), int):
-            style = ann.get("style", {})
-            stype = style.get("type")
-            skind = style.get("kind")
-            if stype == "custom" and skind == "decoration":
-                fname = style.get("friendly_name")
+        if ann.get('start_cfi') and isinstance(ann.get('spine_index'), int):
+            style = ann.get('style', {})
+            stype = style.get('type')
+            skind = style.get('kind')
+            if stype == 'custom' and skind == 'decoration':
+                fname = style.get('friendly_name')
                 if fname:
                     used_decorations[fname] = style
-            elif stype == "builtin" and skind == "decoration":
-                fname = style.get("which")
+            elif stype == 'builtin' and skind == 'decoration':
+                fname = style.get('which')
                 if fname:
                     used_decorations[fname] = {
-                        "text-decoration-color": "#000000",
-                        "text-decoration-line": "underline",
-                        "text-decoration-style": fname
+                        'text-decoration-color': '#000000',
+                        'text-decoration-line': 'underline',
+                        'text-decoration-style': fname
                     }
 
     for fname, dec_style in used_decorations.items():
         safe_fname = re.sub(r'[^a-zA-Z0-9-]', '', fname).lower()
-        dec_color = dec_style.get("text-decoration-color", "#000")
-        dec_line = dec_style.get("text-decoration-line", "underline")
-        dec_style_type = dec_style.get("text-decoration-style", "solid")
+        dec_color = dec_style.get('text-decoration-color', '#000')
+        dec_line = dec_style.get('text-decoration-line', 'underline')
+        dec_style_type = dec_style.get('text-decoration-style', 'solid')
         
         filter_inputs.append(f'<input type="checkbox" id="filter-decor-{safe_fname}" class="calibre-filter-cb" style="display:none;">')
         filter_labels.append(f'<label for="filter-decor-{safe_fname}" class="calibre-filter-label" style="text-decoration: {dec_line} {dec_style_type} {dec_color};">{fname}</label>')
@@ -590,7 +590,7 @@ def format_annotations_to_html(json_annotations_string: str, markdown_string: st
     for i, id in enumerate(ids):
         ids[i] = f'form.calibre-annotations-container:has(#{id}:checked) label[for="{id}"]'
     
-    style_lines.extend([f'\n{", ".join(ids)} {{\n    /* The inner bevel effect */\n',
+    style_lines.extend([f'\n{', '.join(ids)} {{\n    /* The inner bevel effect */\n',
     '    box-shadow: inset 2px 2px 4px rgba(0, 0, 0, 0.3),\n',
     '    inset -1px -1px 2px rgba(255, 255, 255, 0.5);\n\n',
     '    /* Optional: slightly darken the background to enhance the \"pressed\" look */\n',
@@ -601,42 +601,42 @@ def format_annotations_to_html(json_annotations_string: str, markdown_string: st
     '}\n'])
     # Styles for the generated outline sidebar and main content
     style_lines.extend([
-        ".calibre-wrapper { display: flex; min-height: 100vh; }",
-        ".calibre-outline { width: 280px; position: fixed; left: 0; top: 0; bottom: 0; overflow-y: auto; background: #fafafa; border-right: 1px solid #eee; padding: 2em 1.5em 1.5em 1.5em; box-sizing: border-box; z-index: 100; transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1); box-shadow: 2px 0 8px rgba(0, 0, 0, 0.03); }",
-        ".calibre-main { margin-left: 280px; padding: 2em 3em; box-sizing: border-box; width: 100%; transition: margin-left 0.3s cubic-bezier(0.4, 0, 0.2, 1); }",
-        ".calibre-toggle { position: fixed; left: 295px; top: 20px; z-index: 200; width: 40px; height: 40px; display: flex; align-items: center; justify-content: center; cursor: pointer; border-radius: 50%; border: 1px solid #e2e8f0; background: #ffffff; box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06); transition: left 0.3s cubic-bezier(0.4, 0, 0.2, 1), background-color 0.2s, color 0.2s, transform 0.2s; font-size: 1.25em; color: #4a5568; }",
-        ".calibre-toggle:hover { background: #f7fafc; color: #1a202c; transform: scale(1.05); }",
-        ".calibre-wrapper.sidebar-collapsed .calibre-outline { transform: translateX(-100%); }",
-        ".calibre-wrapper.sidebar-collapsed .calibre-main { margin-left: 0; padding-left: 5em; }",
-        ".calibre-wrapper.sidebar-collapsed .calibre-toggle { left: 20px; }",
-        ".calibre-outline-list { list-style: none; padding-left: 0; margin: 0; }",
-        ".calibre-outline-list ul { list-style: none; padding-left: 1.2em; margin: 0.25em 0; border-left: 1px solid #edf2f7; }",
-        ".calibre-outline-item { margin: 0.4em 0; }",
-        ".calibre-outline a { color: #4a5568; text-decoration: none; font-size: 0.9em; transition: color 0.15s ease; display: inline-block; padding: 2px 0; }",
-        ".calibre-outline a:hover { color: #3182ce; }",
-        ".calibre-outline a.active { font-weight: 600; color: #2b6cb0; }",
-        "@media (max-width: 900px) {",
-        "  .calibre-outline { transform: translateX(-100%); box-shadow: 4px 0 15px rgba(0, 0, 0, 0.1); }",
-        "  .calibre-main { margin-left: 0; padding: 1.5em; padding-top: 5em; }",
-        "  .calibre-toggle { left: 20px !important; top: 20px; }",
-        "  .calibre-wrapper.sidebar-open .calibre-outline { transform: translateX(0); }",
-        "  .calibre-sidebar-overlay { display: none; position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0, 0, 0, 0.4); z-index: 90; opacity: 0; transition: opacity 0.3s ease; }",
-        "  .calibre-wrapper.sidebar-open .calibre-sidebar-overlay { display: block; opacity: 1; }",
-        "}"
+        '.calibre-wrapper { display: flex; min-height: 100vh; }',
+        '.calibre-outline { width: 280px; position: fixed; left: 0; top: 0; bottom: 0; overflow-y: auto; background: #fafafa; border-right: 1px solid #eee; padding: 2em 1.5em 1.5em 1.5em; box-sizing: border-box; z-index: 100; transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1); box-shadow: 2px 0 8px rgba(0, 0, 0, 0.03); }',
+        '.calibre-main { margin-left: 280px; padding: 2em 3em; box-sizing: border-box; width: 100%; transition: margin-left 0.3s cubic-bezier(0.4, 0, 0.2, 1); }',
+        '.calibre-toggle { position: fixed; left: 295px; top: 20px; z-index: 200; width: 40px; height: 40px; display: flex; align-items: center; justify-content: center; cursor: pointer; border-radius: 50%; border: 1px solid #e2e8f0; background: #ffffff; box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06); transition: left 0.3s cubic-bezier(0.4, 0, 0.2, 1), background-color 0.2s, color 0.2s, transform 0.2s; font-size: 1.25em; color: #4a5568; }',
+        '.calibre-toggle:hover { background: #f7fafc; color: #1a202c; transform: scale(1.05); }',
+        '.calibre-wrapper.sidebar-collapsed .calibre-outline { transform: translateX(-100%); }',
+        '.calibre-wrapper.sidebar-collapsed .calibre-main { margin-left: 0; padding-left: 5em; }',
+        '.calibre-wrapper.sidebar-collapsed .calibre-toggle { left: 20px; }',
+        '.calibre-outline-list { list-style: none; padding-left: 0; margin: 0; }',
+        '.calibre-outline-list ul { list-style: none; padding-left: 1.2em; margin: 0.25em 0; border-left: 1px solid #edf2f7; }',
+        '.calibre-outline-item { margin: 0.4em 0; }',
+        '.calibre-outline a { color: #4a5568; text-decoration: none; font-size: 0.9em; transition: color 0.15s ease; display: inline-block; padding: 2px 0; }',
+        '.calibre-outline a:hover { color: #3182ce; }',
+        '.calibre-outline a.active { font-weight: 600; color: #2b6cb0; }',
+        '@media (max-width: 900px) {',
+        '  .calibre-outline { transform: translateX(-100%); box-shadow: 4px 0 15px rgba(0, 0, 0, 0.1); }',
+        '  .calibre-main { margin-left: 0; padding: 1.5em; padding-top: 5em; }',
+        '  .calibre-toggle { left: 20px !important; top: 20px; }',
+        '  .calibre-wrapper.sidebar-open .calibre-outline { transform: translateX(0); }',
+        '  .calibre-sidebar-overlay { display: none; position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0, 0, 0, 0.4); z-index: 90; opacity: 0; transition: opacity 0.3s ease; }',
+        '  .calibre-wrapper.sidebar-open .calibre-sidebar-overlay { display: block; opacity: 1; }',
+        '}'
     ])
 
-    style_lines.append("</style>\n")
+    style_lines.append('</style>\n')
     
     # Build outline HTML from collected headings
     outline_html = generate_outline_html(outline_headings)
 
-    html_output = "\n".join(style_lines) + "\n\n"
+    html_output = '\n'.join(style_lines) + '\n\n'
     html_output += '<div class="calibre-wrapper">\n'
-    html_output += outline_html + "\n"
+    html_output += outline_html + '\n'
     html_output += '<main class="calibre-main">\n'
     html_output += '<form class="calibre-annotations-container">\n'
-    html_output += "\n".join(filter_inputs) + "\n"
-    html_output += '<div class="calibre-filter-controls">\n' + "\n".join(filter_labels) + '\n</div>\n\n'
+    html_output += '\n'.join(filter_inputs) + '\n'
+    html_output += '<div class="calibre-filter-controls">\n' + '\n'.join(filter_labels) + '\n</div>\n\n'
     html_output += final_markdown
     html_output += '\n</form>\n'
     html_output += '</main>\n</div>\n'
@@ -719,7 +719,7 @@ def format_annotations_to_html(json_annotations_string: str, markdown_string: st
     
     final_output_string = html_output
     # Replace all lines matching `rgx_split_delim` with <hr> tags
-    final_output_string = re.sub(rgx_split_delim, "\n<hr>\n", final_output_string)
+    final_output_string = re.sub(rgx_split_delim, '\n<hr>\n', final_output_string)
 
     return final_output_string
 

--- a/src/calibre/gui2/viewer/highlights.py
+++ b/src/calibre/gui2/viewer/highlights.py
@@ -317,14 +317,10 @@ class Export(ExportBase):
             }, ensure_ascii=False, sort_keys=True, indent=2)
 
         if fmt == 'html':
-            from calibre.gui2.library.annotations import format_annotations_to_html
-            json_data = json.dumps({
-                'version': 1,
-                'type': 'calibre_highlights',
-                'highlights': self.annotations,
-            })
-            md_data = _generate_markdown()
-            return format_annotations_to_html(json_data, md_data)
+            root = ChapterGroup()
+            for a in self.annotations:
+                root.add_annot(a)
+            return root.render_as_html(link_prefix)
 
         if fmt == 'md':
             return _generate_markdown()

--- a/src/calibre/gui2/viewer/highlights.py
+++ b/src/calibre/gui2/viewer/highlights.py
@@ -304,9 +304,29 @@ class Export(ExportBase):
                 'type': 'calibre_highlights',
                 'highlights': self.annotations,
             }, ensure_ascii=False, sort_keys=True, indent=2)
+
+        link_prefix = link_prefix_for_location_links()
+        
+        def _generate_markdown():
+            lines = []
+            root = ChapterGroup()
+            for a in self.annotations:
+                root.add_annot(a)
+            root.render_as_text(lines, True, link_prefix)
+            return '\n'.join(lines).strip()
+
+        if fmt == 'html':
+            from calibre.gui2.library.annotations import format_annotations_to_html
+            json_data = json.dumps({
+                'version': 1,
+                'type': 'calibre_highlights',
+                'highlights': self.annotations,
+            })
+            md_data = _generate_markdown()
+            return format_annotations_to_html(json_data, md_data)
+
         lines = []
         as_markdown = fmt == 'md'
-        link_prefix = link_prefix_for_location_links()
         root = ChapterGroup()
         for a in self.annotations:
             root.add_annot(a)

--- a/src/calibre/gui2/viewer/highlights.py
+++ b/src/calibre/gui2/viewer/highlights.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # License: GPL v3 Copyright: 2020, Kovid Goyal <kovid at kovidgoyal.net>
 
+from calibre.gui2.dialogs import template_general_info
 import json
 import math
 from collections import defaultdict
@@ -298,15 +299,8 @@ class Export(ExportBase):
 
     def exported_data(self):
         fmt = self.export_format.currentData()
-        if fmt == 'calibre_highlights':
-            return json.dumps({
-                'version': 1,
-                'type': 'calibre_highlights',
-                'highlights': self.annotations,
-            }, ensure_ascii=False, sort_keys=True, indent=2)
-
         link_prefix = link_prefix_for_location_links()
-        
+
         def _generate_markdown():
             lines = []
             root = ChapterGroup()
@@ -314,6 +308,13 @@ class Export(ExportBase):
                 root.add_annot(a)
             root.render_as_text(lines, True, link_prefix)
             return '\n'.join(lines).strip()
+
+        if fmt == 'calibre_highlights':
+            return json.dumps({
+                'version': 1,
+                'type': 'calibre_highlights',
+                'highlights': self.annotations,
+            }, ensure_ascii=False, sort_keys=True, indent=2)
 
         if fmt == 'html':
             from calibre.gui2.library.annotations import format_annotations_to_html
@@ -325,13 +326,8 @@ class Export(ExportBase):
             md_data = _generate_markdown()
             return format_annotations_to_html(json_data, md_data)
 
-        lines = []
-        as_markdown = fmt == 'md'
-        root = ChapterGroup()
-        for a in self.annotations:
-            root.add_annot(a)
-        root.render_as_text(lines, as_markdown, link_prefix)
-        return '\n'.join(lines).strip()
+        if fmt == 'md':
+            return _generate_markdown()
 
 
 class Highlights(QTreeWidget):


### PR DESCRIPTION
## Goal / Context
This PR integrates rich, interactive HTML export functionality for highlights and annotations in Calibre, allowing users to export their notes with a responsive, styled sidebar, outline navigation, and real-time filtering options. It updates both the main library annotations dialog and the standalone E-book viewer highlights dialog.

---

## Technical Details

### 1. Library Annotations Manager (`src/calibre/gui2/library/annotations.py`)

- **HTML Generation Engine (`format_annotations_to_html`)**:
  - Implemented the conversion logic that takes raw JSON annotations and markdown formatted highlights and outputs a fully stylized HTML page.
  - Parsed headings to construct an interactive navigation sidebar outline using custom outline parsing helpers.
  - Injected responsive inline CSS styling that supports a collapsible sidebar (responsive layout under `900px`), CSS Grid and Flex layouts for notes, and highlight color tokens.
  - Appended client-side Javascript to handle:
    - Sidebar expansion/collapsing (and backdrop handling on mobile viewports).
    - Active heading highlighting based on scroll position using `scroll` event listeners and `offsetTop` bounds.
    - Smooth scrolling when outline links are clicked.
- **Helper Functions**:
  - **`slugify`**: Generates url-safe slugs from section headers.
  - **`get_unique_id`**: Ensures header anchors are unique to avoid collision.
  - **`generate_outline_html`**: Builds a nested semantic tree layout for the table of contents sidebar.
- **Export UI and Data Flow (`Export` class)**:
  - Added the **HTML** option to the format combobox dropdown in `setup_ui`.
  - Refactored `exported_data()` to abstract markdown generation into a local helper function `_generate_markdown()`. This allows both standard Markdown export and HTML export to leverage the same document structures.
  - In the `html` branch, the method constructs a JSON representation of the collection along with the generated Markdown, then invokes `format_annotations_to_html()`.

---

### 2. Viewer Highlights Dialog (`src/calibre/gui2/viewer/highlights.py`)

- **Export Compatibility**:
  - Modified the viewer's `Export` dialog to handle the `html` format similarly.
  - Refactored the core Markdown generation routine into a local `_generate_markdown()` function within `exported_data()`.
  - Dynamically imports `format_annotations_to_html` from the library annotations module when the user chooses to export annotations or highlights as HTML from the E-book viewer.
