### PR TITLE
Update Economist Recipe with Fixes

### DIFF
--- a/recipes/economist.recipe
+++ b/recipes/economist.recipe
@@ -236,7 +236,11 @@ class Economist(BasicNewsRecipe):
     resolve_internal_links = True
 
     delay = 2
-    browser_type = 'webengine'
+    # Article pages must be fetched via get_obfuscated_article (which uses the
+    # mobile-app webview headers to bypass the Cloudflare challenge); without
+    # this flag calibre fetches them with the plain browser and gets a 403
+    # challenge page, crashing preprocess_raw_html with an IndexError.
+    articles_are_obfuscated = True
     recipe_specific_options = {
         'date': {
             'short': 'The date of the edition to download (YYYY-MM-DD format)',


### PR DESCRIPTION
The Economist recipe currently fails to download any articles and produces an epub containing only the section index pages, a generated fallback cover, and no images. Two independent bugs, tested with calibre 9.11.0 on macOS:

### Bug 1: `get_obfuscated_article` is never called — every article download crashes

The recipe defines `get_obfuscated_article()`, which fetches article pages via `get_content()` using the mobile-app webview headers (`x-requested-with: com.economist.lamarr`, `webview=liskov` query params) to bypass economist.com's Cloudflare challenge. However, it never sets `articles_are_obfuscated = True`, and calibre only dispatches to `fetch_obfuscated_article` when that flag is set (`src/calibre/web/feeds/news.py`):

```python
else ((self.fetch_obfuscated_article if self.articles_are_obfuscated else self.fetch_article), url)
```

So every article is fetched with the plain recipe browser instead, which receives a Cloudflare challenge page (HTTP 403, `cf-mitigated: challenge`) with no `__NEXT_DATA__` script tag, and `preprocess_raw_html` crashes on every article:

```
Could not fetch link https://www.economist.com/the-world-this-week/2026/07/23/politics
Traceback (most recent call last):
  File "calibre/web/fetch/simple.py", line 558, in process_links
  File "calibre/web/fetch/simple.py", line 195, in get_soup
  File "calibre/web/feeds/news.py", line 669, in preprocess_raw_html_
  File "<string>", line 452, in preprocess_raw_html
IndexError: list index out of range
```

The index parse succeeds (it calls `get_content()` directly), which masks the problem until article download time.

**Fix:** set `articles_are_obfuscated = True`.

### Bug 2: `browser_type = 'webengine'` corrupts all binary image downloads

With the webengine browser, every economist.com image fetch (cover and in-article images) fails:

```
34% Downloading cover from https://www.economist.com/cdn-cgi/image/width=960,quality=80,format=auto/content-assets/images/20260725_DE_US.jpg
Failed to download cover
...
ValueError: Failed to export image as JPEG with error: Image is empty

Fetching https://www.economist.com/cdn-cgi/image/width=600,quality=80,format=auto/content-assets/images/20260725_WWP001.jpg
calibre.utils.img.NotImage: Not a valid image (detected type: None). Error: Unsupported image format
```

The same URLs download as valid JPEGs through calibre's default mechanize browser (verified via `calibre-debug`: correct `\xff\xd8\xff\xe0` JPEG magic bytes, with both the default and the Liskov user agent). The images are not bot-protected — only the webengine fetch mangles them.

Once bug 1 is fixed, all article HTML goes through `get_content()` (its own mechanize browser), so the recipe browser is only used for images, the cover, and the `publication_date` lookup — none of which need webengine.

**Fix:** remove `browser_type = 'webengine'`, falling back to the default mechanize browser.

I worked with Claude to produce this fix it works locally running on MacOs