### PR TITLE
Fix missing CHM/HTML images on macOS caused by /var vs /private/var

### DIFF
--- a/src/calibre/ebooks/conversion/plugins/html_input.py
+++ b/src/calibre/ebooks/conversion/plugins/html_input.py
@@ -78,7 +78,8 @@ class HTMLInput(InputFormatPlugin):
     }
 
     def set_root_dir_of_input(self, basedir):
-        self.root_dir_of_input = os.path.normcase(get_long_path_name(os.path.abspath(basedir)) + os.sep)
+        # realpath so /var and /private/var compare equal on macOS
+        self.root_dir_of_input = os.path.normcase(get_long_path_name(os.path.realpath(os.path.abspath(basedir))) + os.sep)
 
     def convert(self, stream, options, file_ext, log, accelerators):
         opts = options


### PR DESCRIPTION
## Problem

On macOS, converting or viewing CHM (and some HTML) books drops linked images. `ebook-viewer` then caches HTML with no image files.

The CHM itself contains the images. Calibre extracts them correctly, but HTML Input rejects them:

```
Not adding /private/var/folders/.../chigb/up.gif as it is outside the document root: /var/folders/.../
```

## Cause

`link_to_local_path()` resolves linked files with `os.path.realpath()`, which turns `/var/folders/...` into `/private/var/folders/...` (`/var` is a symlink to `/private/var`).

`set_root_dir_of_input()` only used `os.path.abspath()`, so the document root stayed `/var/folders/...`. The `startswith` check then failed for every in-tree resource.

HTML pages are added directly and still appear. Images are only added through that check, so they disappear.

## Fix

Resolve the document root with `os.path.realpath()` as well, matching the linked-file path.

Verified with a CHM that previously produced HTML-only output: after this change, all 10 embedded images are included in both `ebook-convert` and the viewer cache.