### PR TITLE
Fix argument binding when opening store search results

### DIFF
--- a/src/calibre/gui2/store/search/search.py
+++ b/src/calibre/gui2/store/search/search.py
@@ -444,7 +444,11 @@ class SearchDialog(QDialog, Ui_Dialog):
             self.gui.download_ebook(result.downloads[ext], filename=fname, create_browser=result.create_browser)
 
     def open_store(self, result):
-        self.gui.istores[result.store_name].open(self, result.detail_item, self.open_external.isChecked())
+        self.gui.istores[result.store_name].open(
+            self,
+            detail_item=result.detail_item,
+            external=self.open_external.isChecked(),
+        )
 
     def check_progress(self):
         m = self.results_view.model()

--- a/src/calibre/gui2/store/stores/mobileread/store_dialog.py
+++ b/src/calibre/gui2/store/stores/mobileread/store_dialog.py
@@ -48,7 +48,7 @@ class MobileReadStoreDialog(QDialog, Ui_Dialog):
         assert isinstance(_m, BooksModel)
         result = _m.get_book(index)
         if result:
-            self.plugin.open(self, result.detail_item)
+            self.plugin.open(self, detail_item=result.detail_item)
 
     def update_book_total(self, total):
         self.total.setText('%s' % total)


### PR DESCRIPTION
I was getting this error when double-clicking or actioning context menu command "Show in store":

```
  Traceback (most recent call last):
  File "calibre\gui2\store\search\search.py", line 447, in open_store
  File "calibre\gui2\store\stores\mobileread\mobileread_plugin.py", line 43, in open
TypeError: QUrl(): arguments did not match any overloaded call:
  overload 1: too many arguments
  overload 2: argument 1 has unexpected type 'bool'
  overload 3: argument 1 has unexpected type 'bool'
```
   
From tests I did I gather this PR fixes it satisfactorily:

> Store search passed detail_item and external positionally to StorePlugin.open(), omitting its parent parameter. This shifted the values so that external became detail_item. MobileRead subsequently attempted to construct QUrl from that boolean and raised a TypeError.
> 
> Pass the optional arguments by keyword in the shared search result handler and the MobileRead result dialog.