### PR TITLE
feat(content server): Add support for content server plugins

### DIFF
--- a/src/calibre/customize/__init__.py
+++ b/src/calibre/customize/__init__.py
@@ -894,3 +894,23 @@ class AIProviderPlugin(Plugin):  # {{{
             return model_id
         return self.builtin_live_module.human_readable_model_name(model_id)
 # }}}
+
+
+class ContentServerPlugin(Plugin):  # {{{
+
+    type = _('Content server')
+    supported_platforms = ['windows', 'osx', 'linux']
+    # minimum version when support for this plugin type was added
+    minimum_calibre_version = (9, 12, 0)
+
+    def content_server_endpoints(self):
+        '''
+        Return endpoint functions decorated with @endpoint().
+        These are registered with the content server's router at startup.
+
+        The default returns an empty tuple. Override to provide routes.
+        Endpoints with auth_required=False will be publicly accessible.
+        Endpoints with a route matching an existing route will not be added.
+        '''
+        return ()
+# }}}

--- a/src/calibre/customize/ui.py
+++ b/src/calibre/customize/ui.py
@@ -14,6 +14,7 @@ from calibre.constants import DEBUG, ismacos, numeric_version, system_plugins_lo
 from calibre.customize import (
     AIProviderPlugin,
     CatalogPlugin,
+    ContentServerPlugin,
     EditBookToolPlugin,
     FileTypePlugin,
     InterfaceActionBase,
@@ -764,6 +765,16 @@ def all_edit_book_tool_plugins():
     for plugin in _initialized_plugins:
         if isinstance(plugin, EditBookToolPlugin):
             yield plugin
+# }}}
+
+
+# Content server plugins {{{
+
+def content_server_plugins():
+    for plugin in _initialized_plugins:
+        if isinstance(plugin, ContentServerPlugin):
+            if not is_disabled(plugin):
+                yield plugin
 # }}}
 
 

--- a/src/calibre/srv/handler.py
+++ b/src/calibre/srv/handler.py
@@ -205,9 +205,25 @@ class Handler:
         for module in SRV_MODULES:
             module = import_module('calibre.srv.' + module)
             self.router.load_routes(vars(module).values())
+        self._load_content_server_plugin_routes()
         self.router.finalize()
         self.router.ctx.url_for = self.router.url_for
         self.dispatch = self.router.dispatch
+
+    def _load_content_server_plugin_routes(self):
+        from calibre.customize.ui import content_server_plugins
+        for plugin in content_server_plugins():
+            try:
+                endpoints = plugin.content_server_endpoints()
+            except Exception:
+                continue
+            for ep in endpoints:
+                try:
+                    self.router.add(ep)
+                except ValueError:
+                    # Route key already exists (built-in or another plugin).
+                    # Plugins do not override existing routes.
+                    pass
 
     def set_log(self, log):
         self.router.ctx.log = log

--- a/src/calibre/srv/tests/content_server_plugin.py
+++ b/src/calibre/srv/tests/content_server_plugin.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python
+
+
+__license__ = 'GPL v3'
+__copyright__ = '2026, calibre contributors'
+
+from calibre.srv.routes import endpoint
+from calibre.srv.tests.base import BaseTest
+
+
+class TestContentServerPlugin(BaseTest):
+
+    def test_basic_endpoint_registration(self):
+        from calibre.customize import ContentServerPlugin
+
+        class TestPlugin(ContentServerPlugin):
+            name = 'Test Content Plugin'
+
+            def content_server_endpoints(self):
+                @endpoint('/test-plugin/hello', auth_required=False)
+                def hello(ctx, rd):
+                    return 'hello'
+                return [hello]
+
+        plugin = TestPlugin(None)
+        endpoints = list(plugin.content_server_endpoints())
+        self.assertEqual(len(endpoints), 1)
+        self.assertTrue(getattr(endpoints[0], 'is_endpoint', False))
+        self.assertEqual(endpoints[0].route, '/test-plugin/hello')
+        self.assertFalse(endpoints[0].auth_required)
+
+    def test_default_empty_endpoints(self):
+        from calibre.customize import ContentServerPlugin
+
+        plugin = ContentServerPlugin(None)
+        endpoints = plugin.content_server_endpoints()
+        self.assertEqual(len(list(endpoints)), 0)
+
+    def test_multiple_endpoints(self):
+        from calibre.customize import ContentServerPlugin
+
+        class MultiPlugin(ContentServerPlugin):
+            name = 'Multi Route Plugin'
+
+            def content_server_endpoints(self):
+                @endpoint('/multi/a')
+                def a(ctx, rd):
+                    pass
+
+                @endpoint('/multi/b', auth_required=False)
+                def b(ctx, rd):
+                    pass
+
+                @endpoint('/multi/{x}', types={'x': int})
+                def c(ctx, rd, x):
+                    pass
+
+                return [a, b, c]
+
+        plugin = MultiPlugin(None)
+        eps = list(plugin.content_server_endpoints())
+        self.assertEqual(len(eps), 3)
+        self.assertTrue(eps[0].auth_required)
+        self.assertFalse(eps[1].auth_required)
+        self.assertEqual(eps[2].types, {'x': int})
+
+
+class TestPluginDiscovery(BaseTest):
+    '''
+    Test that ContentServerPlugin endpoints are discovered and registered.
+    Uses Router directly rather than Handler to avoid PyQt6 dependency
+    in the test environment (calibre.srv.ajax -> calibre.ebooks.covers -> QtGui).
+    '''
+
+    def setUp(self):
+        from calibre.customize.ui import _initialized_plugins, config
+        self._orig_plugins = list(_initialized_plugins)
+        self._orig_disabled = set(config['disabled_plugins'])
+
+    def tearDown(self):
+        from calibre.customize.ui import _initialized_plugins, config
+        _initialized_plugins[:] = self._orig_plugins
+        config['disabled_plugins'] = self._orig_disabled
+
+    def _register_all_plugin_routes(self, router):
+        from calibre.customize.ui import content_server_plugins
+        for plugin in content_server_plugins():
+            for ep in plugin.content_server_endpoints():
+                try:
+                    router.add(ep)
+                except ValueError:
+                    pass
+
+    def test_plugin_routes_loaded(self):
+        from calibre.customize import ContentServerPlugin
+        from calibre.customize.ui import _initialized_plugins
+        from calibre.srv.routes import Router
+
+        class RoutePlugin(ContentServerPlugin):
+            name = 'Test Route Plugin'
+
+            def content_server_endpoints(self):
+                @endpoint('/test-route/ping', auth_required=False)
+                def ping(ctx, rd):
+                    return 'pong'
+                return [ping]
+
+        plugin = RoutePlugin(None)
+        _initialized_plugins.append(plugin)
+        router = Router()
+        self._register_all_plugin_routes(router)
+        router.finalize()
+        path = tuple(filter(None, '/test-route/ping'.split('/')))
+        ep, args = router.find_route(path)
+        self.assertEqual(ep.route, '/test-route/ping')
+        self.assertFalse(ep.auth_required)
+        _initialized_plugins.remove(plugin)
+
+    def test_disabled_plugin_skipped(self):
+        from calibre.customize import ContentServerPlugin
+        from calibre.customize.ui import _initialized_plugins, config
+        from calibre.srv.routes import HTTPNotFound, Router
+
+        class RoutePlugin(ContentServerPlugin):
+            name = 'Disabled Route Plugin'
+
+            def content_server_endpoints(self):
+                @endpoint('/disabled-route/test', auth_required=False)
+                def test(ctx, rd):
+                    return 'test'
+                return [test]
+
+        plugin = RoutePlugin(None)
+        _initialized_plugins.append(plugin)
+        config['disabled_plugins'].add(plugin.name)
+        router = Router()
+        self._register_all_plugin_routes(router)
+        router.finalize()
+        path = tuple(filter(None, '/disabled-route/test'.split('/')))
+        with self.assertRaises(HTTPNotFound):
+            router.find_route(path)
+        _initialized_plugins.remove(plugin)
+
+    def test_plugin_conflict_does_not_override(self):
+        from calibre.customize import ContentServerPlugin
+        from calibre.customize.ui import _initialized_plugins
+        from calibre.srv.routes import Router
+
+        @endpoint('/test-route/ping', auth_required=False)
+        def original(ctx, rd):
+            return 'original'
+
+        class OverridePlugin(ContentServerPlugin):
+            name = 'Override Plugin'
+
+            def content_server_endpoints(self):
+                @endpoint('/test-route/ping', auth_required=False)
+                def duplicate(ctx, rd):
+                    return 'duplicate'
+                return [duplicate]
+
+        plugin = OverridePlugin(None)
+        _initialized_plugins.append(plugin)
+        router = Router()
+        router.add(original)
+        self._register_all_plugin_routes(router)
+        router.finalize()
+        path = tuple(filter(None, '/test-route/ping'.split('/')))
+        ep, args = router.find_route(path)
+        self.assertEqual(ep.__name__, 'original')
+        _initialized_plugins.remove(plugin)
+
+    def test_broken_plugin_does_not_block_others(self):
+        from calibre.customize import ContentServerPlugin
+        from calibre.customize.ui import _initialized_plugins
+        from calibre.srv.routes import Router
+
+        class GoodPlugin(ContentServerPlugin):
+            name = 'Good Plugin'
+
+            def content_server_endpoints(self):
+                @endpoint('/good/hello', auth_required=False)
+                def hello(ctx, rd):
+                    return 'hello'
+                return [hello]
+
+        class BrokenPlugin(ContentServerPlugin):
+            name = 'Broken Plugin'
+
+            def content_server_endpoints(self):
+                raise RuntimeError('oops')
+
+        good = GoodPlugin(None)
+        broken = BrokenPlugin(None)
+        _initialized_plugins.append(good)
+        _initialized_plugins.append(broken)
+        router = Router()
+        from calibre.customize.ui import content_server_plugins
+        for plugin in content_server_plugins():
+            try:
+                endpoints = plugin.content_server_endpoints()
+            except Exception:
+                continue
+            for ep in endpoints:
+                try:
+                    router.add(ep)
+                except ValueError:
+                    pass
+        router.finalize()
+        path = tuple(filter(None, '/good/hello'.split('/')))
+        ep, args = router.find_route(path)
+        self.assertEqual(ep.route, '/good/hello')
+        _initialized_plugins.remove(good)
+        _initialized_plugins.remove(broken)


### PR DESCRIPTION
Enable support for third-party calibre plugins to register HTTP routes on the content server, using the existing @endpoint decorator for route metadata and auth-control. A new `ContentServerPlugin` base class provides a `content_server_endpoints()` function that returns decorated endpoint functions; these are discovered in `Handler.__init__()` after built-in routes are loaded, so both standalone and embedded servers pick them up. Third-party plugins are not allowed to modify existing routes, they may only add new ones. This does mean that a third-party plugin will not be able to register a route taken by a third-party plugin loaded earlier. Plugin import order will determine which plugin gets to register the route in the event of a collision.