### PR TITLE
Improve `setup.py fmt`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ dev = [
 line-length = 160
 builtins = ['_', 'I', 'P']
 include = ['*.py', '*.pyi', '*.recipe']
+extension = { recipe = "python" }
 extend-exclude = [
     "*_ui.py",
     "bypy/*",

--- a/setup/fmt.py
+++ b/setup/fmt.py
@@ -33,7 +33,7 @@ class AutoFormat(Command):
             m = tomllib.loads(f.read())
             line_length = m['tool']['ruff']['line-length']
         print('Formatting Python files...')
-        cmd = [ruff, 'format', '--extension', 'recipe:python']
+        cmd = [ruff, 'format']
         if opts.check_only:
             cmd.append('--check')
         pp = subprocess.run(cmd + list(py_files), cwd=self.PROJECT_ROOT)

--- a/setup/fmt.py
+++ b/setup/fmt.py
@@ -33,6 +33,10 @@ class AutoFormat(Command):
             m = tomllib.loads(f.read())
             line_length = m['tool']['ruff']['line-length']
         print('Formatting Python files...')
+        cmd = [ruff, 'check', '--fix-only']
+        if opts.check_only:
+            cmd.append('--diff')
+        fp = subprocess.run(cmd + list(py_files), cwd=self.PROJECT_ROOT)
         cmd = [ruff, 'format']
         if opts.check_only:
             cmd.append('--check')
@@ -42,8 +46,5 @@ class AutoFormat(Command):
         if opts.check_only:
             cmd.append('--check-only')
         cp = subprocess.run(cmd + (list(pyj_files) or ['src/pyj']), cwd=self.PROJECT_ROOT)
-        if cp.returncode != 0 or pp.returncode != 0:
+        if fp.returncode != 0 or cp.returncode != 0 or pp.returncode != 0:
             raise SystemExit(1)
-        if not opts.check_only:
-            if subprocess.run([ruff, 'check', '--fix']).returncode != 0:
-                raise SystemExit(1)


### PR DESCRIPTION
Improve ruff check execution on the `setup.py fmt` by:
- using `--fix-only` arg to not raise "no formating" code error ("bigger" error should be limited to `setup.py check`)
- use `--diff` arg in check only mode (instead of skip it)
- run `ruff check` before  `ruff format` to ensure consitency of formating

also define the recipe extension globaly.