### PR TITLE
SNB input: fix IndexError by keeping entry filenames as str

### DIFF
--- a/src/calibre/ebooks/snb/snbfile.py
+++ b/src/calibre/ebooks/snb/snbfile.py
@@ -107,7 +107,8 @@ class SNBFile:
         for i in range(fileCount):
             f = FileStream()
             (f.attr, f.fileNameOffset, f.fileSize) = struct.unpack('>iii', vfat[i * 12 : (i+1)*12])
-            f.fileName = fileNames[i]
+            # Decode to str so lookups against str keys match (see GetFileStream)
+            f.fileName = fileNames[i].decode('utf-8', 'replace')
             self.files.append(f)
 
     def ParseTail(self, vtail, fileCount):
@@ -159,8 +160,6 @@ class SNBFile:
         with open(os.path.join(tdir, fileName), 'rb') as data:
             f.fileBody = data.read()
         f.fileName = fileName.replace(os.sep, '/')
-        if isinstance(f.fileName, str):
-            f.fileName = f.fileName.encode('ascii', 'ignore')
         self.files.append(f)
 
     def AppendBinary(self, fileName, tdir):
@@ -170,8 +169,6 @@ class SNBFile:
         with open(os.path.join(tdir, fileName), 'rb') as data:
             f.fileBody = data.read()
         f.fileName = fileName.replace(os.sep, '/')
-        if isinstance(f.fileName, str):
-            f.fileName = f.fileName.encode('ascii', 'ignore')
         self.files.append(f)
 
     def GetFileStream(self, fileName):
@@ -208,7 +205,7 @@ class SNBFile:
         binStream = b''
         for f in self.files:
             vfat += struct.pack('>iii', f.attr, len(fileNameTable), f.fileSize)
-            fileNameTable += (f.fileName + b'\0')
+            fileNameTable += f.fileName.encode('ascii', 'ignore') + b'\0'
 
             if f.attr & 0x41000000 == 0x41000000:
                 # Plain Files


### PR DESCRIPTION
### Problem

Converting an SNB file (`ebook-convert book.snb out.epub`) crashes:

```
File "calibre/ebooks/oeb/base.py", line 1967, in _to_ncx
IndexError: list index out of range
```

The real failure happens earlier. `SNBFile.ParseFile` stores each entry's `fileName` as the raw ASCII **bytes** from the container, but every consumer works with **str**:

- the SNB input plugin calls `snbFile.GetFileStream('snbf/book.snbf')` and builds `'snbc/' + chapterSrc`
- `GetFileStream` compares `file.fileName == fileName`

Under Python 3 a `bytes`/`str` comparison is always `False`, so the plugin reads nothing and produces an empty book — which then blows up with the `IndexError` during NCX/cover generation.

### Fix

Decode entry filenames to `str` in `ParseFile` so the lookups match. Correspondingly, keep filenames as `str` in `AppendPlain`/`AppendBinary` and encode them to ASCII bytes only where the on-disk format actually needs them, in `Output()`. This makes `fileName` consistently `str` everywhere in memory.

### Testing

- Before: `ebook-convert book.snb out.epub` fails with `IndexError: list index out of range`.
- After: the same conversion succeeds and produces a valid EPUB with chapters and cover.
- The SNB `Output()` round-trip is unchanged byte-for-byte (filenames are still written as `encode('ascii', 'ignore')`).