### PR TITLE
Fix lock assertion

### DIFF
--- a/src/calibre/utils/zipfile.py
+++ b/src/calibre/utils/zipfile.py
@@ -1157,7 +1157,9 @@ class ZipFile:
         if path is None:
             path = os.getcwd()
 
-        return self._extract_member(member, path, pwd)
+        lock = Lock()
+
+        return self._extract_member(member, path, pwd, lock=lock)
 
     def extractall(self, path=None, members=None, pwd=None):
         """
@@ -1223,8 +1225,11 @@ class ZipFile:
                     os.makedirs(upperdirs)
         return targetpath
 
-    def _extract_member(self, member, targetpath, pwd):
-        return self._extract_member_to(member, self._get_targetpath(member, targetpath), pwd)
+    def _extract_member(self, member, targetpath, pwd, lock=None):
+        if lock is None:
+            lock = Lock()
+
+        return self._extract_member_to(member, self._get_targetpath(member, targetpath), pwd, lock=lock)
 
     def _extract_member_to(self, member, targetpath, pwd, lock=None):
         """Extract the ZipInfo object 'member' to a physical


### PR DESCRIPTION
The function `ZipFile._extract_member` calls `ZipFile._extract_member_to` without a lock but commit [e86e28a05f3b4b6471a359feee94b98245020ba2](https://github.com/kovidgoyal/calibre/blame/e86e28a05f3b4b6471a359feee94b98245020ba2/src/calibre/utils/zipfile.py#L1240) introduced an assertion on the existence of a lock. When importing an HTML file, this prevents the metadata being extracted from the file.

This pull request creates a lock as a minimal solution. It satisfies the assertion and enables the code after it to run properly but is otherwise unnecessary since there should be no parallel execution at this point.

I do not know the source code well enough to know if this is a full solution. Considering the assertion, at least the default value of `None` for `lock` in `ZipFile._extract_member_to` should probably also be removed for semantic reasons.