### PR TITLE
Allow typed AI prompts to reference selected viewer text

### DIFF
--- a/src/calibre/gui2/viewer/llm.py
+++ b/src/calibre/gui2/viewer/llm.py
@@ -19,6 +19,38 @@ from calibre.utils.localization import ui_language_as_english
 from polyglot.binary import from_hex_unicode
 
 
+def selected_text_for_prompt(selected_text: str) -> str:
+    if not selected_text:
+        return ''
+    probably_has_multiple_words = len(selected_text) > 20 or ' ' in selected_text
+    what = 'Text to analyze: ' if probably_has_multiple_words else 'Word to analyze: '
+    return prompt_sep + what + selected_text
+
+
+def uses_field(template: str, field_name: str) -> bool:
+    try:
+        for _, fname, _, _ in string.Formatter().parse(template):
+            if fname == field_name:
+                return True
+    except ValueError:
+        pass
+    return False
+
+
+class SafeFormatDict(dict):
+
+    def __missing__(self, key):
+        return '{' + key + '}'
+
+
+def format_prompt_template(template: str, **kwargs: str) -> str:
+    vals = SafeFormatDict(language=ui_language_as_english(), **kwargs)
+    try:
+        return template.format_map(vals)
+    except ValueError:
+        return template
+
+
 class Action(ActionData):
 
     @property
@@ -31,7 +63,6 @@ class Action(ActionData):
     def prompt_text(self, selected_text: str = '') -> str:
         probably_has_multiple_words = len(selected_text) > 20 or ' ' in selected_text
         pt = self.prompt_template
-        what = 'Text to analyze: ' if probably_has_multiple_words else 'Word to analyze: '
         if not probably_has_multiple_words:
             match self.name:
                 case 'explain':
@@ -41,8 +72,7 @@ class Action(ActionData):
                 case 'translate':
                     pt = 'Translate the following word into the language {language}. {selected}'
 
-        selected_text = (prompt_sep + what + selected_text) if selected_text else ''
-        return pt.format(selected=selected_text, language=ui_language_as_english()).strip()
+        return format_prompt_template(pt, selected=selected_text_for_prompt(selected_text)).strip()
 
 
 @lru_cache(2)
@@ -92,21 +122,14 @@ class LLMPanel(ConverseWidget):
         authors = metadata.get('authors', [])
         self.book_authors = authors_to_string(authors)
 
-    def add_selected_text_reference(self, prompt: str) -> str:
-        selected_text = self.latched_conversation_text
-        if selected_text:
-            prompt += prompt_sep + _('Quoted text from the current selection:') + '\n\n' + selected_text
-        return prompt
-
     def activate_action(self, action: Action) -> None:
         self.start_api_call(self.prompt_text_for_action(action), uses_selected_text=action.uses_selected_text)
 
     def run_custom_prompt(self, prompt: str) -> None:
         if prompt := prompt.strip():
-            starts_new_conversation = not self.conversation_history
-            if starts_new_conversation:
-                prompt = self.add_selected_text_reference(prompt)
-            self.start_api_call(prompt, uses_selected_text=starts_new_conversation and bool(self.latched_conversation_text))
+            uses_selected_text = uses_field(prompt, 'selected')
+            prompt = format_prompt_template(prompt, selected=selected_text_for_prompt(self.latched_conversation_text))
+            self.start_api_call(prompt, uses_selected_text=uses_selected_text)
 
     def settings_dialog(self) -> QDialog:
         return LLMSettingsDialog(self)
@@ -158,8 +181,10 @@ class LLMPanel(ConverseWidget):
                 st = st[:200] + '…'
             msg = f"<h3>{_('Selected text')}</h3><i>{st}</i>"
             msg += self.quick_actions_as_html(current_actions())
-            msg += '<p>' + _('Or, type a question to the AI below, for example:') + '<br>'
-            msg += '<i>Summarize this book.</i>'
+            msg += '<p>' + _(
+                'Or, type a question to the AI below. Use {0} to include the selected text, for example:'
+            ).format('<b>{selected}</b>') + '<br>'
+            msg += '<i>Summarize {selected}</i>'
         return msg
 
     def prompt_text_for_action(self, action) -> str:

--- a/src/calibre/gui2/viewer/llm.py
+++ b/src/calibre/gui2/viewer/llm.py
@@ -92,8 +92,21 @@ class LLMPanel(ConverseWidget):
         authors = metadata.get('authors', [])
         self.book_authors = authors_to_string(authors)
 
+    def add_selected_text_reference(self, prompt: str) -> str:
+        selected_text = self.latched_conversation_text
+        if selected_text:
+            prompt += prompt_sep + _('Quoted text from the current selection:') + '\n\n' + selected_text
+        return prompt
+
     def activate_action(self, action: Action) -> None:
         self.start_api_call(self.prompt_text_for_action(action), uses_selected_text=action.uses_selected_text)
+
+    def run_custom_prompt(self, prompt: str) -> None:
+        if prompt := prompt.strip():
+            starts_new_conversation = not self.conversation_history
+            if starts_new_conversation:
+                prompt = self.add_selected_text_reference(prompt)
+            self.start_api_call(prompt, uses_selected_text=starts_new_conversation and bool(self.latched_conversation_text))
 
     def settings_dialog(self) -> QDialog:
         return LLMSettingsDialog(self)


### PR DESCRIPTION
### Motivation

When text is selected in the ebook viewer, the AI panel already includes that selection when the user clicks one of the predefined quick actions. However, if the user types a free-form question directly into the AI chat box, the selected text was not included in the model context.

This makes typed prompts behave differently from quick actions even though both are initiated from the same selected viewer text.

### Description

This change allows free-form AI chat prompts in the viewer to reference the current selected text explicitly with the `{selected}` placeholder.

This matches the existing custom action behavior:

- If a typed prompt contains `{selected}`, it is replaced with the currently latched viewer selection.
- If a typed prompt does not contain `{selected}`, it is sent unchanged.
- Unknown placeholders are preserved instead of raising formatting errors.
- The viewer help text now documents `{selected}` for free-form prompts.

### Testing

- `python -m py_compile src/calibre/gui2/viewer/llm.py`
- `git diff --check`


---
> ### Description
> 
> This change makes free-form AI chat prompts include the currently latched viewer selection when they start a new conversation.
> 
> - Add `LLMPanel.add_selected_text_reference()` to append the selected text to a prompt with a clear localized label: `Quoted text from the current selection:`.
> - Override `LLMPanel.run_custom_prompt()` so typed prompts include the selected text only when starting a new conversation.
> - Do not repeat the selected text on follow-up prompts in the same conversation, since the existing conversation history already contains the initial quoted context.
> - Pass `uses_selected_text=True` only when the typed prompt actually starts a new conversation with selected-text context.
> 
> ### Testing
> 
> - `python -m py_compile src/calibre/gui2/viewer/llm.py`
> - `git diff --check`