### PR TITLE
Fix New Scientist magazine recipe

### DIFF
--- a/recipes/new_scientist_mag.recipe
+++ b/recipes/new_scientist_mag.recipe
@@ -56,20 +56,23 @@ class NewScientist(BasicNewsRecipe):
 
     extra_css = '''
         img {display:block; margin:0 auto;}
-        .ArticleHeader__Category { font-size:small; color:#404040; }
-        .ArticleHeader__Author, .ArticleHeader__DateTimeWrapper { font-size:small; }
-        .ArticleHeader__Copy { font-style:italic; color:#202020; }
-        .ArticleImage { font-size:small; text-align:center; }
-        .ArticleImageCaption__Credit { font-size:smaller; }
+        .article__category { font-size:small; color:#404040; }
+        .article__byline, .article__date { font-size:small; }
+        .article__excerpt { font-style:italic; color:#202020; }
+        figcaption { font-size:small; text-align:center; }
+        .wp-image__caption--credit { font-size:smaller; }
     '''
 
     keep_only_tags = [
-        classes('ArticleHeader ArticleContent')
+        classes('article__category article__title article__excerpt article__byline article__date article__content')
     ]
 
     remove_tags = [
         dict(name=['svg', 'button']),
-        classes('ArticleHeader__SocialWrapper AdvertWrapper ReadMoreWithImage ArticleTopics')
+        classes(
+            'advert-wrapper read-more__standard '
+            'wp-block-newscientist-newsletter-promotion js-content-prompt-opportunity'
+        )
     ]
 
     recipe_specific_options = {
@@ -86,27 +89,39 @@ class NewScientist(BasicNewsRecipe):
             issue_url = 'https://www.newscientist.com/issue/' + d
 
         soup = self.index_to_soup(issue_url)
-        div = soup.find('div', attrs={'class':'ThisWeeksMagazineHero__CoverInfo'})
-        tme = div.find(**classes('ThisWeeksMagazineHero__MagInfoHeading'))
-        self.log('Downloading issue:', self.tag_to_string(tme))
-        self.timefmt = ' [' + self.tag_to_string(tme) + ']'
-        self.cover_url = div.find(**classes('ThisWeeksMagazineHero__ImageLink')).img['src']
+        issue_date = soup.find(**classes('issue__date'))
+        issue_number = soup.find(**classes('issue__number'))
+        cover = soup.find(**classes('issue__cover'))
+        if issue_date is None or issue_number is None or cover is None or cover.img is None:
+            raise ValueError('Failed to find issue metadata on New Scientist')
+        issue = ' - '.join((self.tag_to_string(issue_date).strip(), self.tag_to_string(issue_number).strip()))
+        self.log('Downloading issue:', issue)
+        self.timefmt = ' [' + issue + ']'
+        self.cover_url = cover.img['src']
 
         feeds = []
-        for cont in soup.findAll(attrs={'class':'TableOfContents__Section'}):
-            sec = self.tag_to_string(cont.find('h3'))
+        for cont in soup.findAll(**classes('issue__table-of-contents-section')):
+            sec = self.tag_to_string(cont.find('h3')).strip()
             self.log(sec)
             articles = []
-            for a in cont.findAll('a', attrs={'class':'CardLink'}):
-                url = a['href']
-                if url.startswith('http') is False:
-                    url = 'https://www.newscientist.com' + a['href']
-                title = self.tag_to_string(a.find(**classes('Card__Title')))
-                desc = ''
-                desc += self.tag_to_string(a.find(**classes('Card__Category')))
-                teaser = a.find(**classes('Card__TeaserCopy'))
-                if teaser:
-                    desc += ' | ' + self.tag_to_string(teaser)
+            for a in cont.findAll('a', **classes('content-item')):
+                url = a.get('href')
+                title_tag = a.find(**classes('content-item__title'))
+                if not url or title_tag is None:
+                    continue
+                if not url.startswith('http'):
+                    url = 'https://www.newscientist.com' + url
+                title = self.tag_to_string(title_tag).strip()
+                desc = []
+                for x in (
+                    a.find(**classes('content-item__subject')),
+                    a.find(**classes('content-item__tag')),
+                    a.find(**classes('content-item__excerpt')),
+                ):
+                    text = self.tag_to_string(x).strip()
+                    if text:
+                        desc.append(text)
+                desc = ' | '.join(desc)
                 self.log('\t', title, '\n\t', desc, '\n\t\t', url)
                 articles.append({'title': title, 'description': desc, 'url': url})
             if articles:
@@ -114,7 +129,7 @@ class NewScientist(BasicNewsRecipe):
         return feeds
 
     def preprocess_html(self, soup):
-        time = soup.find(**classes('ArticleHeader__DateTimeWrapper'))
+        time = soup.find('time', **classes('article__pubdate'))
         if time:
             time.name = 'div'
         for img in soup.findAll('img', attrs={'data-src':True}):


### PR DESCRIPTION
## What changed

- update the current-issue metadata, cover, section, and article selectors for the redesigned New Scientist site
- update article content selectors and styling for the current WordPress markup
- remove advertisements, read-more cards, newsletter promotions, and content prompt placeholders from downloaded articles
- skip incomplete cards and normalize section, title, and description whitespace

## Why

The recipe still expected the former `ThisWeeksMagazineHero__*`, `TableOfContents__*`, `Card__*`, `ArticleHeader`, and `ArticleContent` markup. The current site uses `issue__*`, `content-item__*`, and `article__*` classes, so the issue header lookup returned `None` and the recipe failed before downloading any articles.

## Validation

- compiled the recipe with calibre 9.11.0
- ran `ebook-convert recipes/new_scientist_mag.recipe new-scientist.epub --test`
- ran a full conversion of the current issue: 7 sections and 39 articles produced a 6.2 MB EPUB
- inspected the generated article documents: body text was present, with no download-failure placeholders, advertisement modules, or newsletter-promotion modules

The optional subscription login path is unchanged and was not tested with credentials.
