### PR TITLE
Add translation context for CYOA Bold action

### DIFF
--- a/src/calibre/ai/cyoa.py
+++ b/src/calibre/ai/cyoa.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING, Annotated, Any, NamedTuple, Protocol
 
 from calibre.ai import AICapabilities, StructuredOutputResult
 from calibre.ai.structured import Doc, Kind, TypeSpec, instantiate, spec_for_class
-from calibre.utils.localization import _
+from calibre.utils.localization import _, pgettext
 
 if TYPE_CHECKING:
     from unittest.suite import TestSuite
@@ -246,7 +246,7 @@ def quick_action_kind_name(kind: QuickActionKind) -> str:
     # worth taking up space in the UI for.
     return {
         QuickActionKind.cautious: _('Cautious'),
-        QuickActionKind.bold: _('Bold'),
+        QuickActionKind.bold: pgettext('CYOA quick action kind', 'Bold'),
         QuickActionKind.social: _('Social'),
         QuickActionKind.investigate: _('Investigate'),
     }.get(kind, '')


### PR DESCRIPTION
The string "Bold" is used both for the text-formatting command and for a quick-action category in Create Your Own Adventure. These meanings require different translations in many languages.

This change gives the CYOA occurrence its own gettext context, allowing translators to localize the two meanings independently without changing the displayed English text.