### PR TITLE
add smarten punctuation to PlainTextEdit

### DIFF
--- a/src/calibre/gui2/comments_editor.py
+++ b/src/calibre/gui2/comments_editor.py
@@ -1664,7 +1664,7 @@ class Editor(QWidget):  # {{{
         self.tabs = QTabWidget(self)
         self.tabs.setTabPosition(QTabWidget.TabPosition.South)
         self.wyswyg = QWidget(self.tabs)
-        self.code_edit = PlainTextEdit(self.tabs)
+        self.code_edit = PlainTextEdit(self.tabs, use_smarten_punctuation=True)
         self.code_edit.setTabChangesFocus(True)
         self.source_dirty = False
         self.wyswyg_dirty = True

--- a/src/calibre/gui2/custom_column_widgets.py
+++ b/src/calibre/gui2/custom_column_widgets.py
@@ -19,7 +19,6 @@ from qt.core import (
     QLabel,
     QLineEdit,
     QMessageBox,
-    QPlainTextEdit,
     QSizePolicy,
     QSpacerItem,
     QStyle,
@@ -37,6 +36,7 @@ from calibre.gui2.complete2 import EditWithComplete as EWC
 from calibre.gui2.dialogs.tag_editor import TagEditor
 from calibre.gui2.library.delegates import ClearingDoubleSpinBox, ClearingSpinBox
 from calibre.gui2.markdown_editor import Editor as MarkdownEditor
+from calibre.gui2.tweak_book.widgets import PlainTextEdit
 from calibre.gui2.widgets2 import DateTimeEdit as DateTimeEditBase
 from calibre.gui2.widgets2 import RatingEditor
 from calibre.library.comments import comments_to_html
@@ -241,7 +241,7 @@ class LongText(Base):
         self._box = QGroupBox(parent)
         self._box.setTitle(label_string(self.col_metadata['name']))
         self._layout = QVBoxLayout()
-        self._tb = QPlainTextEdit(self._box)
+        self._tb = PlainTextEdit(self._box, use_smarten_punctuation=True)
         self._tb.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
         self._layout.addWidget(self._tb)
         self._box.setLayout(self._layout)

--- a/src/calibre/gui2/dialogs/comments_dialog.py
+++ b/src/calibre/gui2/dialogs/comments_dialog.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
 # License: GPLv3 Copyright: 2008, Kovid Goyal kovid@kovidgoyal.net
 
-from qt.core import QDialog, QDialogButtonBox, QHBoxLayout, QLabel, QPlainTextEdit, QSize, Qt, QVBoxLayout, pyqtSignal
+from qt.core import QDialog, QDialogButtonBox, QHBoxLayout, QLabel, QSize, Qt, QVBoxLayout, pyqtSignal
 
 from calibre.gui2 import Application, gprefs
 from calibre.gui2.comments_editor import Editor
+from calibre.gui2.tweak_book.widgets import PlainTextEdit as BasePlainTextEdit
 from calibre.gui2.widgets2 import Dialog
 from calibre.library.comments import comments_to_html
 from calibre.utils.localization import _
@@ -51,8 +52,11 @@ class CommentsDialog(QDialog):
         return QDialog.closeEvent(self, a0)
 
 
-class PlainTextEdit(QPlainTextEdit):
+class PlainTextEdit(BasePlainTextEdit):
     ctrl_enter_pushed = pyqtSignal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent, use_smarten_punctuation=True)
 
     def keyPressEvent(self, e):
         if e.modifiers() & Qt.KeyboardModifier.ControlModifier and e.key() == Qt.Key.Key_Return:

--- a/src/calibre/gui2/markdown_editor.py
+++ b/src/calibre/gui2/markdown_editor.py
@@ -3,10 +3,11 @@
 
 import os
 
-from qt.core import QDialog, QDialogButtonBox, QPlainTextEdit, QSize, Qt, QTabWidget, QUrl, QVBoxLayout, QWidget, pyqtSignal
+from qt.core import QDialog, QDialogButtonBox, QSize, Qt, QTabWidget, QUrl, QVBoxLayout, QWidget
 
 from calibre.gui2 import gprefs, safe_open_url
 from calibre.gui2.book_details import resolved_css
+from calibre.gui2.tweak_book.widgets import PlainTextEdit
 from calibre.gui2.widgets2 import HTMLDisplay
 from calibre.library.comments import markdown as get_markdown
 from calibre.utils.localization import _
@@ -25,21 +26,12 @@ class Preview(HTMLDisplay):
         return super().loadResource(type, name)
 
 
-class MarkdownEdit(QPlainTextEdit):
-    smarten_punctuation = pyqtSignal()
-
+class MarkdownEdit(PlainTextEdit):
     def __init__(self, parent=None):
-        super().__init__(parent)
+        super().__init__(parent, use_smarten_punctuation=True)
         from calibre.gui2.markdown_syntax_highlighter import MarkdownHighlighter
 
         self.highlighter = MarkdownHighlighter(self.document())
-
-    def contextMenuEvent(self, e):
-        m = self.createStandardContextMenu()
-        assert m is not None
-        m.addSeparator()
-        m.addAction(_('Smarten punctuation'), self.smarten_punctuation.emit)
-        m.exec(e.globalPos())
 
 
 class MarkdownEditDialog(QDialog):
@@ -102,7 +94,6 @@ class Editor(QWidget):  # {{{
         self._layout.addWidget(self.tabs)
 
         self.editor = MarkdownEdit(self)
-        self.editor.smarten_punctuation.connect(self.smarten_punctuation)
 
         self.preview = Preview(self)
         self.preview.anchor_clicked.connect(self.link_clicked)
@@ -165,14 +156,6 @@ class Editor(QWidget):  # {{{
         tab_bar = self.tabs.tabBar()
         assert tab_bar is not None
         tab_bar.setVisible(False)
-
-    def smarten_punctuation(self):
-        from calibre.ebooks.conversion.preprocess import smarten_punctuation
-
-        markdown = self.markdown
-        newmarkdown = smarten_punctuation(markdown)
-        if markdown != newmarkdown:
-            self.markdown = newmarkdown
 
 
 # }}}

--- a/src/calibre/gui2/tweak_book/widgets.py
+++ b/src/calibre/gui2/tweak_book/widgets.py
@@ -1486,9 +1486,9 @@ class PlainTextEdit(QPlainTextEdit):  # {{{
     """A class that overrides some methods from QPlainTextEdit to fix handling
     of the nbsp unicode character and AltGr input method on windows."""
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, *, use_smarten_punctuation: bool = False):
         QPlainTextEdit.__init__(self, parent)
-        self.syntax = None
+        self.use_smarten_punctuation = use_smarten_punctuation
 
     def toPlainText(self):
         return to_plain_text(self)
@@ -1563,6 +1563,22 @@ class PlainTextEdit(QPlainTextEdit):  # {{{
                 break
         if changed:
             self.setTextCursor(c)
+
+    def contextMenuEvent(self, e):
+        m = self.createStandardContextMenu()
+        assert m is not None
+        if self.use_smarten_punctuation:
+            m.addSeparator()
+            m.addAction(_('Smarten punctuation'), self.smarten_punctuation)
+        m.exec(e.globalPos())
+
+    def smarten_punctuation(self):
+        from calibre.ebooks.conversion.preprocess import smarten_punctuation
+
+        text = self.toPlainText().strip()
+        newtext = smarten_punctuation(text)
+        if text != newtext:
+            self.setPlainText(newtext)
 
 
 # }}}


### PR DESCRIPTION
Add smarten punctuation action to PlainTextEdit context menu, to be accessible on markdown and long text fields editors. Incidaly, apply all the improvement relative to smart quotes and nbsp.

The smarten punctuation action is disable by default to preserve previous behavior.