### PR TITLE
Fix content server language field handling

### DIFF
--- a/src/calibre/srv/cdb.py
+++ b/src/calibre/srv/cdb.py
@@ -238,6 +238,9 @@ def cdb_set_fields(ctx, rd, book_id, library_id):
             def to_lang_code(x):
                 return rmap.get(x, canonicalize_lang(x))
 
+            if isinstance(value, str):
+                value = (value,)
+
             value = list(filter(None, map(to_lang_code, value)))
         dirtied |= db.set_field(field, {book_id: value})
     ctx.notify_changes(db.backend.library_path, metadata(dirtied))

--- a/src/calibre/srv/tests/content.py
+++ b/src/calibre/srv/tests/content.py
@@ -230,6 +230,33 @@ class ContentTest(LibraryBaseTest):
 
     # }}}
 
+    def test_set_fields_languages(self):  # {{{
+        "Test /cdb/set-fields with a single language string"
+        with self.create_server() as server:
+            db = server.handler.router.ctx.library_broker.get(None)
+            conn = server.connect()
+
+            data = json.dumps({
+                'changes': {'languages': 'eng'},
+                'loaded_book_ids': [1],
+            }).encode('utf-8')
+
+            conn.request(
+                'POST',
+                '/cdb/set-fields/1',
+                body=data,
+                headers={'Content-Type': 'application/json'},
+            )
+
+            r = conn.getresponse()
+            self.ae(r.status, http.client.OK)
+
+            result = json.loads(r.read())
+            self.ae(result['1']['languages'], ['eng'])
+            self.ae(db.field_for('languages', 1), ('eng',))
+
+    # }}}
+
     def test_html_as_json(self):  # {{{
         from calibre.ebooks.oeb.parse_utils import html5_parse
         from calibre.srv.render_book import html_as_json


### PR DESCRIPTION
This fixes an issue where /cdb/set-fields can receive a single language value as a string and iterate it character-by-character.

This is relevant to reports of books ending up with an E/eee language value and subsequently failing Send to Kindle with E999.

The regression test covers a single language string being submitted through /cdb/set-fields.

Calibre issue #2085005 (v7.20.0, October 2024) addressed language handling in the Content Server, and this change fixes a related edge case in the same code path. This appears to be when the problem was introduced, and there are a few of us who have been sitting on 7.19.0 ever since.

I can't believe I haven't fixed this before now. I didn't even submit an issue! A lot of people will be happy to have this fixed. :-)

Love the app, and thank you!