### PR TITLE
setup.py: use common ensure_venv()

### DIFF
--- a/setup/__init__.py
+++ b/setup/__init__.py
@@ -195,10 +195,13 @@ def edit_file(path):
 class Command:
 
     SRC = SRC
-    RESOURCES = os.path.join(os.path.dirname(SRC), 'resources')
+    PROJECT_ROOT = os.path.dirname(SRC)
+    RESOURCES = os.path.join(PROJECT_ROOT, 'resources')
+
     description = ''
     usage_help = ''
     drop_privileges_for_subcommands = False
+    require_venv = False
 
     sub_commands = []
 
@@ -251,6 +254,8 @@ class Command:
 
         st = time.time()
         self.running(cmd)
+        if cmd.require_venv:
+            self.ensure_venv()
         cmd.run(opts)
         self.info(f'* {command_names[cmd]} took {time.time() - st:.1f} seconds')
         if is_ci:
@@ -279,6 +284,14 @@ class Command:
 
     def clean(self):
         pass
+
+    @lru_cache(maxsize=2)
+    def ensure_venv(self) -> None:
+        venv_dir = self.j(self.PROJECT_ROOT, '.venv')
+        if not self.e(venv_dir):
+            subprocess.check_call(['uv', 'venv'], cwd=self.PROJECT_ROOT)
+        deps = subprocess.check_output(['uv', 'pip', 'compile', 'pyproject.toml', '--group', 'dev'], cwd=self.PROJECT_ROOT)
+        subprocess.run(['uv', 'pip', 'sync', '-'], check=True, input=deps, cwd=self.PROJECT_ROOT)
 
     @classmethod
     def newer(cls, targets, sources):

--- a/setup/check.py
+++ b/setup/check.py
@@ -41,6 +41,7 @@ def checkable_python_files(SRC):
 class Check(Command):
 
     description = 'Check for errors in the calibre source code'
+    require_venv = True
 
     CACHE = 'check.json'
 
@@ -86,7 +87,7 @@ class Check(Command):
         dump_json(cache, self.cache_file)
 
     def _ruff_executable(self):
-        ruff = self.j(self.d(self.SRC), '.venv', 'bin', 'ruff')
+        ruff = self.j(self.PROJECT_ROOT, '.venv/bin/ruff')
         if iswindows:
             ruff += '.exe'
         if not os.path.exists(ruff):
@@ -99,9 +100,9 @@ class Check(Command):
         if ext in {'.py', '.pyi', '.recipe'}:
             ruff = self._ruff_executable()
             if self.auto_fix:
-                p = subprocess.Popen([ruff, 'check', '-q', '--fix', f])
+                p = subprocess.Popen([ruff, 'check', '-q', '--fix', f], cwd=self.PROJECT_ROOT)
             else:
-                p = subprocess.Popen([ruff, 'check', '-q', f])
+                p = subprocess.Popen([ruff, 'check', '-q', f], cwd=self.PROJECT_ROOT)
             return p.wait() != 0
         if ext == '.pyj':
             p = subprocess.Popen(['rapydscript', 'lint', f])
@@ -165,6 +166,7 @@ class Check(Command):
                     p = subprocess.run(
                         ruff_cmd + batch,
                         capture_output=True, text=True,
+                        cwd=self.PROJECT_ROOT,
                     )
                     if p.returncode != 0:
                         try:

--- a/setup/type_check.py
+++ b/setup/type_check.py
@@ -6,27 +6,14 @@ import os
 import re
 import subprocess
 
-from setup import Command
+from setup import Command, iswindows
 
 
 class TypeCheck(Command):
 
     description = 'Run the ty type checker over the calibre source code'
     usage_help = 'To type check specific files, specify them as command line arguments'
-
-    @property
-    def project_root(self):
-        return self.d(self.SRC)
-
-    @property
-    def venv_dir(self):
-        return self.j(self.project_root, '.venv')
-
-    def ensure_venv(self):
-        if not self.e(self.venv_dir):
-            subprocess.check_call(['uv', 'venv'], cwd=self.project_root)
-        deps = subprocess.check_output(['uv', 'pip', 'compile', 'pyproject.toml', '--group', 'dev'], cwd=self.project_root)
-        subprocess.run(['uv', 'pip', 'sync', '-'], check=True, input=deps, cwd=self.project_root)
+    require_venv = True
 
     def patch_qt_stubs(self, version: int = 1):
         def patch(mod: str, changes: dict[str, list[str]]) -> str:
@@ -94,9 +81,10 @@ def raise_without_focus(self) -> None: ...
 '''.splitlines()})
 
     def run(self, opts):
-        self.ensure_venv()
-        ty = os.path.abspath('.venv/bin/ty')
+        ty = self.j(self.PROJECT_ROOT, '.venv/bin/ty')
+        if iswindows:
+            ty += '.exe'
         self.patch_qt_stubs()
-        cp = subprocess.run([ty, 'check'] + list(opts.cli_args), cwd=self.project_root)
+        cp = subprocess.run([ty, 'check'] + list(opts.cli_args), cwd=self.PROJECT_ROOT)
         if cp.returncode != 0:
             raise SystemExit(cp.returncode)


### PR DESCRIPTION
In the `setup.py` check and type_check, use a common ensure_venv(), executed once if their is severals on sub_commands.

Also uniform a bit ruff and ty run command.