### PR TITLE
Add AirDop context menu option on MacOS for sharing books

### DIFF
--- a/src/calibre/customize/builtins.py
+++ b/src/calibre/customize/builtins.py
@@ -10,7 +10,7 @@ from calibre.ai.lm_studio import LMStudioAI
 from calibre.ai.ollama import OllamaAI
 from calibre.ai.open_router import OpenRouterAI
 from calibre.ai.openai_compatible import OpenAICompatible
-from calibre.constants import numeric_version
+from calibre.constants import ismacos, numeric_version
 from calibre.customize import FileTypePlugin, InterfaceActionBase, MetadataReaderPlugin, MetadataWriterPlugin, PreferencesPlugin, StoreBase
 from calibre.ebooks.html.to_zip import HTML2ZIP
 from calibre.ebooks.metadata.archive import ArchiveExtract, KPFExtract, get_comic_metadata
@@ -1144,6 +1144,13 @@ class ActionBooklistContextMenu(InterfaceActionBase):
     description = _('Open the context menu for the column')
 
 
+class ActionAirdrop(InterfaceActionBase):
+    name = 'AirDrop books'
+    author = 'Peter Warrington'
+    actual_plugin = 'calibre.gui2.actions.airdrop:AirdropAction'
+    description = _('Share books via AirDrop on macOS')
+
+
 class ActionAllActions(InterfaceActionBase):
     name = 'All GUI actions'
     author = 'Charles Haley'
@@ -1200,6 +1207,9 @@ plugins += [ActionAdd, ActionAllActions, ActionColumnTooltip, ActionFetchAnnotat
         ActionVirtualLibrary, ActionBrowseAnnotations, ActionTemplateFunctions, ActionAutoscrollBooks,
         ActionFullTextSearch, ActionManageCategories, ActionBooklistContextMenu, ActionSavedSearches,
         ActionLayoutActions, ActionBrowseNotes,]
+
+if ismacos:
+    plugins.append(ActionAirdrop)
 
 # }}}
 

--- a/src/calibre/gui2/actions/airdrop.py
+++ b/src/calibre/gui2/actions/airdrop.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+
+__license__ = 'GPL v3'
+__copyright__ = '2024'
+__docformat__ = 'restructuredtext en'
+
+import os
+import shutil
+
+from calibre.gui2.dialogs.progress import ProgressDialog
+from qt.core import QDialog
+
+from calibre.constants import ismacos
+from calibre.gui2 import error_dialog, info_dialog
+from calibre.gui2.actions import InterfaceActionWithLibraryDrop
+from calibre.gui2.dialogs.choose_format import ChooseFormatDialog
+from calibre.utils.localization import _
+from calibre.ptempfile import PersistentTemporaryDirectory
+
+
+class AirdropAction(InterfaceActionWithLibraryDrop):
+
+    name = 'AirDrop books'
+    action_spec = (_('AirDrop books'), 'send.png',
+                   _('Share the selected books via AirDrop'), ())
+    action_type = 'current'
+    dont_add_to = frozenset(('context-menu-device',))
+
+    def genesis(self):
+        self.qaction.triggered.connect(self.airdrop_books)
+
+    def do_drop(self):
+        book_ids = self.dropped_ids
+        del self.dropped_ids
+        if book_ids:
+            self.airdrop_book_ids(book_ids)
+
+    def location_selected(self, loc):
+        self.qaction.setEnabled(loc == 'library')
+
+    def airdrop_books(self):
+        book_ids = self.gui.library_view.get_selected_ids()
+        if not book_ids:
+            return error_dialog(self.gui, _('Cannot AirDrop'),
+                    _('No book selected'), show=True)
+        self.airdrop_book_ids(book_ids)
+
+    def airdrop_book_ids(self, book_ids):
+        if not ismacos:
+            return error_dialog(self.gui, _('Cannot AirDrop'),
+                    _('AirDrop is only available on macOS'), show=True)
+        db = self.gui.current_db.new_api
+        formats = {book_id: [f.upper() for f in db.formats(book_id)] for book_id in book_ids}
+        all_fmts = sorted({f for fmts in formats.values() for f in fmts})
+        if not all_fmts:
+            return error_dialog(self.gui, _('Cannot AirDrop'),
+                    _('The selected books have no files to share'), show=True)
+        if len(all_fmts) > 1:
+            d = ChooseFormatDialog(self.gui, _('Choose the format to AirDrop'), all_fmts)
+            if d.exec() != QDialog.DialogCode.Accepted or not d.format():
+                return
+            fmt = d.format()
+        else:
+            fmt = all_fmts[0]
+        lib_paths = []
+        skipped = 0
+        for book_id in book_ids:
+            path = db.format_abspath(book_id, fmt) if fmt in formats[book_id] else None
+            if path:
+                lib_paths.append(path)
+            else:
+                skipped += 1
+
+        if not lib_paths:
+            return error_dialog(self.gui, _('Cannot AirDrop'),
+                    _('The selected books are not available in the %s format') % fmt, show=True)
+        
+        temp_dir = PersistentTemporaryDirectory()
+        pd = ProgressDialog(_('Exporting books for AirDrop...'), min=0, max=0, icon='send.png')
+
+        paths = []
+
+        for path in lib_paths:
+            pd.set_msg(_('Exporting %s') % path)
+            pd.set_value(0)
+            if os.access(path, os.R_OK):
+                dest = os.path.abspath(os.path.join(temp_dir, os.path.relpath(path, os.path.dirname(path))))
+                try:
+                    shutil.copy2(path, dest)
+                except FileNotFoundError:
+                    os.makedirs(os.path.dirname(dest), exist_ok=True)
+                    shutil.copy2(path, dest)
+
+                paths.append(dest)
+
+        try:
+            from calibre_extensions.cocoa import airdrop_share
+            airdrop_share(*paths)
+        except Exception as err:
+            import traceback
+            return error_dialog(self.gui, _('AirDrop failed'), str(err),
+                    det_msg=traceback.format_exc(), show=True)
+        if skipped:
+            info_dialog(self.gui, _('Some books skipped'),
+                    _('%(num)d of the selected books were not available in the'
+                      ' %(fmt)s format and were not sent.') % dict(num=skipped, fmt=fmt),
+                    show=True)

--- a/src/calibre/gui2/actions/device.py
+++ b/src/calibre/gui2/actions/device.py
@@ -7,6 +7,7 @@ __docformat__ = 'restructuredtext en'
 
 from qt.core import QIcon, QMenu, QTimer, QToolButton, QUrl, pyqtSignal
 
+from calibre.constants import ismacos
 from calibre.gui2 import info_dialog, open_url, question_dialog
 from calibre.gui2.actions import InterfaceAction
 from calibre.gui2.dialogs.smartdevice import SmartdeviceDialog
@@ -38,6 +39,7 @@ class ShareConnMenu(QMenu):  # {{{
     connect_to_folder = pyqtSignal()
 
     config_email = pyqtSignal()
+    share_airdrop = pyqtSignal()
     toggle_server = pyqtSignal()
     control_smartdevice = pyqtSignal()
     server_state_changed_signal = pyqtSignal(object, object)
@@ -74,6 +76,10 @@ class ShareConnMenu(QMenu):  # {{{
         control_smartdevice_action = self.control_smartdevice_action
         assert control_smartdevice_action is not None
         connect_lambda(control_smartdevice_action.triggered, self, lambda self: self.control_smartdevice.emit())
+        self.airdrop_action = None
+        if ismacos:
+            self.airdrop_action = self.addAction(QIcon.ic('send.png'), _('Send via AirDrop'))
+            connect_lambda(self.airdrop_action.triggered, self, lambda self: self.share_airdrop.emit())
         self.addSeparator()
 
         self.email_actions = []
@@ -231,6 +237,12 @@ class ConnectShareAction(InterfaceAction):
             self.gui.iactions['Preferences'].do_config(initial_plugin=('Sharing', 'Email'), close_after_initial=True))
         self.qaction.setMenu(self.share_conn_menu)
         self.share_conn_menu.connect_to_folder.connect(self.gui.connect_to_folder)
+        self.share_conn_menu.share_airdrop.connect(self.share_via_airdrop)
+
+    def share_via_airdrop(self):
+        ac = self.gui.iactions.get('AirDrop books')
+        if ac is not None:
+            ac.airdrop_books()
 
     def location_selected(self, loc):
         enabled = loc == 'library'

--- a/src/calibre/utils/cocoa.m
+++ b/src/calibre/utils/cocoa.m
@@ -355,6 +355,50 @@ get_appearance(PyObject *self, PyObject *args) {
 }
 
 
+static PyObject*
+airdrop_share(PyObject *self, PyObject *args) {
+    (void)self;
+    Py_ssize_t num = PyTuple_GET_SIZE(args);
+    if (num < 1) {
+        PyErr_SetString(PyExc_TypeError, "must specify at least one file to share");
+        return NULL;
+    }
+
+    @autoreleasepool {
+        NSMutableArray *items = [NSMutableArray arrayWithCapacity:num];
+        for (Py_ssize_t i = 0; i < num; i++) {
+            PyObject *pypath = PyTuple_GET_ITEM(args, i);
+            if (!PyUnicode_Check(pypath)) {
+                PyErr_SetString(PyExc_TypeError, "paths must be strings");
+                return NULL;
+            }
+            const char *path = PyUnicode_AsUTF8(pypath);
+            if (!path) return NULL;
+            NSURL *url = [NSURL fileURLWithPath:@(path)];
+            if (!url) {
+                PyErr_Format(PyExc_ValueError, "invalid path: %s", path);
+                return NULL;
+            }
+            [items addObject:url];
+        }
+
+        NSSharingService *service = [NSSharingService sharingServiceNamed:NSSharingServiceNameSendViaAirDrop];
+        if (!service) {
+            PyErr_SetString(PyExc_OSError, "AirDrop service not available on this system");
+            return NULL;
+        }
+
+        if (![service canPerformWithItems:items]) {
+            PyErr_SetString(PyExc_OSError, "AirDrop cannot share the specified files");
+            return NULL;
+        }
+
+        [service performWithItems:items];
+    }
+    Py_RETURN_NONE;
+}
+
+
 static PyMethodDef module_methods[] = {
     {"close_finder_window", (PyCFunction)close_finder_window, METH_VARARGS, "close_finder_window(name) -> None -- Close a Finder window whose title matches name."},
     {"get_appearance", (PyCFunction)get_appearance, METH_VARARGS, ""},
@@ -371,6 +415,7 @@ static PyMethodDef module_methods[] = {
     {"locale_names", (PyCFunction)locale_names, METH_VARARGS, ""},
     {"create_io_pm_assertion", (PyCFunction)create_io_pm_assertion, METH_VARARGS, ""},
     {"release_io_pm_assertion", (PyCFunction)release_io_pm_assertion, METH_VARARGS, ""},
+    {"airdrop_share", (PyCFunction)airdrop_share, METH_VARARGS, "airdrop_share(*paths) -> None -- Share the specified files via AirDrop."},
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };
 


### PR DESCRIPTION
Pull request adding an AirDrop context menu option on MacOS.

Screenshots:

<img width="503" height="128" alt="Context Menu screenshot" src="https://github.com/user-attachments/assets/c23a4cb5-ae9d-4754-8377-85912ac12934" />

<img width="512" height="408" alt="Choose Format screenshot" src="https://github.com/user-attachments/assets/bc133ffe-58bd-47ad-b5b8-11c66c0bbe72" />

<img width="371" height="262" alt="AirDrop modal screenshot" src="https://github.com/user-attachments/assets/148905ab-43e0-491b-bbf1-d3cedef959d2" />

