### PR TITLE
Run CI format checker in last

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,9 +73,6 @@ jobs:
             - name: Run linter
               run: ./setup.py check
 
-            - name: Run format checker
-              run: ./setup.py fmt --check-only
-
             - name: Test calibre
               env:
                 PYTHONWARNINGS: error
@@ -85,3 +82,6 @@ jobs:
                   runuser -u ci -- python setup.py test --under-sanitize
                   echo "Running test_rs"
                   runuser -u ci -- python setup.py test_rs
+
+            - name: Run format checker
+              run: ./setup.py fmt --check-only


### PR DESCRIPTION
Run the CI format checker in last, after Test calibre.
This ensure to not skip calibre tests because simply of some format error that don't impact on code execution.