### PR TITLE
palette: Style QMenu::separator explicitly to prevent invisible separators

### DIFF
--- a/src/calibre/gui2/palette.py
+++ b/src/calibre/gui2/palette.py
@@ -325,7 +325,7 @@ class PaletteManager(QObject):
         QIcon.ic.set_theme()  # type: ignore
         app.setProperty('is_dark_theme', self.is_dark_theme)
         if self.using_calibre_style:
-            ss = 'QTabBar::tab:selected { font-style: italic }\n\n'
+            ss = 'QTabBar::tab:selected { font-style: italic }\nQMenu::separator { height: 1px; background: palette(shadow); margin-top: 4px; margin-bottom: 4px; }\n\n'
             if self.is_dark_theme:
                 ss += 'QMenu { border: 1px solid palette(shadow); }'
                 ss += '''


### PR DESCRIPTION
**palette: Style QMenu::separator explicitly to prevent invisible separators**

This fixes a rendering issue where QMenu separators become completely invisible or collapse to 0 height in calibre's main window and plugin context menus (such as Action Chains, Calibre Config Reports, etc.).

When calibre's custom style is active and applies custom stylesheet rules (like the QMenu border in dark mode) to a QMenu:
```python
ss += 'QMenu { border: 1px solid palette(shadow); }'
```
Qt 6 transitions its menu rendering to a stylesheet-based rendering path. Because calibre did not explicitly define styling for `QMenu::separator` in the global application stylesheet, the separators were rendered as invisible/zero-height spaces.

By explicitly styling `QMenu::separator` in `palette.py`, we ensure separators render as a visible 1px line using calibre's standard theme shadow color:

```diff
diff --git a/src/calibre/gui2/palette.py b/src/calibre/gui2/palette.py
--- a/src/calibre/gui2/palette.py
+++ b/src/calibre/gui2/palette.py
@@ -327,5 +327,5 @@
         if self.using_calibre_style:
-            ss = 'QTabBar::tab:selected { font-style: italic }\n\n'
+            ss = 'QTabBar::tab:selected { font-style: italic }\nQMenu::separator { height: 1px; background: palette(shadow); margin-top: 4px; margin-bottom: 4px; }\n\n'
             if self.is_dark_theme:
                 ss += 'QMenu { border: 1px solid palette(shadow); }'