### PR TITLE
Add translation context for character names

### DIFF
--- a/src/calibre/gui2/cyoa/world.py
+++ b/src/calibre/gui2/cyoa/world.py
@@ -34,7 +34,7 @@ from calibre.customize import AIProviderPlugin
 from calibre.gui2 import error_dialog
 from calibre.gui2.cyoa import data
 from calibre.gui2.progress_indicator import WaitStack
-from calibre.utils.localization import _
+from calibre.utils.localization import _, pgettext
 
 
 class PremadeWorld(NamedTuple):
@@ -138,7 +138,7 @@ class CharacterEditor(QWidget):
         l.setContentsMargins(0, 0, 0, 0)
         l.setFieldGrowthPolicy(QFormLayout.FieldGrowthPolicy.ExpandingFieldsGrow)
         self.name_edit = QLineEdit(self)
-        l.addRow(_('&Name:'), self.name_edit)
+        l.addRow(pgettext('name of a character in a story', '&Name:'), self.name_edit)
         self.description_edit = QPlainTextEdit(self)
         l.addRow(_('&Description:'), self.description_edit)
         self.backstory_edit = QPlainTextEdit(self)


### PR DESCRIPTION
The generic `Name` label is used for both object names and personal names. These concepts can require different translations across languages. Give the character editor occurrence a gettext context so translators can localize it according to its semantic role without affecting other uses.