### PR TITLE
Add KOReader collection synchronization opcodes

### DIFF
--- a/src/calibre/devices/smart_device_app/driver.py
+++ b/src/calibre/devices/smart_device_app/driver.py
@@ -275,6 +275,8 @@ class SMART_DEVICE_APP(DeviceConfig, DevicePlugin):
         'SET_CALIBRE_DEVICE_INFO': 1,
         'SET_CALIBRE_DEVICE_NAME': 2,
         'TOTAL_SPACE': 4,
+        'GET_COLLECTIONS': 21,
+        'UPDATE_COLLECTIONS': 22,
     }
     reverse_opcodes = {v: k for k, v in opcodes.items()}
 


### PR DESCRIPTION
## Summary

Add the two protocol opcodes required for KOReader collection synchronization:

* `GET_COLLECTIONS` (opcode 21)
* `UPDATE_COLLECTIONS` (opcode 22)

These are used by KOReader's Calibre wireless plugin to synchronize collections with Calibre.
