### PR TITLE
docs: fix typo definately -> definitely

### DIFF
--- a/src/calibre/devices/mtp/unix/upstream/music-players.h
+++ b/src/calibre/devices/mtp/unix/upstream/music-players.h
@@ -523,7 +523,7 @@
 
     /*
      * SanDisk
-     * several devices (c150 for sure) are definately dual-mode and must
+     * several devices (c150 for sure) are definitely dual-mode and must
      * have the USB mass storage driver that hooks them unloaded first.
      * They all have problematic dual-mode making the device unload effect
      * uncertain on these devices.


### PR DESCRIPTION
Corrects the misspelling `definately` -> `definitely` in `src/calibre/devices/mtp/unix/upstream/music-players.h`.

Documentation only, no behaviour change.