### PR TITLE
setup.py check: remove file arguments

### DIFF
--- a/setup/check.py
+++ b/setup/check.py
@@ -51,7 +51,6 @@ class Check(Command):
             action='store_true',
             help='Try to automatically fix some of the smallest errors instead of opening an editor for bad files.',
         )
-        parser.add_option('-f', '--file', dest='files', type='string', action='append', help='Specific file to be check. Can be repeat to check severals.')
         parser.add_option('--no-editor', default=False, action='store_true', help="Don't open the editor when a bad file is found.")
 
     def get_files(self):
@@ -118,8 +117,12 @@ class Check(Command):
         self.wn_path = os.path.expanduser('~/work/srv/main/static')
         self.has_changelog_check = os.path.exists(self.wn_path)
         self.auto_fix = opts.fix
-        self.files = opts.files
         self.no_editor = opts.no_editor
+        self.files = ()
+        if opts.cli_args:
+            self.files = tuple(x for x in opts.cli_args if x.endswith(('.py', '.recipe', '.pyj')))
+            if not self.files:
+                return
         self.run_check_files()
 
     def run_check_files(self):

--- a/setup/git_pre_commit_hook.py
+++ b/setup/git_pre_commit_hook.py
@@ -40,19 +40,15 @@ if not output:
 else:
     output = output.split('\0')
 
-filenames = tuple(filter(testfile, output))
+filenames = list(filter(testfile, output))
 if not filenames:
     sys.exit(0)
 
 check_args = ['./setup.py', 'check', '--no-editor']
-# let's hope that too many arguments do not hold any surprises
-for f in filenames:
-    check_args.append('-f')
-    check_args.append(f)
 
 before = sys.argv
 try:
-    sys.argv = check_args
+    sys.argv = check_args + filenames
     runpy.run_path('setup.py', run_name='__main__')
 finally:
     sys.argv = before


### PR DESCRIPTION
Since it possible to pass arbitrary arguments to retrive specific files to be check, remove redundant `--file` arguments and use arbitrary arguments instead.