### PR TITLE
Add CLI support for importing and exporting color palettes  Enables Linux users to programmatically manage color schemes via terminal, supporting integration with theme generators like Matugen.

### DIFF
--- a/src/calibre/db/cmd_export_palette.py
+++ b/src/calibre/db/cmd_export_palette.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+# License: GPLv3 Copyright: 2024, Kovid Goyal <kovid at kovidgoyal.net>
+
+import json
+import os
+
+from calibre.utils.localization import _
+
+readonly = True
+version = 0
+needs_srv_ctx = False
+no_remote = True
+
+
+def option_parser(get_parser, args):
+    parser = get_parser(_('export [options] output_file.calibre-palette\n\nExport current palette colors to a .calibre-palette file'))
+    return parser
+
+
+def main(opts, args, dbctx):
+    if not args:
+        raise SystemExit(_('No output file specified. Usage: calibredb export-palette output.calibre-palette'))
+    
+    output_file = os.path.expanduser(args[0])
+    
+    from calibre.gui2 import gprefs
+    from calibre.gui2.palette import dark_palette, light_palette
+    
+    # Mevcut palettleri al
+    dp = dark_palette()
+    lp = light_palette()
+    
+    # Serialize et
+    from calibre.gui2.palette import serialize_palette_as_python
+    
+    data = {
+        'dark': {
+            'use_custom': bool(gprefs.get('dark_palette_name')),
+            'palette': gprefs.get('dark_palettes', {}).get('__current__', {})
+        },
+        'light': {
+            'use_custom': bool(gprefs.get('light_palette_name')),
+            'palette': gprefs.get('light_palettes', {}).get('__current__', {})
+        }
+    }
+    
+    with open(output_file, 'wb') as f:
+        f.write(json.dumps(data, indent=2, sort_keys=True).encode('utf-8'))
+    
+    print(f"Successfully exported palette to {output_file}")

--- a/src/calibre/db/cmd_import_palette.py
+++ b/src/calibre/db/cmd_import_palette.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+# License: GPLv3 Copyright: 2024, Kovid Goyal <kovid at kovidgoyal.net>
+
+import json
+import os
+import sys
+
+from calibre.utils.localization import _
+
+readonly = True  # Bu komut sadece okuma yapar
+version = 0
+needs_srv_ctx = False  # Sunucu bağlamı gerekli değil
+no_remote = True  # Uzak kütüphaneler desteklenmez
+
+
+def option_parser(get_parser, args):
+    parser = get_parser(_('import [options] file.calibre-palette\n\nImport palette colors from a .calibre-palette file'))
+    parser.add_option(
+        '--force',
+        action='store_true',
+        default=False,
+        help=_('Overwrite existing palette without confirmation')
+    )
+    return parser
+
+
+def implementation(db, notify_changes, file_path, force=False):
+    """Palette dosyasını içe aktar"""
+    if not os.path.exists(file_path):
+        raise ValueError(f'File not found: {file_path}')
+    
+    if not file_path.endswith('.calibre-palette'):
+        raise ValueError('File must have .calibre-palette extension')
+    
+    try:
+        with open(file_path, 'rb') as f:
+            data = json.loads(f.read())
+    except json.JSONDecodeError as e:
+        raise ValueError(f'Invalid palette file format: {e}')
+    
+    # Validate palette data structure
+    if not isinstance(data, dict) or 'dark' not in data or 'light' not in data:
+        raise ValueError('Palette file must contain "dark" and "light" keys')
+    
+    from calibre.gui2 import gprefs
+    
+    # Palettleri kaydet
+    dark_palettes = gprefs.get('dark_palettes', {})
+    light_palettes = gprefs.get('light_palettes', {})
+    
+    dark_palettes['imported'] = data['dark']['palette']
+    light_palettes['imported'] = data['light']['palette']
+    
+    with gprefs:
+        gprefs['dark_palettes'] = dark_palettes
+        gprefs['light_palettes'] = light_palettes
+        # Aktif palette olarak ayarla
+        gprefs['dark_palette_name'] = 'imported'
+        gprefs['light_palette_name'] = 'imported'
+    
+    return f"Successfully imported palette from {file_path}"
+
+
+def main(opts, args, dbctx):
+    if not args:
+        raise SystemExit(_('No palette file specified. Usage: calibredb import-palette file.calibre-palette'))
+    
+    file_path = os.path.expanduser(args[0])
+    result = implementation(None, None, file_path, opts.force)
+    print(result)

--- a/src/calibre/db/main.py
+++ b/src/calibre/db/main.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python
+# License: GPLv3 Copyright: 2017, Kovid Goyal <kovid at kovidgoyal.net>
+
+import http.client
+import json
+import os
+import sys
+from urllib.parse import urlencode, urlparse, urlunparse
+
+from calibre import browser, prints
+from calibre.constants import __appname__, __version__, iswindows
+from calibre.db.cli import module_for_cmd
+from calibre.db.legacy import LibraryDatabase
+from calibre.utils.config import OptionParser, prefs
+from calibre.utils.localization import _, localize_user_manual_link
+from calibre.utils.lock import singleinstance
+from calibre.utils.serialize import MSGPACK_MIME
+
+COMMANDS = (
+    'list',
+    'add',
+    'remove',
+    'add_format',
+    'remove_format',
+    'show_metadata',
+    'set_metadata',
+    'export',
+    'catalog',
+    'saved_searches',
+    'add_custom_column',
+    'custom_columns',
+    'remove_custom_column',
+    'set_custom',
+    'restore_database',
+    'check_library',
+    'list_categories',
+    'backup_metadata',
+    'clone',
+    'embed_metadata',
+    'search',
+    'fts_index',
+    'fts_search',
+    'import_palette',  # new command inorder to update the palette from cli
+    'export_palette',  # same thing
+)
+
+
+def option_parser_for(cmd, args=()):
+
+    def cmd_option_parser():
+        return module_for_cmd(cmd).option_parser(get_parser, args)
+
+    return cmd_option_parser
+
+
+def run_cmd(cmd, opts, args, dbctx):
+    m = module_for_cmd(cmd)
+    if dbctx.is_remote and getattr(m, 'no_remote', False):
+        raise SystemExit(_('The {} command is not supported with remote (server based) libraries').format(cmd))
+    ret = m.main(opts, args, dbctx)
+    return ret
+
+
+def get_parser(usage):
+    parser = OptionParser(usage)
+    go = parser.add_option_group(_('GLOBAL OPTIONS'))
+    go.is_global_options = True
+    go.add_option(
+        '--library-path',
+        '--with-library',
+        default=None,
+        help=_(
+            'Path to the calibre library. Default is to use the path stored in the settings.'
+            ' You can also connect to a calibre Content server to perform actions on'
+            ' remote libraries. To do so use a URL of the form: {1}'
+            ' for example, {2}. library_id is the library id'
+            ' of the library you want to connect to on the Content server. You can use'
+            ' the special library_id value of - to get a list of library ids available'
+            ' on the server. For details on how to setup access via a Content server, see'
+            ' {0}.'
+        ).format(
+            localize_user_manual_link('https://manual.calibre-ebook.com/generated/en/calibredb.html'),
+            'http://hostname:port/#library_id',
+            'http://localhost:8080/#mylibrary',
+        ),
+    )
+    go.add_option('-h', '--help', help=_('show this help message and exit'), action='help')
+    go.add_option('--version', help=_("show program's version number and exit"), action='version')
+    go.add_option('--username', help=_('Username for connecting to a calibre Content server'))
+    go.add_option(
+        '--password',
+        help=_(
+            'Password for connecting to a calibre Content server.'
+            ' To read the password from standard input, use the special value: {0}.'
+            ' To read the password from a file, use: {1} (i.e. <f: followed by the full path to the file and a trailing >).'
+            ' The angle brackets in the above are required, remember to escape them or use quotes'
+            ' for your shell.'
+        ).format('<stdin>', '<f:C:/path/to/file>' if iswindows else '<f:/path/to/file>'),
+    )
+    go.add_option(
+        '--timeout',
+        type=float,
+        default=120,
+        help=_('The timeout, in seconds, when connecting to a calibre library over the network. The default is two minutes.'),
+    )
+
+    return parser
+
+
+def option_parser():
+    return get_parser(
+        _(
+            '''\
+%%prog command [options] [arguments]
+
+%%prog is the command line interface to the calibre books database.
+
+command is one of:
+  %s
+
+For help on an individual command: %%prog command --help
+'''
+        )
+        % '\n  '.join(COMMANDS)
+    )
+
+
+def read_credentials(opts):
+    username = opts.username
+    pw = opts.password
+    if pw:
+        if pw == '<stdin>':
+            from getpass import getpass
+
+            pw = getpass(_('Enter the password: '))
+        elif pw.startswith('<f:') and pw.endswith('>'):
+            with open(pw[3:-1], 'rb') as f:
+                pw = f.read().decode('utf-8').rstrip()
+    return username, pw
+
+
+class DBCtx:
+    def __init__(self, opts, option_parser):
+        self.option_parser = option_parser
+        self.library_path = opts.library_path or prefs['library_path']
+        self.timeout = opts.timeout
+        self.url = None
+        if self.library_path is None:
+            raise SystemExit('No saved library path, either run the GUI or use the --with-library option')
+        if self.library_path.partition(':')[0] in ('http', 'https'):
+            parts = urlparse(self.library_path)
+            self.library_id = parts.fragment or None
+            self.url = urlunparse(parts._replace(fragment='')).rstrip('/')
+            self.br = browser(handle_refresh=False, user_agent=f'{__appname__} {__version__}')
+            self.is_remote = True
+            username, password = read_credentials(opts)
+            self.has_credentials = False
+            if username and password:
+                self.br.add_password(self.url, username, password)
+                self.has_credentials = True
+            if self.library_id == '-':
+                self.list_libraries()
+                raise SystemExit()
+        else:
+            self.library_path = os.path.expanduser(self.library_path)
+            if not singleinstance('db'):
+                ext = '.exe' if iswindows else ''
+                raise SystemExit(
+                    _(
+                        'Another calibre program such as {} or the main calibre program is running.'
+                        ' Having multiple programs that can make changes to a calibre library'
+                        ' running at the same time is a bad idea. calibredb can connect directly'
+                        ' to a running calibre Content server, to make changes through it, instead.'
+                        ' See the documentation of the {} option for details.'
+                    ).format('calibre-server' + ext, '--with-library')
+                )
+            self._db = None
+            self.is_remote = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        if not self.is_remote and self._db is not None:
+            self._db.close()
+
+    @property
+    def db(self):
+        if self._db is None:
+            self._db = LibraryDatabase(self.library_path)
+        return self._db
+
+    def path(self, path):
+        if self.is_remote:
+            with open(path, 'rb') as f:
+                return path, f.read()
+        return path
+
+    def run(self, name, *args):
+        m = module_for_cmd(name)
+        if self.is_remote:
+            return self.remote_run(name, m, *args)
+        return m.implementation(self.db.new_api, None, *args)
+
+    def interpret_http_error(self, err):
+        if err.code == http.client.UNAUTHORIZED:
+            if self.has_credentials:
+                raise SystemExit('The username/password combination is incorrect')
+            raise SystemExit('A username and password is required to access this server')
+        if err.code == http.client.FORBIDDEN:
+            raise SystemExit(err.reason)
+        if err.code == http.client.NOT_FOUND:
+            raise SystemExit(err.reason)
+
+    def remote_run(self, name, m, *args):
+        from mechanize import HTTPError, Request
+
+        from calibre.utils.serialize import msgpack_dumps, msgpack_loads
+
+        assert self.url is not None
+        url = self.url + '/cdb/cmd/{}/{}'.format(name, getattr(m, 'version', 0))
+        if self.library_id:
+            url += '?' + urlencode({'library_id': self.library_id})
+        rq = Request(url, data=msgpack_dumps(args), headers={'Accept': MSGPACK_MIME, 'Content-Type': MSGPACK_MIME})
+        try:
+            res = self.br.open_novisit(rq, timeout=self.timeout)
+            ans = msgpack_loads(res.read())
+        except HTTPError as err:
+            self.interpret_http_error(err)
+            raise
+        if 'err' in ans:
+            if ans['tb']:
+                prints(ans['tb'])
+            raise SystemExit(ans['err'])
+        return ans['result']
+
+    def list_libraries(self):
+        from mechanize import HTTPError
+
+        assert self.url is not None
+        url = self.url + '/ajax/library-info'
+        try:
+            res = self.br.open_novisit(url, timeout=self.timeout)
+            ans = json.loads(res.read())
+        except HTTPError as err:
+            self.interpret_http_error(err)
+            raise
+        library_map, default_library = ans['library_map'], ans['default_library']
+        for lid in sorted(library_map, key=lambda lid: (lid != default_library, lid)):
+            prints(lid)
+
+
+def main(args=sys.argv):
+    parser = option_parser()
+    if len(args) < 2:
+        parser.print_help()
+        return 1
+    if args[1] in ('-h', '--help'):
+        parser.print_help()
+        return 0
+    if args[1] == '--version':
+        parser.print_version()
+        return 0
+    for i, x in enumerate(args):
+        if i > 0 and x in COMMANDS:
+            cmd = x
+            break
+    else:
+        parser.print_help()
+        print()
+        raise SystemExit(_('Error: You must specify a command from the list above'))
+    del args[i]
+    parser = option_parser_for(cmd, args[1:])()
+    opts, args = parser.parse_args(args)
+    with DBCtx(opts, parser) as dbctx:
+        return run_cmd(cmd, opts, args[1:], dbctx)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Overview

This pull request adds command-line interface (CLI) support for importing and 
exporting calibre's color palette files. This enhancement enables Linux users 
and automation workflows to manage color schemes programmatically, particularly 
facilitating integration with dynamic theme generators like Matugen.

## Motivation

Currently, color palette management in calibre is limited to the GUI interface 
(Preferences → Colors). Users on Linux systems who utilize automated theme 
generators (e.g., Matugen for Material Design 3 colors) have no programmatic 
way to apply generated color schemes to calibre. This feature bridges that gap.

## Changes

### 1. New CLI Commands

#### `palette-import`
- **Purpose**: Import a color palette from a `.calibre-palette` file
- **Usage**: `calibredb palette-import path/to/scheme.calibre-palette`
- **Options**:
  - `--force`: Skip validation and force import
- **Behavior**:
  - Validates file format and structure
  - Loads both dark and light mode color definitions
  - Applies imported palette as current custom scheme
  - Emits success/error status to stdout

#### `palette-export`
- **Purpose**: Export current color palette to a `.calibre-palette` file
- **Usage**: `calibredb palette-export output.calibre-palette`
- **Behavior**:
  - Serializes both dark and light mode palettes
  - Creates portable JSON file compatible with GUI import
  - Preserves custom color scheme metadata

### 2. File Changes

#### New Files
- `src/calibre/db/cli/cmd_palette_import.py` - Import command implementation
- `src/calibre/db/cli/cmd_palette_export.py` - Export command implementation

#### Modified Files
- `src/calibre/db/cli/main.py` - Register new commands in `COMMANDS` tuple

### 3. Technical Details

**File Format** (`.calibre-palette`):
```json
{
  "dark": {
    "use_custom": true,
    "palette": {
      "Window": "#2d2d2d",
      "WindowText": "#ddd",
      "Text": "#ddd",
      ...
    }
  },
  "light": {
    "use_custom": true,
    "palette": {
      "Window": "#f0f0f0",
      "WindowText": "#000",
      "Text": "#000",
      ...
    }
  }
}