### PR TITLE
plugins_mirror: Refactor HTML decoding into separate function

### DIFF
--- a/setup/plugins_mirror.py
+++ b/setup/plugins_mirror.py
@@ -103,21 +103,32 @@ def url_to_plugin_id(url, deprecated):
     return ans
 
 
+def decode_html(raw_bytes, info=None):
+    charset = 'cp1252'
+    if info is not None:
+        try:
+            content_type = info.get('Content-Type', '')
+            if 'charset=' in content_type:
+                charset = content_type.split('charset=')[-1].strip()
+        except Exception:
+            pass
+    c = charset.lower().replace('_', '-').replace(' ', '')
+    if c in ('iso-8859-1', 'latin-1', 'latin1', 'iso8859-1', 'iso_8859-1'):
+        charset = 'cp1252'
+    try:
+        return raw_bytes.decode(charset, 'replace')
+    except Exception:
+        return raw_bytes.decode('cp1252', 'replace')
+
+
 def parse_index(raw=None):  # {{{
     if raw is None:
         res = read(INDEX, get_info=True)
         if isinstance(res, tuple):
             raw_bytes, info = res
-            charset = 'cp1252'
-            try:
-                content_type = info.get('Content-Type', '')
-                if 'charset=' in content_type:
-                    charset = content_type.split('charset=')[-1].strip()
-            except Exception:
-                pass
-            raw = raw_bytes.decode(charset, 'replace')
+            raw = decode_html(raw_bytes, info)
         else:
-            raw = res.decode('cp1252', 'replace')
+            raw = decode_html(res)
 
     dpat = re.compile(r'''(?is)Donate\s*:\s*<a\s+href=['"](.+?)['"]''')
     key_pat = re.compile(r'''(?is)(History|Uninstall)\s*:\s*([^<;]+)[<;]''')
@@ -444,7 +455,8 @@ def update_plugin_from_entry(plugin, entry):
 
 def fetch_plugin(old_index, entry):
     lm_map = {plugin['thread_id']: plugin for plugin in old_index.values()}
-    raw = read(entry.url).decode('utf-8', 'replace')
+    res = read(entry.url, get_info=True)
+    raw = decode_html(*res)
     url, name = parse_plugin_zip_url(raw)
     if url is None:
         raise ValueError(f'Failed to find zip file URL for entry: {entry!r}')


### PR DESCRIPTION
The patch submitted yesterday worked only partially:

<img width="244" height="406" alt="MWSnap 2026-07-26, 14_34_53" src="https://github.com/user-attachments/assets/36d8dc5a-d5d1-44d3-bdfa-f16985e89ba2" />

The Serbian character `ž` in `DELFI knjižare` was replaced with a missing character block (``), while the Chinese Conversion bullet was successfully resolved.

MobileRead forum pages are served with HTTP headers declaring `Content-Type: text/html; charset=ISO-8859-1`. Modern browsers treat `ISO-8859-1` as `windows-1252` (CP1252) under standard HTML5 encoding specifications. 

In Python, however:
* Standard `ISO-8859-1` maps byte `\x9e` to codepoint `158` (`U+009E`, an unprintable control character). Qt then renders this control character as the replacement glyph (``).
* `CP1252` maps byte `\x9e` to codepoint `382` (`U+017E`, the lowercase character `ž`).

Because our initial patch decoded directly with the header's declared `ISO-8859-1` charset, the Serbian `ž` became an unprintable control character, whereas the Chinese Conversion bullet (which used standard ASCII HTML entity entities unescaped by `HTMLParser`) worked.

### Proposal
I have updated plugins_mirror.py with the following changes:

1. **Introduced `decode_html` helper function** which intercepts `ISO-8859-1`, `latin-1`, and `latin1` content-type declarations and maps them to `cp1252` (aligning with HTML5 web standards).
2. **Updated `parse_index`** to use this helper when decoding the main plugin index pages.
3. **Updated `fetch_plugin`** to fetch thread metadata with `get_info=True` and decode using the same encoding-aware helper rather than hardcoded `utf-8`.

I created a diagnostic script and verified that both `'Chinese Conversion · 简繁转换'` and `'DELFI knjižare'` now parse and decode correctly from the live feed.