### PR TITLE
Improve tooltip for column lookup name input

### DIFF
--- a/src/calibre/gui2/preferences/create_custom_column.py
+++ b/src/calibre/gui2/preferences/create_custom_column.py
@@ -312,10 +312,11 @@ class CreateCustomColumn(QDialog):
                         la.setBuddy(w)
                         break
             return la
-
+        
         # Lookup name
         self.column_name_box = cnb = QLineEdit(self)
-        cnb.setToolTip(_('Used for searching the column. Must contain only digits, lower case letters and underscores and start with a letter.'))
+        cnb.setToolTip(_('Used for searching the column.<br>'
+        '<br>The lookup name must contain only lower case letters, digits and underscores, and start with a letter.'))
         add_row(_('&Lookup name:'), cnb)
 
         # Heading


### PR DESCRIPTION
Updated tooltip for column lookup name input to be consistent with the error message in same file. Now it reads:

```Used for searching the column. The lookup name must contain only lower case letters, digits and underscores, and start with a letter.```

Before, it was:

```Used for searching the column. Must contain only digits and lower case letters.```

