### PR TITLE
plugins_mirror: Decode MobileRead index page using HTTP headers or CP1252 fallback

### DIFF
--- a/setup/plugins_mirror.py
+++ b/setup/plugins_mirror.py
@@ -104,7 +104,21 @@ def url_to_plugin_id(url, deprecated):
 
 
 def parse_index(raw=None):  # {{{
-    raw = raw or read(INDEX).decode('utf-8', 'replace')
+    if raw is None:
+        res = read(INDEX, get_info=True)
+        if isinstance(res, tuple):
+            raw_bytes, info = res
+            charset = 'cp1252'
+            try:
+                content_type = info.get('Content-Type', '')
+                if 'charset=' in content_type:
+                    charset = content_type.split('charset=')[-1].strip()
+            except Exception:
+                pass
+            raw = raw_bytes.decode(charset, 'replace')
+        else:
+            raw = res.decode('cp1252', 'replace')
+
 
     dpat = re.compile(r'''(?is)Donate\s*:\s*<a\s+href=['"](.+?)['"]''')
     key_pat = re.compile(r'''(?is)(History|Uninstall)\s*:\s*([^<;]+)[<;]''')


### PR DESCRIPTION
**plugins_mirror: Decode MobileRead index page using HTTP headers or CP1252 fallback**

This aims to fix a display issue in plugin updater for plugin names with special characters such as Chinese Conversion · 简繁转换 and DELFI knjižare.

In plugins_mirror.py, the `parse_index` function now dynamically retrieves the encoding of the MobileRead forum page via the HTTP response headers (defaulting to the forum's expected `cp1252`/`ISO-8859-1` encoding if unavailable or when reading from a local test file):

```diff
 def parse_index(raw=None):  # {{{
-    raw = raw or read(INDEX).decode('utf-8', 'replace')
+    if raw is None:
+        res = read(INDEX, get_info=True)
+        if isinstance(res, tuple):
+            raw_bytes, info = res
+            charset = 'cp1252'
+            try:
+                content_type = info.get('Content-Type', '')
+                if 'charset=' in content_type:
+                    charset = content_type.split('charset=')[-1].strip()
+            except Exception:
+                pass
+            raw = raw_bytes.decode(charset, 'replace')
+        else:
+            raw = res.decode('cp1252', 'replace')
```

This prevents the Unicode replacement characters (`\ufffd`) from corrupting the index names on the mirror server during index generation — allowing characters like `·` and `ž` to decode correctly.